### PR TITLE
docs: nettoyage documentation et configuration Git (#55, #65)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Normalisation des fins de ligne : LF dans le dépôt, quel que soit le poste.
+# Évite qu'un éditeur Windows (CRLF) fasse apparaître tous les fichiers comme modifiés.
+* text=auto eol=lf
+
+# Fichiers binaires : aucune conversion.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.pdf  binary
+*.woff  binary
+*.woff2 binary

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Les cours sont récupérés exclusivement côté serveur, via des adaptateurs in
 
 ```
 backend/    API Express, schéma SQL, services métier
-frontend/   application React (à initialiser)
+frontend/   application React (Vite + React 18)
 docs/       cadrage, cahier des charges, conception, planning, conventions
 ```
 
@@ -49,6 +49,17 @@ docs/       cadrage, cahier des charges, conception, planning, conventions
 - [Planning](docs/planning.md)
 - [Convention de commits](docs/convention-commits.md)
 
-## Installation
+## Installation (développement local)
 
-Le projet est en cours de développement. La procédure d'installation complète (docker-compose, variables d'environnement, seed) sera documentée ici au fur et à mesure.
+Prérequis : Node.js 20+, PostgreSQL 15+, Redis. Copier `backend/.env.example` vers `backend/.env` et renseigner les variables.
+
+```
+npm run install:all                          # dépendances back-end et front-end
+psql -d capitall -f backend/db/schema.sql    # création du schéma
+psql -d capitall -f backend/db/seed.sql      # jeu de données de démonstration
+npm run dev                                  # lance l'API et le front simultanément
+```
+
+L'API répond sur `http://localhost:5000` (route de santé : `/api/sante`). Les comptes de démonstration sont créés par le seed (voir l'en-tête de `backend/db/seed.sql`).
+
+La procédure complète avec Docker Compose sera ajoutée à la mise en place du déploiement.

--- a/docs/convention-commits.md
+++ b/docs/convention-commits.md
@@ -14,7 +14,7 @@ corps optionnel, uniquement si le pourquoi n'est pas évident depuis le titre et
 
 ## Branches
 
-Une branche par issue, créée depuis `dev` : `feature/<numéro>-<slug>` (fonctionnalité) ou `fix/<numéro>-<slug>` (correction), slug court en minuscules séparé par des tirets — par exemple `feature/1-init-monorepo`. La branche se ferme par une pull request vers `dev` (jamais vers `main`), avec le mot-clé `Closes #X` dans la description pour fermer l'issue à la fusion.
+Une branche par issue, créée depuis `dev` : `feature/<numéro>-<slug>` (fonctionnalité) ou `fix/<numéro>-<slug>` (correction), slug court en minuscules séparé par des tirets — par exemple `feature/1-init-monorepo`. La branche se ferme par une pull request vers `dev` (jamais vers `main`), avec le mot-clé `Closes #X` dans la description. Ce mot-clé ne ferme toutefois l'issue automatiquement qu'à la fusion dans la branche par défaut (`main`) : les pull requests étant fusionnées dans `dev`, l'issue correspondante se ferme manuellement après le merge.
 
 ## Types autorisés
 


### PR DESCRIPTION
## Description

Passe de nettoyage documentation et configuration Git avant d'attaquer l'authentification.

- `.gitattributes` : normalisation des fins de ligne (LF dans le dépôt), évite les diffs parasites entre postes Windows et Linux
- `README.md` : procédure d'installation locale (dépendances, schéma, seed, `npm run dev`), statut du dossier `frontend/`
- `docs/convention-commits.md` : précision sur la fermeture des issues — `Closes #X` n'auto-ferme qu'à la fusion dans `main` ; sur `dev`, fermeture manuelle après merge

## Issues liées

Closes #55
Closes #65

## Liste de contrôle

- [x] Aucun secret ni cle d'API n'est present dans le diff
- [x] La documentation reflete l'etat reel du depot
- [x] Le message des commits respecte `docs/convention-commits.md`
