### PR TITLE
feat(back): chaîne d'authentification complète

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,24 @@
+# Modèle de configuration du back-end.
+# Copier ce fichier vers backend/.env et renseigner les valeurs propres au poste.
+# Le fichier .env n'est jamais versionné : aucune valeur réelle ne doit figurer ici.
+
+# Port d'écoute de l'API. Optionnel, 5000 par défaut.
 PORT=5000
-DATABASE_URL=postgresql://user:password@localhost:5432/capitall
+
+# Environnement d'exécution : development, test ou production. Optionnel, development par défaut.
+NODE_ENV=development
+
+# Chaîne de connexion PostgreSQL. Obligatoire, le serveur refuse de démarrer sans elle.
+# Format : postgresql://utilisateur:mot_de_passe@hote:port/base
+DATABASE_URL=postgresql://utilisateur:mot_de_passe@localhost:5432/capitall
+
+# Secret de signature des jetons JWT. Obligatoire, 32 caractères au minimum.
+# Générer une valeur aléatoire par environnement, ne jamais réutiliser celle d'un autre poste.
+JWT_SECRET=
+
+# Durée de validité des jetons émis. Optionnel, 2h par défaut.
+# Accepte les formats de la bibliothèque jsonwebtoken : 2h, 30m, 7d.
+JWT_EXPIRATION=2h
+
+# Chaîne de connexion Redis, utilisée par le cache des cours.
 REDIS_URL=redis://localhost:6379
-JWT_SECRET=change-moi

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,10 +8,520 @@
       "name": "capitall-backend",
       "version": "0.1.0",
       "dependencies": {
+        "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
-        "pg": "^8.13.1"
+        "jsonwebtoken": "^9.0.3",
+        "pg": "^8.13.1",
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
+      "integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^2.0.0-alpha.3",
+        "@emnapi/runtime": "^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -32,6 +542,30 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.6",
@@ -56,6 +590,12 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -95,6 +635,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -115,6 +665,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -176,6 +733,16 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -200,6 +767,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -235,6 +811,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -253,6 +836,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -260,6 +853,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -308,6 +911,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -342,6 +963,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -473,6 +1109,368 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -548,6 +1546,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -555,6 +1572,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/object-assign": {
@@ -576,6 +1613,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/on-finished": {
@@ -603,6 +1654,13 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg": {
@@ -693,6 +1751,56 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postgres-array": {
@@ -787,6 +1895,40 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -812,6 +1954,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.2",
@@ -936,6 +2090,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -944,6 +2115,13 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -954,6 +2132,57 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -962,6 +2191,14 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -1003,6 +2240,192 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -1010,6 +2433,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,12 +5,20 @@
   "main": "server.js",
   "scripts": {
     "dev": "node --watch server.js",
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
-    "pg": "^8.13.1"
+    "jsonwebtoken": "^9.0.3",
+    "pg": "^8.13.1",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.10"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,12 +1,9 @@
-require('dotenv').config();
-
+const config = require('./src/config');
 const app = require('./src/app');
 const { verifierConnexion } = require('./src/db');
 
-const port = process.env.PORT || 5000;
-
-app.listen(port, async () => {
-  console.log(`Serveur CapitAll à l'écoute sur le port ${port}`);
+app.listen(config.port, async () => {
+  console.log(`Serveur CapitAll à l'écoute sur le port ${config.port}`);
   try {
     await verifierConnexion();
     console.log('Connexion PostgreSQL établie');

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 
+const routeurAuthentification = require('./routes/authentification');
 const gestionErreurs = require('./middlewares/gestionErreurs');
 
 const app = express();
@@ -11,6 +12,8 @@ app.use(express.json());
 app.get('/api/sante', (req, res) => {
   res.json({ statut: 'ok' });
 });
+
+app.use('/api/auth', routeurAuthentification);
 
 // Toujours en dernier : Express n'y passe que si une route a appelé next(erreur).
 app.use(gestionErreurs);

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const cors = require('cors');
 
+const gestionErreurs = require('./middlewares/gestionErreurs');
+
 const app = express();
 
 app.use(cors());
@@ -9,5 +11,8 @@ app.use(express.json());
 app.get('/api/sante', (req, res) => {
   res.json({ statut: 'ok' });
 });
+
+// Toujours en dernier : Express n'y passe que si une route a appelé next(erreur).
+app.use(gestionErreurs);
 
 module.exports = app;

--- a/backend/src/config/__tests__/config.test.js
+++ b/backend/src/config/__tests__/config.test.js
@@ -1,0 +1,82 @@
+// NODE_ENV vaut test sous Vitest : la configuration ne lit alors pas le fichier .env
+// du poste, ce qui rend ces cas reproductibles ailleurs que sur la machine de
+// développement. La variable n'est donc jamais supprimée dans les cas ci-dessous.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const SECRET_VALIDE = 'a'.repeat(32);
+const URL_VALIDE = 'postgresql://utilisateur:secret@localhost:5432/capitall';
+
+let environnementInitial;
+
+// La configuration se contrôle au chargement du module : chaque cas doit repartir
+// d'un cache de modules vide pour rejouer ce contrôle.
+async function chargerConfig() {
+  vi.resetModules();
+  const module = await import('../index.js');
+  return module.default;
+}
+
+beforeEach(() => {
+  environnementInitial = { ...process.env };
+  delete process.env.DATABASE_URL;
+  delete process.env.JWT_SECRET;
+  delete process.env.PORT;
+  delete process.env.JWT_EXPIRATION;
+});
+
+afterEach(() => {
+  process.env = environnementInitial;
+});
+
+describe('chargement de la configuration', () => {
+  it('expose les valeurs attendues quand tout est renseigné', async () => {
+    process.env.DATABASE_URL = URL_VALIDE;
+    process.env.JWT_SECRET = SECRET_VALIDE;
+    process.env.PORT = '4321';
+
+    const config = await chargerConfig();
+
+    expect(config.databaseUrl).toBe(URL_VALIDE);
+    expect(config.port).toBe(4321);
+    expect(config.nodeEnv).toBe(process.env.NODE_ENV);
+  });
+
+  it('applique les valeurs par défaut du port et de la durée du jeton', async () => {
+    process.env.DATABASE_URL = URL_VALIDE;
+    process.env.JWT_SECRET = SECRET_VALIDE;
+
+    const config = await chargerConfig();
+
+    expect(config.port).toBe(5000);
+    expect(config.jwtExpiration).toBe('2h');
+  });
+
+  it('refuse de démarrer si DATABASE_URL est absente', async () => {
+    process.env.JWT_SECRET = SECRET_VALIDE;
+    await expect(chargerConfig()).rejects.toThrow(/DATABASE_URL/);
+  });
+
+  it('refuse de démarrer si JWT_SECRET est absent', async () => {
+    process.env.DATABASE_URL = URL_VALIDE;
+    await expect(chargerConfig()).rejects.toThrow(/JWT_SECRET/);
+  });
+
+  // Le message liste toutes les variables manquantes d'un coup, pour éviter de les
+  // découvrir une par une à chaque redémarrage.
+  it('liste toutes les variables manquantes dans le même message', async () => {
+    await expect(chargerConfig()).rejects.toThrow(/DATABASE_URL, JWT_SECRET/);
+  });
+
+  it('refuse un JWT_SECRET de moins de 32 caractères', async () => {
+    process.env.DATABASE_URL = URL_VALIDE;
+    process.env.JWT_SECRET = 'trop-court';
+    await expect(chargerConfig()).rejects.toThrow(/32 caractères/);
+  });
+
+  it('renvoie un objet gelé', async () => {
+    process.env.DATABASE_URL = URL_VALIDE;
+    process.env.JWT_SECRET = SECRET_VALIDE;
+    const config = await chargerConfig();
+    expect(Object.isFrozen(config)).toBe(true);
+  });
+});

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -1,0 +1,44 @@
+// Point d'entrée unique de la configuration. Le reste du back-end lit ce module
+// plutôt que process.env : les variables sont contrôlées une seule fois, au démarrage,
+// et une configuration incomplète arrête le serveur au lieu de produire des erreurs
+// obscures plus tard (connexion refusée, jeton non signable).
+
+// Le fichier .env local n'est pas lu en environnement de test : les tests doivent
+// donner le même résultat sur n'importe quel poste, sans dépendre de sa configuration.
+if (process.env.NODE_ENV !== 'test') {
+  require('dotenv').config();
+}
+
+const LONGUEUR_MINIMALE_SECRET = 32;
+
+const VARIABLES_OBLIGATOIRES = ['DATABASE_URL', 'JWT_SECRET'];
+
+function verifierEnvironnement() {
+  const manquantes = VARIABLES_OBLIGATOIRES.filter((nom) => !process.env[nom]);
+
+  if (manquantes.length > 0) {
+    throw new Error(
+      `Configuration incomplète. Variables d'environnement manquantes : ${manquantes.join(', ')}. ` +
+        'Copier backend/.env.example vers backend/.env et les renseigner.'
+    );
+  }
+
+  // Un secret court rend la signature du jeton attaquable par force brute.
+  if (process.env.JWT_SECRET.length < LONGUEUR_MINIMALE_SECRET) {
+    throw new Error(
+      `JWT_SECRET est trop court : ${LONGUEUR_MINIMALE_SECRET} caractères au minimum sont exigés.`
+    );
+  }
+}
+
+verifierEnvironnement();
+
+const config = Object.freeze({
+  port: Number(process.env.PORT) || 5000,
+  nodeEnv: process.env.NODE_ENV || 'development',
+  databaseUrl: process.env.DATABASE_URL,
+  jwtSecret: process.env.JWT_SECRET,
+  jwtExpiration: process.env.JWT_EXPIRATION || '2h',
+});
+
+module.exports = config;

--- a/backend/src/controllers/authentification.js
+++ b/backend/src/controllers/authentification.js
@@ -3,6 +3,7 @@
 // transmises au gestionnaire centralisé par next().
 
 const serviceAuthentification = require('../services/authentification');
+const modeleUtilisateur = require('../models/utilisateur');
 
 async function inscription(req, res, next) {
   try {
@@ -27,4 +28,18 @@ async function connexion(req, res, next) {
   }
 }
 
-module.exports = { inscription, connexion };
+// Profil du porteur du jeton. Sert aussi de route protégée de référence pour vérifier
+// le middleware d'authentification.
+async function profil(req, res, next) {
+  try {
+    const utilisateur = await modeleUtilisateur.trouverParId(req.utilisateur.id);
+    if (!utilisateur) {
+      return res.status(404).json({ erreur: 'Utilisateur introuvable.' });
+    }
+    return res.status(200).json(utilisateur);
+  } catch (erreur) {
+    return next(erreur);
+  }
+}
+
+module.exports = { inscription, connexion, profil };

--- a/backend/src/controllers/authentification.js
+++ b/backend/src/controllers/authentification.js
@@ -1,0 +1,21 @@
+// Contrôleurs d'authentification : lecture de la requête, code de statut, format de
+// réponse. Aucune règle métier ici, et aucune erreur traitée sur place : elles sont
+// transmises au gestionnaire centralisé par next().
+
+const serviceAuthentification = require('../services/authentification');
+
+async function inscription(req, res, next) {
+  try {
+    const utilisateur = await serviceAuthentification.inscrire(req.body);
+    res.status(201).json({
+      id: utilisateur.id,
+      email: utilisateur.email,
+      pseudo: utilisateur.pseudo,
+      role: utilisateur.role,
+    });
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+module.exports = { inscription };

--- a/backend/src/controllers/authentification.js
+++ b/backend/src/controllers/authentification.js
@@ -18,4 +18,13 @@ async function inscription(req, res, next) {
   }
 }
 
-module.exports = { inscription };
+async function connexion(req, res, next) {
+  try {
+    const resultat = await serviceAuthentification.connecter(req.body);
+    res.status(200).json(resultat);
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+module.exports = { inscription, connexion };

--- a/backend/src/db/index.js
+++ b/backend/src/db/index.js
@@ -4,15 +4,9 @@
 // L'URL de connexion vient de DATABASE_URL (voir backend/.env.example).
 
 const { Pool } = require('pg');
+const config = require('../config');
 
-if (!process.env.DATABASE_URL) {
-  throw new Error(
-    "DATABASE_URL est absente de l'environnement. Copier backend/.env.example vers " +
-      'backend/.env et renseigner la chaîne de connexion PostgreSQL.'
-  );
-}
-
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const pool = new Pool({ connectionString: config.databaseUrl });
 
 // Erreur sur un client inactif du pool (coupure réseau, base redémarrée...).
 // On journalise sans arrêter le process : les requêtes suivantes rouvriront un client.

--- a/backend/src/erreurs.js
+++ b/backend/src/erreurs.js
@@ -1,0 +1,39 @@
+// Erreurs métier. Les services lèvent ces erreurs plutôt que de manipuler des codes
+// HTTP : la couche métier reste testable sans Express, et le gestionnaire centralisé
+// se charge seul de la traduction en réponse HTTP.
+
+class ErreurMetier extends Error {
+  constructor(message, statut) {
+    super(message);
+    this.name = this.constructor.name;
+    this.statut = statut;
+  }
+}
+
+// Ressource déjà existante, typiquement un email déjà inscrit.
+class ErreurConflit extends ErreurMetier {
+  constructor(message) {
+    super(message, 409);
+  }
+}
+
+// Échec d'authentification. Le message reste volontairement générique.
+class ErreurAuthentification extends ErreurMetier {
+  constructor(message) {
+    super(message, 401);
+  }
+}
+
+// Utilisateur authentifié mais dont le rôle ne permet pas l'action.
+class ErreurAutorisation extends ErreurMetier {
+  constructor(message) {
+    super(message, 403);
+  }
+}
+
+module.exports = {
+  ErreurMetier,
+  ErreurConflit,
+  ErreurAuthentification,
+  ErreurAutorisation,
+};

--- a/backend/src/middlewares/__tests__/authentifier.test.js
+++ b/backend/src/middlewares/__tests__/authentifier.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import jwt from 'jsonwebtoken';
+
+const SECRET = 'b'.repeat(32);
+
+let authentifier;
+
+// Le middleware lit la configuration au chargement : l'environnement doit être en place
+// avant l'import, d'où l'import dynamique.
+beforeAll(async () => {
+  process.env.DATABASE_URL = 'postgresql://utilisateur:secret@localhost:5432/capitall';
+  process.env.JWT_SECRET = SECRET;
+  ({ default: authentifier } = await import('../authentifier.js'));
+});
+
+// Doublures minimales d'Express : on n'observe que le statut, le corps et l'appel à next.
+function creerReponse() {
+  return {
+    statut: null,
+    corps: null,
+    status(code) {
+      this.statut = code;
+      return this;
+    },
+    json(donnees) {
+      this.corps = donnees;
+      return this;
+    },
+  };
+}
+
+let next;
+
+beforeEach(() => {
+  next = vi.fn();
+});
+
+describe("middleware d'authentification", () => {
+  it('refuse une requête sans en-tête Authorization', () => {
+    const res = creerReponse();
+    authentifier({ headers: {} }, res, next);
+
+    expect(res.statut).toBe(401);
+    expect(res.corps.erreur).toMatch(/absent/i);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('refuse un en-tête mal formé, sans préfixe Bearer', () => {
+    const res = creerReponse();
+    authentifier({ headers: { authorization: 'jeton-sans-prefixe' } }, res, next);
+
+    expect(res.statut).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('refuse un jeton dont la signature est invalide', () => {
+    const token = jwt.sign({ sub: 1, role: 'utilisateur' }, 'un-autre-secret-de-32-caracteres');
+    const res = creerReponse();
+    authentifier({ headers: { authorization: `Bearer ${token}` } }, res, next);
+
+    expect(res.statut).toBe(401);
+    expect(res.corps.erreur).toMatch(/invalide ou expiré/i);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('refuse un jeton expiré', () => {
+    const token = jwt.sign({ sub: 1, role: 'utilisateur' }, SECRET, { expiresIn: '-1s' });
+    const res = creerReponse();
+    authentifier({ headers: { authorization: `Bearer ${token}` } }, res, next);
+
+    expect(res.statut).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("accepte un jeton valide et attache l'utilisateur à la requête", () => {
+    const token = jwt.sign({ sub: 42, role: 'admin' }, SECRET, { algorithm: 'HS256' });
+    const req = { headers: { authorization: `Bearer ${token}` } };
+    const res = creerReponse();
+
+    authentifier(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.utilisateur).toEqual({ id: 42, role: 'admin' });
+    expect(res.statut).toBeNull();
+  });
+
+  // Un jeton signé avec l'algorithme "none" ne doit jamais être accepté.
+  it('refuse un jeton non signé', () => {
+    const token = jwt.sign({ sub: 1, role: 'admin' }, null, { algorithm: 'none' });
+    const res = creerReponse();
+    authentifier({ headers: { authorization: `Bearer ${token}` } }, res, next);
+
+    expect(res.statut).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/middlewares/__tests__/exigerRole.test.js
+++ b/backend/src/middlewares/__tests__/exigerRole.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import exigerRole from '../exigerRole.js';
+
+function creerReponse() {
+  return {
+    statut: null,
+    corps: null,
+    status(code) {
+      this.statut = code;
+      return this;
+    },
+    json(donnees) {
+      this.corps = donnees;
+      return this;
+    },
+  };
+}
+
+let next;
+
+beforeEach(() => {
+  next = vi.fn();
+});
+
+describe('middleware de contrôle de rôle', () => {
+  it('laisse passer un utilisateur dont le rôle correspond', () => {
+    const res = creerReponse();
+    exigerRole('admin')({ utilisateur: { id: 1, role: 'admin' } }, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statut).toBeNull();
+  });
+
+  it('refuse un utilisateur dont le rôle ne correspond pas', () => {
+    const res = creerReponse();
+    exigerRole('admin')({ utilisateur: { id: 2, role: 'utilisateur' } }, res, next);
+
+    expect(res.statut).toBe(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  // Le middleware n'est jamais employé seul : sans authentifier en amont, il n'y a pas
+  // de rôle à contrôler, et la requête doit être refusée plutôt que laissée passer.
+  it('refuse une requête non authentifiée', () => {
+    const res = creerReponse();
+    exigerRole('admin')({}, res, next);
+
+    expect(res.statut).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/middlewares/__tests__/valider.test.js
+++ b/backend/src/middlewares/__tests__/valider.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import valider from '../valider.js';
+import { schemaInscription } from '../../validation/utilisateur.js';
+
+function creerReponse() {
+  return {
+    statut: null,
+    corps: null,
+    status(code) {
+      this.statut = code;
+      return this;
+    },
+    json(donnees) {
+      this.corps = donnees;
+      return this;
+    },
+  };
+}
+
+let next;
+
+beforeEach(() => {
+  next = vi.fn();
+});
+
+describe('middleware de validation', () => {
+  it('remplace le corps par les données normalisées et poursuit', () => {
+    const req = { body: { email: '  Camille@Example.FR ', motDePasse: 'motdepasse-solide' } };
+    const res = creerReponse();
+
+    valider(schemaInscription)(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.body.email).toBe('camille@example.fr');
+  });
+
+  it('renvoie 400 avec la liste des champs en erreur', () => {
+    const req = { body: { email: 'invalide', motDePasse: 'court' } };
+    const res = creerReponse();
+
+    valider(schemaInscription)(req, res, next);
+
+    expect(res.statut).toBe(400);
+    expect(next).not.toHaveBeenCalled();
+    const champsEnErreur = res.corps.champs.map((entree) => entree.champ);
+    expect(champsEnErreur).toContain('email');
+    expect(champsEnErreur).toContain('motDePasse');
+  });
+
+  it('renvoie 400 quand le corps contient un champ role', () => {
+    const req = {
+      body: { email: 'camille@example.fr', motDePasse: 'motdepasse-solide', role: 'admin' },
+    };
+    const res = creerReponse();
+
+    valider(schemaInscription)(req, res, next);
+
+    expect(res.statut).toBe(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/middlewares/authentifier.js
+++ b/backend/src/middlewares/authentifier.js
@@ -1,0 +1,30 @@
+// Premier des trois niveaux de contrôle d'accès : le jeton est-il valide ?
+// Viennent ensuite la propriété de la ressource, puis le rôle (exigerRole).
+
+const jwt = require('jsonwebtoken');
+const config = require('../config');
+
+const PREFIXE_BEARER = 'Bearer ';
+
+function authentifier(req, res, next) {
+  const entete = req.headers.authorization;
+
+  // Distinguer l'absence de jeton du jeton refusé aide le client à savoir s'il doit
+  // se connecter ou se reconnecter. Aucun des deux messages n'expose la cause technique.
+  if (!entete || !entete.startsWith(PREFIXE_BEARER)) {
+    return res.status(401).json({ erreur: "Jeton d'authentification absent." });
+  }
+
+  const token = entete.slice(PREFIXE_BEARER.length).trim();
+
+  try {
+    const charge = jwt.verify(token, config.jwtSecret, { algorithms: ['HS256'] });
+    req.utilisateur = { id: charge.sub, role: charge.role };
+    return next();
+  } catch (erreur) {
+    // Expiration et signature invalide sont volontairement traitées de la même façon.
+    return res.status(401).json({ erreur: "Jeton d'authentification invalide ou expiré." });
+  }
+}
+
+module.exports = authentifier;

--- a/backend/src/middlewares/exigerRole.js
+++ b/backend/src/middlewares/exigerRole.js
@@ -1,0 +1,20 @@
+// Troisième niveau de contrôle d'accès (D23), à placer systématiquement après
+// authentifier : sans req.utilisateur, il n'y a pas de rôle à contrôler.
+// Le rôle admin reste à moindre privilège, il n'ouvre jamais l'accès aux données
+// patrimoniales d'autrui, qui relèvent de la vérification de propriété.
+
+function exigerRole(roleAttendu) {
+  return (req, res, next) => {
+    if (!req.utilisateur) {
+      return res.status(401).json({ erreur: "Jeton d'authentification absent." });
+    }
+
+    if (req.utilisateur.role !== roleAttendu) {
+      return res.status(403).json({ erreur: 'Action réservée à un autre rôle.' });
+    }
+
+    return next();
+  };
+}
+
+module.exports = exigerRole;

--- a/backend/src/middlewares/gestionErreurs.js
+++ b/backend/src/middlewares/gestionErreurs.js
@@ -1,0 +1,21 @@
+// Gestionnaire d'erreurs centralisé, branché en dernier dans app.js. Il est le seul
+// endroit du back-end qui décide du code HTTP renvoyé sur erreur, et le seul à
+// journaliser. Le client ne reçoit qu'un message : ni pile d'appels, ni détail
+// technique, ni message d'erreur SQL, qui renseigneraient un attaquant sur la
+// structure interne de l'application.
+
+const { ErreurMetier } = require('../erreurs');
+
+// La signature à quatre paramètres est ce qui identifie un gestionnaire d'erreurs
+// auprès d'Express : next doit rester présent même s'il n'est pas utilisé.
+// eslint-disable-next-line no-unused-vars
+function gestionErreurs(erreur, req, res, next) {
+  if (erreur instanceof ErreurMetier) {
+    return res.status(erreur.statut).json({ erreur: erreur.message });
+  }
+
+  console.error(`Erreur non gérée sur ${req.method} ${req.originalUrl}`, erreur);
+  return res.status(500).json({ erreur: 'Une erreur interne est survenue.' });
+}
+
+module.exports = gestionErreurs;

--- a/backend/src/middlewares/valider.js
+++ b/backend/src/middlewares/valider.js
@@ -1,0 +1,23 @@
+// Middleware de validation générique. Il s'intercale avant le contrôleur et garantit
+// que celui-ci ne reçoit jamais qu'un corps de requête déjà contrôlé et normalisé.
+
+function valider(schema) {
+  return (req, res, next) => {
+    const resultat = schema.safeParse(req.body);
+
+    if (!resultat.success) {
+      const champs = resultat.error.issues.map((probleme) => ({
+        champ: probleme.path.join('.') || '(racine)',
+        message: probleme.message,
+      }));
+      return res.status(400).json({ erreur: 'Données invalides.', champs });
+    }
+
+    // Le corps est remplacé par la valeur validée : le contrôleur travaille sur des
+    // données normalisées (email en minuscules, espaces retirés) et sur elles seules.
+    req.body = resultat.data;
+    return next();
+  };
+}
+
+module.exports = valider;

--- a/backend/src/models/utilisateur.js
+++ b/backend/src/models/utilisateur.js
@@ -1,0 +1,46 @@
+// Accès aux données de la table utilisateur. Toutes les requêtes passent par le helper
+// query() du pool et sont paramétrées : aucune valeur n'est concaténée dans du SQL.
+//
+// Règle appliquée ici : mot_de_passe_hache ne remonte jamais vers les couches
+// supérieures, à la seule exception de trouverParEmail (voir son commentaire).
+
+const { query } = require('../db');
+
+const CHAMPS_PUBLICS = 'id, email, pseudo, role, date_inscription';
+
+// La colonne role n'est jamais alimentée depuis une entrée utilisateur (D23) :
+// elle prend la valeur par défaut du schéma, donc 'utilisateur'.
+async function creerUtilisateur({ email, motDePasseHache, pseudo }) {
+  const { rows } = await query(
+    `INSERT INTO utilisateur (email, mot_de_passe_hache, pseudo)
+     VALUES ($1, $2, $3)
+     RETURNING ${CHAMPS_PUBLICS}`,
+    [email, motDePasseHache, pseudo]
+  );
+  return rows[0];
+}
+
+// Seule fonction à renvoyer le hachage : la connexion en a besoin pour le comparer.
+// Elle n'est appelée que par le service d'authentification, et son résultat ne doit
+// jamais être transmis tel quel à un contrôleur.
+async function trouverParEmail(email) {
+  const { rows } = await query(
+    `SELECT ${CHAMPS_PUBLICS}, mot_de_passe_hache
+     FROM utilisateur
+     WHERE email = $1`,
+    [email]
+  );
+  return rows[0] || null;
+}
+
+async function trouverParId(id) {
+  const { rows } = await query(
+    `SELECT ${CHAMPS_PUBLICS}
+     FROM utilisateur
+     WHERE id = $1`,
+    [id]
+  );
+  return rows[0] || null;
+}
+
+module.exports = { creerUtilisateur, trouverParEmail, trouverParId };

--- a/backend/src/routes/authentification.js
+++ b/backend/src/routes/authentification.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const controleur = require('../controllers/authentification');
 const valider = require('../middlewares/valider');
-const { schemaInscription } = require('../validation/utilisateur');
+const { schemaInscription, schemaConnexion } = require('../validation/utilisateur');
 
 const routeur = express.Router();
 
 routeur.post('/inscription', valider(schemaInscription), controleur.inscription);
+routeur.post('/connexion', valider(schemaConnexion), controleur.connexion);
 
 module.exports = routeur;

--- a/backend/src/routes/authentification.js
+++ b/backend/src/routes/authentification.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const controleur = require('../controllers/authentification');
+const valider = require('../middlewares/valider');
+const { schemaInscription } = require('../validation/utilisateur');
+
+const routeur = express.Router();
+
+routeur.post('/inscription', valider(schemaInscription), controleur.inscription);
+
+module.exports = routeur;

--- a/backend/src/routes/authentification.js
+++ b/backend/src/routes/authentification.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const controleur = require('../controllers/authentification');
 const valider = require('../middlewares/valider');
+const authentifier = require('../middlewares/authentifier');
 const { schemaInscription, schemaConnexion } = require('../validation/utilisateur');
 
 const routeur = express.Router();
 
 routeur.post('/inscription', valider(schemaInscription), controleur.inscription);
 routeur.post('/connexion', valider(schemaConnexion), controleur.connexion);
+routeur.get('/moi', authentifier, controleur.profil);
 
 module.exports = routeur;

--- a/backend/src/services/authentification.js
+++ b/backend/src/services/authentification.js
@@ -2,8 +2,10 @@
 // HTTP : il renvoie des données ou lève une erreur métier, ce qui le rend testable seul.
 
 const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const config = require('../config');
 const modeleUtilisateur = require('../models/utilisateur');
-const { ErreurConflit } = require('../erreurs');
+const { ErreurConflit, ErreurAuthentification } = require('../erreurs');
 
 const COUT_HACHAGE = 10;
 
@@ -38,4 +40,39 @@ async function inscrire({ email, motDePasse, pseudo }) {
   }
 }
 
-module.exports = { inscrire };
+// Hachage neutre, servant de comparaison de repli quand l'email est inconnu.
+// Sans lui, une réponse immédiate sur email inexistant et une réponse retardée par
+// bcrypt sur email existant permettraient de déterminer quels comptes existent.
+const HACHAGE_FACTICE = bcrypt.hashSync('comparaison-a-temps-constant', COUT_HACHAGE);
+
+const MESSAGE_ECHEC = 'Email ou mot de passe incorrect.';
+
+async function connecter({ email, motDePasse }) {
+  const utilisateur = await modeleUtilisateur.trouverParEmail(email);
+  const hachageAComparer = utilisateur ? utilisateur.mot_de_passe_hache : HACHAGE_FACTICE;
+
+  const motDePasseValide = await bcrypt.compare(motDePasse, hachageAComparer);
+
+  // Un seul message pour les deux causes d'échec : rien n'indique si c'est l'email
+  // ou le mot de passe qui est en cause.
+  if (!utilisateur || !motDePasseValide) {
+    throw new ErreurAuthentification(MESSAGE_ECHEC);
+  }
+
+  const token = jwt.sign({ sub: utilisateur.id, role: utilisateur.role }, config.jwtSecret, {
+    algorithm: 'HS256',
+    expiresIn: config.jwtExpiration,
+  });
+
+  return {
+    token,
+    utilisateur: {
+      id: utilisateur.id,
+      email: utilisateur.email,
+      pseudo: utilisateur.pseudo,
+      role: utilisateur.role,
+    },
+  };
+}
+
+module.exports = { inscrire, connecter };

--- a/backend/src/services/authentification.js
+++ b/backend/src/services/authentification.js
@@ -1,0 +1,41 @@
+// Logique métier de l'authentification. Ce service ne connaît ni Express ni les codes
+// HTTP : il renvoie des données ou lève une erreur métier, ce qui le rend testable seul.
+
+const bcrypt = require('bcrypt');
+const modeleUtilisateur = require('../models/utilisateur');
+const { ErreurConflit } = require('../erreurs');
+
+const COUT_HACHAGE = 10;
+
+// Code renvoyé par PostgreSQL sur violation d'une contrainte d'unicité.
+const CODE_VIOLATION_UNICITE = '23505';
+
+const LONGUEUR_MAXIMALE_PSEUDO = 100;
+
+// Le pseudo est facultatif à l'inscription alors que la colonne est obligatoire :
+// à défaut, on reprend la partie locale de l'email.
+function pseudoParDefaut(email) {
+  return email.split('@')[0].slice(0, LONGUEUR_MAXIMALE_PSEUDO);
+}
+
+async function inscrire({ email, motDePasse, pseudo }) {
+  const motDePasseHache = await bcrypt.hash(motDePasse, COUT_HACHAGE);
+
+  try {
+    return await modeleUtilisateur.creerUtilisateur({
+      email,
+      motDePasseHache,
+      pseudo: pseudo || pseudoParDefaut(email),
+    });
+  } catch (erreur) {
+    // Deux inscriptions simultanées sur le même email passeraient toutes deux un
+    // contrôle préalable en lecture : c'est la contrainte d'unicité de la base qui
+    // fait foi, et sa violation est traduite ici en erreur métier.
+    if (erreur.code === CODE_VIOLATION_UNICITE) {
+      throw new ErreurConflit('Cet email est déjà utilisé.');
+    }
+    throw erreur;
+  }
+}
+
+module.exports = { inscrire };

--- a/backend/src/validation/__tests__/utilisateur.test.js
+++ b/backend/src/validation/__tests__/utilisateur.test.js
@@ -1,0 +1,80 @@
+// Les fichiers de test sont écrits en modules ES : Vitest refuse d'être chargé par
+// require(). Le code de production reste en CommonJS, Vite assurant l'interopérabilité.
+
+import { describe, it, expect } from 'vitest';
+import { schemaInscription, schemaConnexion } from '../utilisateur.js';
+
+describe("schéma d'inscription", () => {
+  const inscriptionValide = {
+    email: 'camille@example.fr',
+    motDePasse: 'motdepasse-solide',
+    pseudo: 'Camille',
+  };
+
+  it('accepte une inscription complète', () => {
+    expect(schemaInscription.safeParse(inscriptionValide).success).toBe(true);
+  });
+
+  it('accepte une inscription sans pseudo', () => {
+    const { pseudo, ...sansPseudo } = inscriptionValide;
+    expect(schemaInscription.safeParse(sansPseudo).success).toBe(true);
+  });
+
+  it("normalise l'email en minuscules et retire les espaces", () => {
+    const resultat = schemaInscription.parse({
+      ...inscriptionValide,
+      email: '  Camille@Example.FR  ',
+    });
+    expect(resultat.email).toBe('camille@example.fr');
+  });
+
+  it('rejette un email au format invalide', () => {
+    expect(schemaInscription.safeParse({ ...inscriptionValide, email: 'pas-un-email' }).success).toBe(
+      false
+    );
+  });
+
+  it('rejette un mot de passe de moins de 10 caractères', () => {
+    expect(schemaInscription.safeParse({ ...inscriptionValide, motDePasse: 'court' }).success).toBe(
+      false
+    );
+  });
+
+  // Test de la règle D23 : un rôle ne s'obtient jamais par une entrée utilisateur.
+  it('rejette un champ role injecté dans le corps de la requête', () => {
+    const resultat = schemaInscription.safeParse({ ...inscriptionValide, role: 'admin' });
+    expect(resultat.success).toBe(false);
+    expect(resultat.error.issues[0].code).toBe('unrecognized_keys');
+  });
+
+  it('ne laisse jamais passer role dans les données validées', () => {
+    const resultat = schemaInscription.safeParse({ ...inscriptionValide, role: 'admin' });
+    expect(resultat.data).toBeUndefined();
+  });
+
+  it('rejette toute clé inconnue', () => {
+    expect(schemaInscription.safeParse({ ...inscriptionValide, actif: true }).success).toBe(false);
+  });
+});
+
+describe('schéma de connexion', () => {
+  const connexionValide = { email: 'camille@example.fr', motDePasse: 'motdepasse-solide' };
+
+  it('accepte des identifiants bien formés', () => {
+    expect(schemaConnexion.safeParse(connexionValide).success).toBe(true);
+  });
+
+  // La règle de longueur ne s'applique qu'à l'inscription : un compte créé avant un
+  // durcissement doit continuer à pouvoir se connecter.
+  it('accepte un mot de passe court à la connexion', () => {
+    expect(schemaConnexion.safeParse({ ...connexionValide, motDePasse: 'abc' }).success).toBe(true);
+  });
+
+  it('rejette un mot de passe vide', () => {
+    expect(schemaConnexion.safeParse({ ...connexionValide, motDePasse: '' }).success).toBe(false);
+  });
+
+  it('rejette un champ role injecté', () => {
+    expect(schemaConnexion.safeParse({ ...connexionValide, role: 'admin' }).success).toBe(false);
+  });
+});

--- a/backend/src/validation/utilisateur.js
+++ b/backend/src/validation/utilisateur.js
@@ -1,0 +1,47 @@
+// Schémas de validation des entrées d'authentification (D41).
+// Deux règles de sécurité gouvernent ces schémas :
+//   - le champ role n'apparaît dans aucun schéma d'entrée (D23), un rôle ne s'obtient
+//     que par le seed ou une intervention SQL directe ;
+//   - .strict() rejette toute clé inconnue plutôt que de l'ignorer silencieusement,
+//     ce qui bloque au passage toute tentative d'injecter role dans le corps de requête.
+
+const { z } = require('zod');
+
+const LONGUEUR_MAXIMALE_EMAIL = 255;
+const LONGUEUR_MINIMALE_MOT_DE_PASSE = 10;
+const LONGUEUR_MAXIMALE_MOT_DE_PASSE = 128;
+const LONGUEUR_MAXIMALE_PSEUDO = 100;
+
+const email = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .max(LONGUEUR_MAXIMALE_EMAIL, `L'email ne peut pas dépasser ${LONGUEUR_MAXIMALE_EMAIL} caractères.`)
+  .pipe(z.email("Le format de l'email est invalide."));
+
+const motDePasse = z
+  .string()
+  .min(
+    LONGUEUR_MINIMALE_MOT_DE_PASSE,
+    `Le mot de passe doit contenir au moins ${LONGUEUR_MINIMALE_MOT_DE_PASSE} caractères.`
+  )
+  .max(LONGUEUR_MAXIMALE_MOT_DE_PASSE);
+
+const schemaInscription = z
+  .object({
+    email,
+    motDePasse,
+    pseudo: z.string().trim().min(1).max(LONGUEUR_MAXIMALE_PSEUDO).optional(),
+  })
+  .strict();
+
+// La connexion ne contrôle pas la longueur du mot de passe : une règle durcie plus tard
+// ne doit pas empêcher un compte existant de se connecter.
+const schemaConnexion = z
+  .object({
+    email,
+    motDePasse: z.string().min(1, 'Le mot de passe est obligatoire.'),
+  })
+  .strict();
+
+module.exports = { schemaInscription, schemaConnexion };

--- a/docs/conception/direction-artistique.md
+++ b/docs/conception/direction-artistique.md
@@ -34,7 +34,7 @@ Contrastes vérifiés à respecter (RGAA) : texte principal et secondaire sur fo
 1. connexion / inscription
 2. tableau de bord (valeur totale, plus-value globale, anneau de répartition, courbe d'évolution, sélecteur de devise d'affichage euro/dollar)
 3. liste des actifs (carte par actif : symbole, quantité, PRU, cours, plus-value)
-4. détail d'un actif (historique des transactions, plus-value latente)
+4. détail d'un actif (historique des transactions, plus-value latente et réalisée)
 5. formulaire d'ajout de transaction
 
 Chaque écran en version mobile (375 px) et desktop (1440 px).

--- a/docs/convention-commits.md
+++ b/docs/convention-commits.md
@@ -1,6 +1,6 @@
 # Convention de commits - CapitAll
 
-Validée le 14/07/2026 (D19), étendue le 24/07/2026 (D39) avec la référence d'issue et le workflow de branches. Conventional Commits, messages en français (D13).
+Validée le 14/07/2026 (D19), étendue le 24/07/2026 (D39) avec la référence d'issue et le workflow de branches, puis le 29/07/2026 (D47) avec la granularité par lot fonctionnel. Conventional Commits, messages en français (D13).
 
 ## Format
 
@@ -14,7 +14,11 @@ corps optionnel, uniquement si le pourquoi n'est pas évident depuis le titre et
 
 ## Branches
 
-Une branche par issue, créée depuis `dev` : `feature/<numéro>-<slug>` (fonctionnalité) ou `fix/<numéro>-<slug>` (correction), slug court en minuscules séparé par des tirets — par exemple `feature/1-init-monorepo`. La branche se ferme par une pull request vers `dev` (jamais vers `main`), avec le mot-clé `Closes #X` dans la description. Ce mot-clé ne ferme toutefois l'issue automatiquement qu'à la fusion dans la branche par défaut (`main`) : les pull requests étant fusionnées dans `dev`, l'issue correspondante se ferme manuellement après le merge.
+Une branche par **lot fonctionnel cohérent** (D47), créée depuis `dev` : `feature/<numéro>-<slug>` (fonctionnalité) ou `fix/<numéro>-<slug>` (correction), slug court en minuscules séparé par des tirets — par exemple `feature/9-authentification`. Le numéro est celui de l'issue principale du lot.
+
+À l'intérieur du lot, chaque issue garde son commit, avec son suffixe `(#X)` : l'historique reste granulaire, seule la fréquence des branches et des pull requests diminue. Un lot regroupe des travaux qui n'ont pas d'intérêt à être livrés séparément, comme la chaîne d'authentification (configuration, inscription, connexion, middlewares).
+
+La branche se ferme par une pull request vers `dev` (jamais vers `main`), dont la description liste toutes les issues du lot avec le mot-clé `Closes #X`. Ce mot-clé ne ferme toutefois l'issue automatiquement qu'à la fusion dans la branche par défaut (`main`) : les pull requests étant fusionnées dans `dev`, chaque issue se ferme manuellement après le merge.
 
 ## Types autorisés
 
@@ -51,3 +55,4 @@ Optionnel mais recommandé dans un monorepo, pour situer immédiatement le commi
 - commits réguliers au fil du travail, pas un seul gros commit par phase : un historique granulaire documente la progression, facilite la relecture et permet un retour arrière ciblé en cas de régression
 - aucun commit directement sur `main` ou `dev` (D39) : le travail passe systématiquement par une branche `feature/<numéro>-<slug>` ou `fix/<numéro>-<slug>`, fusionnée dans `dev` via pull request revue ; `dev` est fusionnée dans `main` en fin de phase validée
 - un commit qui casse le build ou les tests existants n'est pas acceptable, y compris en cours de journée
+- les tests unitaires du back-end s'exécutent avec Vitest (D48) : `npm test` depuis `backend/`, ou `npm run test:watch` pendant le développement


### PR DESCRIPTION
Closes #2, closes #59, closes #70, closes #58, closes #9, closes #10, closes #11, closes #12, closes #71

Lot A : configuration à variables obligatoires, inscription bcrypt, connexion et émission du JWT, middleware d'authentification, middleware de rôle, gestionnaire d'erreurs centralisé, tests Vitest.
Le champ role n'est accepté dans aucune entrée utilisateur (D23), couvert par un test.

## Détail

- **Configuration** (#2, #59) : `src/config/index.js` expose un objet gelé et contrôle l'environnement au démarrage. Toutes les variables manquantes sont listées d'un coup, et un `JWT_SECRET` de moins de 32 caractères est refusé. Plus aucune lecture directe de `process.env` dans le back-end hors de ce module. `.env.example` complété et commenté, sans valeur réelle.
- **Vitest** (#70) : scripts `test` et `test:watch`. La configuration ne lit pas le `.env` du poste en environnement de test, pour que les tests donnent le même résultat partout.
- **Gestionnaire d'erreurs** (#58) : seul point du back-end qui décide du code HTTP sur erreur et qui journalise. Aucune pile d'appels ni message SQL renvoyé au client.
- **Inscription** (#9) : schéma Zod strict, hachage bcrypt au coût 10, violation d'unicité de l'email traduite en 409 et non en erreur SQL brute.
- **Connexion** (#10) : JWT HS256, charge utile `{ sub, role }`, expiration lue dans la configuration. Message d'échec strictement générique et comparaison de hachage systématique, y compris sur email inconnu, pour ne pas exposer d'écart de temps de réponse.
- **Middlewares** (#11, #12) : `authentifier` (Bearer, 401 distinct entre jeton absent et jeton refusé, sans fuite technique) et `exigerRole` (403), à employer après `authentifier`.
- **Documentation** (#71) : convention de commits mise à jour avec D47 et D48, écran 4 de la direction artistique corrigé (plus-value réalisée, D42).

## Vérification

31 tests unitaires au vert (schémas, configuration, `authentifier`, `exigerRole`, `valider`), sans base ni HTTP.

Vérifié contre PostgreSQL et le serveur démarré : inscription 201, doublon 409, connexion 200 avec jeton HS256 valable 2 h, mot de passe erroné et email inconnu renvoyant le même 401, route protégée 401 sans jeton et 200 avec, et surtout inscription avec `"role": "admin"` refusée en 400 sans création de compte, contrôlée en base.

## Liste de contrôle

- [x] Architecture respectee : routes, middlewares, controllers, services, models
- [x] Entrees validees cote serveur (Zod strict)
- [x] Requetes SQL parametrees, aucune concatenation
- [x] Aucun secret ni cle d'API dans le diff
- [x] Tests unitaires au vert
- [x] Messages de commit conformes a docs/convention-commits.md
