### PR TITLE
feat(back): CRUD du portefeuille cloisonné par utilisateur

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 
 const routeurAuthentification = require('./routes/authentification');
+const routeurActif = require('./routes/actif');
 const gestionErreurs = require('./middlewares/gestionErreurs');
 
 const app = express();
@@ -14,6 +15,7 @@ app.get('/api/sante', (req, res) => {
 });
 
 app.use('/api/auth', routeurAuthentification);
+app.use('/api/actifs', routeurActif);
 
 // Toujours en dernier : Express n'y passe que si une route a appelé next(erreur).
 app.use(gestionErreurs);

--- a/backend/src/controllers/actif.js
+++ b/backend/src/controllers/actif.js
@@ -48,6 +48,22 @@ async function detail(req, res, next) {
   }
 }
 
+async function modifier(req, res, next) {
+  try {
+    const actif = await modeleActif.mettreAJourNom(
+      req.params.id,
+      req.utilisateur.id,
+      req.body.nom
+    );
+    if (!actif) {
+      throw new ErreurIntrouvable('Actif introuvable.');
+    }
+    res.status(200).json(actif);
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
 async function supprimer(req, res, next) {
   try {
     const supprime = await modeleActif.supprimer(req.params.id, req.utilisateur.id);
@@ -60,4 +76,4 @@ async function supprimer(req, res, next) {
   }
 }
 
-module.exports = { lister, creer, detail, supprimer };
+module.exports = { lister, creer, detail, modifier, supprimer };

--- a/backend/src/controllers/actif.js
+++ b/backend/src/controllers/actif.js
@@ -1,0 +1,63 @@
+// Contrôleurs du portefeuille. L'identifiant du propriétaire vient exclusivement de
+// req.utilisateur, posé par le middleware d'authentification : jamais du corps de la
+// requête ni de l'URL, qui sont sous le contrôle de l'appelant.
+//
+// Choix de statut assumé : une ressource qui existe mais appartient à quelqu'un d'autre
+// renvoie 404, et non 403. Un 403 confirmerait au demandeur que l'identifiant existe,
+// ce qui permettrait d'énumérer les actifs des autres comptes par simple balayage.
+// Un utilisateur ne doit pas pouvoir distinguer « cet actif n'existe pas » de
+// « cet actif ne vous appartient pas ».
+
+const modeleActif = require('../models/actif');
+const { ErreurIntrouvable } = require('../erreurs');
+
+async function lister(req, res, next) {
+  try {
+    const actifs = await modeleActif.listerParUtilisateur(req.utilisateur.id);
+    res.status(200).json(actifs);
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+async function creer(req, res, next) {
+  try {
+    const actif = await modeleActif.creer({
+      utilisateurId: req.utilisateur.id,
+      type: req.body.type,
+      symbole: req.body.symbole,
+      nom: req.body.nom,
+    });
+    res.status(201).json(actif);
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+// Le PRU et les plus-values relèvent d'un lot dédié et ne sont volontairement pas
+// calculés ici.
+async function detail(req, res, next) {
+  try {
+    const actif = await modeleActif.trouverParIdEtUtilisateur(req.params.id, req.utilisateur.id);
+    if (!actif) {
+      throw new ErreurIntrouvable('Actif introuvable.');
+    }
+    res.status(200).json(actif);
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+async function supprimer(req, res, next) {
+  try {
+    const supprime = await modeleActif.supprimer(req.params.id, req.utilisateur.id);
+    if (!supprime) {
+      throw new ErreurIntrouvable('Actif introuvable.');
+    }
+    res.status(204).end();
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+module.exports = { lister, creer, detail, supprimer };

--- a/backend/src/controllers/actif.js
+++ b/backend/src/controllers/actif.js
@@ -9,6 +9,8 @@
 // « cet actif ne vous appartient pas ».
 
 const modeleActif = require('../models/actif');
+const modeleTransaction = require('../models/transaction');
+const serviceTransaction = require('../services/transaction');
 const { ErreurIntrouvable } = require('../erreurs');
 
 async function lister(req, res, next) {
@@ -34,15 +36,21 @@ async function creer(req, res, next) {
   }
 }
 
-// Le PRU et les plus-values relèvent d'un lot dédié et ne sont volontairement pas
-// calculés ici.
+// Détail d'un actif et historique de ses transactions. Le PRU et les plus-values
+// relèvent d'un lot dédié et ne sont volontairement pas calculés ici.
 async function detail(req, res, next) {
   try {
     const actif = await modeleActif.trouverParIdEtUtilisateur(req.params.id, req.utilisateur.id);
     if (!actif) {
       throw new ErreurIntrouvable('Actif introuvable.');
     }
-    res.status(200).json(actif);
+
+    const transactions = await modeleTransaction.listerParActifEtUtilisateur(
+      req.params.id,
+      req.utilisateur.id
+    );
+
+    res.status(200).json({ ...actif, transactions });
   } catch (erreur) {
     next(erreur);
   }
@@ -76,4 +84,38 @@ async function supprimer(req, res, next) {
   }
 }
 
-module.exports = { lister, creer, detail, modifier, supprimer };
+async function ajouterTransaction(req, res, next) {
+  try {
+    const transaction = await serviceTransaction.enregistrer({
+      actifId: req.params.id,
+      utilisateurId: req.utilisateur.id,
+      donnees: req.body,
+    });
+    res.status(201).json(transaction);
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+async function supprimerTransaction(req, res, next) {
+  try {
+    await serviceTransaction.supprimer({
+      actifId: req.params.id,
+      idTransaction: req.params.idTransaction,
+      utilisateurId: req.utilisateur.id,
+    });
+    res.status(204).end();
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+module.exports = {
+  lister,
+  creer,
+  detail,
+  modifier,
+  supprimer,
+  ajouterTransaction,
+  supprimerTransaction,
+};

--- a/backend/src/erreurs.js
+++ b/backend/src/erreurs.js
@@ -10,6 +10,21 @@ class ErreurMetier extends Error {
   }
 }
 
+// Règle de gestion non respectée, au-delà de la simple forme des données.
+class ErreurValidation extends ErreurMetier {
+  constructor(message) {
+    super(message, 400);
+  }
+}
+
+// Ressource inexistante, ou appartenant à quelqu'un d'autre : les deux cas renvoient
+// volontairement le même statut, voir le commentaire des contrôleurs du portefeuille.
+class ErreurIntrouvable extends ErreurMetier {
+  constructor(message) {
+    super(message, 404);
+  }
+}
+
 // Ressource déjà existante, typiquement un email déjà inscrit.
 class ErreurConflit extends ErreurMetier {
   constructor(message) {
@@ -33,6 +48,8 @@ class ErreurAutorisation extends ErreurMetier {
 
 module.exports = {
   ErreurMetier,
+  ErreurValidation,
+  ErreurIntrouvable,
   ErreurConflit,
   ErreurAuthentification,
   ErreurAutorisation,

--- a/backend/src/middlewares/validerParamId.js
+++ b/backend/src/middlewares/validerParamId.js
@@ -1,0 +1,19 @@
+// Contrôle des identifiants passés dans l'URL avant toute requête en base : un
+// paramètre non entier partirait sinon jusqu'à PostgreSQL, qui répondrait par une
+// erreur de conversion de type traduite en 500 alors qu'il s'agit d'une requête
+// malformée, donc d'un 400.
+
+function validerParamId(nomParametre) {
+  return (req, res, next) => {
+    const valeur = req.params[nomParametre];
+
+    if (!/^\d+$/.test(valeur) || Number(valeur) < 1) {
+      return res.status(400).json({ erreur: `L'identifiant ${nomParametre} est invalide.` });
+    }
+
+    req.params[nomParametre] = Number(valeur);
+    return next();
+  };
+}
+
+module.exports = validerParamId;

--- a/backend/src/models/actif.js
+++ b/backend/src/models/actif.js
@@ -1,0 +1,80 @@
+// Accès aux données de la table actif. Toutes les requêtes sont paramétrées et portent
+// leur propre filtre sur le propriétaire : le cloisonnement est garanti par le SQL
+// lui-même (D7), jamais par une comparaison faite après coup en JavaScript. Une requête
+// qui ne trouve rien parce que l'actif appartient à quelqu'un d'autre est indiscernable,
+// pour l'appelant, d'une requête sur un actif inexistant.
+
+const { query } = require('../db');
+const { ErreurConflit } = require('../erreurs');
+
+const CHAMPS = 'id, utilisateur_id, type, symbole, nom, date_ajout';
+
+// Violation de la contrainte UNIQUE (utilisateur_id, symbole).
+const CODE_VIOLATION_UNICITE = '23505';
+
+async function listerParUtilisateur(utilisateurId) {
+  const { rows } = await query(
+    `SELECT ${CHAMPS}
+     FROM actif
+     WHERE utilisateur_id = $1
+     ORDER BY type, symbole`,
+    [utilisateurId]
+  );
+  return rows;
+}
+
+async function trouverParIdEtUtilisateur(id, utilisateurId) {
+  const { rows } = await query(
+    `SELECT ${CHAMPS}
+     FROM actif
+     WHERE id = $1 AND utilisateur_id = $2`,
+    [id, utilisateurId]
+  );
+  return rows[0] || null;
+}
+
+async function creer({ utilisateurId, type, symbole, nom }) {
+  try {
+    const { rows } = await query(
+      `INSERT INTO actif (utilisateur_id, type, symbole, nom)
+       VALUES ($1, $2, $3, $4)
+       RETURNING ${CHAMPS}`,
+      [utilisateurId, type, symbole, nom]
+    );
+    return rows[0];
+  } catch (erreur) {
+    if (erreur.code === CODE_VIOLATION_UNICITE) {
+      throw new ErreurConflit(`Le symbole ${symbole} est déjà suivi.`);
+    }
+    throw erreur;
+  }
+}
+
+async function mettreAJourNom(id, utilisateurId, nom) {
+  const { rows } = await query(
+    `UPDATE actif
+     SET nom = $3
+     WHERE id = $1 AND utilisateur_id = $2
+     RETURNING ${CHAMPS}`,
+    [id, utilisateurId, nom]
+  );
+  return rows[0] || null;
+}
+
+// La suppression entraîne en cascade celle des transactions de l'actif et des alertes
+// qui le ciblent (contraintes ON DELETE CASCADE du schéma).
+async function supprimer(id, utilisateurId) {
+  const { rowCount } = await query('DELETE FROM actif WHERE id = $1 AND utilisateur_id = $2', [
+    id,
+    utilisateurId,
+  ]);
+  return rowCount > 0;
+}
+
+module.exports = {
+  listerParUtilisateur,
+  trouverParIdEtUtilisateur,
+  creer,
+  mettreAJourNom,
+  supprimer,
+};

--- a/backend/src/models/transaction.js
+++ b/backend/src/models/transaction.js
@@ -1,0 +1,53 @@
+// Accès aux données de la table transaction.
+//
+// La table ne porte pas de colonne utilisateur_id : c'est actif qui référence le
+// propriétaire, et transaction référence actif. Le cloisonnement passe donc par une
+// jointure sur actif à l'intérieur de la même requête. Ajouter un utilisateur_id à
+// transaction aurait simplifié l'écriture au prix d'une dénormalisation du modèle,
+// avec le risque d'incohérence que cela suppose : la jointure est préférée.
+
+const { query } = require('../db');
+
+const CHAMPS = 't.id, t.actif_id, t.sens, t.quantite, t.prix_unitaire, t.frais, t.date_transaction, t.note';
+
+async function listerParActifEtUtilisateur(actifId, utilisateurId) {
+  const { rows } = await query(
+    `SELECT ${CHAMPS}
+     FROM transaction t
+     JOIN actif a ON a.id = t.actif_id
+     WHERE t.actif_id = $1 AND a.utilisateur_id = $2
+     ORDER BY t.date_transaction DESC, t.id DESC`,
+    [actifId, utilisateurId]
+  );
+  return rows;
+}
+
+// L'insertion est filtrée de la même façon : le SELECT qui alimente l'INSERT ne rend
+// une ligne que si l'actif appartient bien au demandeur. Si ce n'est pas le cas,
+// aucune ligne n'est insérée et la fonction rend null.
+async function creer({ actifId, utilisateurId, sens, quantite, prixUnitaire, frais, dateTransaction, note }) {
+  const { rows } = await query(
+    `INSERT INTO transaction (actif_id, sens, quantite, prix_unitaire, frais, date_transaction, note)
+     SELECT a.id, $3, $4, $5, $6, $7, $8
+     FROM actif a
+     WHERE a.id = $1 AND a.utilisateur_id = $2
+     RETURNING id, actif_id, sens, quantite, prix_unitaire, frais, date_transaction, note`,
+    [actifId, utilisateurId, sens, quantite, prixUnitaire, frais, dateTransaction, note ?? null]
+  );
+  return rows[0] || null;
+}
+
+async function supprimer(id, actifId, utilisateurId) {
+  const { rowCount } = await query(
+    `DELETE FROM transaction t
+     USING actif a
+     WHERE t.actif_id = a.id
+       AND t.id = $1
+       AND t.actif_id = $2
+       AND a.utilisateur_id = $3`,
+    [id, actifId, utilisateurId]
+  );
+  return rowCount > 0;
+}
+
+module.exports = { listerParActifEtUtilisateur, creer, supprimer };

--- a/backend/src/routes/actif.js
+++ b/backend/src/routes/actif.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const controleur = require('../controllers/actif');
+const valider = require('../middlewares/valider');
+const validerParamId = require('../middlewares/validerParamId');
+const authentifier = require('../middlewares/authentifier');
+const { creationActif } = require('../validation/actif');
+
+const routeur = express.Router();
+
+// Aucune route du portefeuille n'est publique : le middleware s'applique à toutes.
+routeur.use(authentifier);
+
+routeur.get('/', controleur.lister);
+routeur.post('/', valider(creationActif), controleur.creer);
+
+routeur.get('/:id', validerParamId('id'), controleur.detail);
+routeur.delete('/:id', validerParamId('id'), controleur.supprimer);
+
+module.exports = routeur;

--- a/backend/src/routes/actif.js
+++ b/backend/src/routes/actif.js
@@ -3,7 +3,7 @@ const controleur = require('../controllers/actif');
 const valider = require('../middlewares/valider');
 const validerParamId = require('../middlewares/validerParamId');
 const authentifier = require('../middlewares/authentifier');
-const { creationActif } = require('../validation/actif');
+const { creationActif, modificationActif } = require('../validation/actif');
 
 const routeur = express.Router();
 
@@ -14,6 +14,7 @@ routeur.get('/', controleur.lister);
 routeur.post('/', valider(creationActif), controleur.creer);
 
 routeur.get('/:id', validerParamId('id'), controleur.detail);
+routeur.patch('/:id', validerParamId('id'), valider(modificationActif), controleur.modifier);
 routeur.delete('/:id', validerParamId('id'), controleur.supprimer);
 
 module.exports = routeur;

--- a/backend/src/routes/actif.js
+++ b/backend/src/routes/actif.js
@@ -4,6 +4,7 @@ const valider = require('../middlewares/valider');
 const validerParamId = require('../middlewares/validerParamId');
 const authentifier = require('../middlewares/authentifier');
 const { creationActif, modificationActif } = require('../validation/actif');
+const { creationTransaction } = require('../validation/transaction');
 
 const routeur = express.Router();
 
@@ -16,5 +17,18 @@ routeur.post('/', valider(creationActif), controleur.creer);
 routeur.get('/:id', validerParamId('id'), controleur.detail);
 routeur.patch('/:id', validerParamId('id'), valider(modificationActif), controleur.modifier);
 routeur.delete('/:id', validerParamId('id'), controleur.supprimer);
+
+routeur.post(
+  '/:id/transactions',
+  validerParamId('id'),
+  valider(creationTransaction),
+  controleur.ajouterTransaction
+);
+routeur.delete(
+  '/:id/transactions/:idTransaction',
+  validerParamId('id'),
+  validerParamId('idTransaction'),
+  controleur.supprimerTransaction
+);
 
 module.exports = routeur;

--- a/backend/src/services/__tests__/portefeuille.test.js
+++ b/backend/src/services/__tests__/portefeuille.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { quantiteDetenue, verifierVenteAutorisee } from '../portefeuille.js';
+
+function achat(quantite) {
+  return { sens: 'achat', quantite };
+}
+
+function vente(quantite) {
+  return { sens: 'vente', quantite };
+}
+
+describe('quantité détenue', () => {
+  it('rend 0 sur un portefeuille sans transaction', () => {
+    expect(quantiteDetenue([])).toBe('0');
+  });
+
+  it('additionne les achats', () => {
+    expect(quantiteDetenue([achat('0.5'), achat('0.3'), achat('1.2')])).toBe('2');
+  });
+
+  it('soustrait les ventes', () => {
+    expect(quantiteDetenue([achat('0.5'), achat('0.3'), vente('0.2')])).toBe('0.6');
+  });
+
+  it('rend une quantité négative si les ventes dépassent les achats', () => {
+    expect(quantiteDetenue([achat('1'), vente('1.5')])).toBe('-0.5');
+  });
+
+  // En arithmétique flottante, 0.1 + 0.2 vaut 0.30000000000000004 : l'accumulation en
+  // entiers de la plus petite unité doit rendre exactement 0.3.
+  it('reste exact là où le calcul flottant dérive', () => {
+    expect(quantiteDetenue([achat('0.1'), achat('0.2')])).toBe('0.3');
+  });
+
+  it('reste exact sur des quantités à 8 décimales', () => {
+    expect(quantiteDetenue([achat('0.00000001'), achat('0.00000002')])).toBe('0.00000003');
+    expect(quantiteDetenue([achat('1.00000001'), vente('0.00000001')])).toBe('1');
+  });
+
+  it('accepte des quantités fournies en nombre comme en chaîne', () => {
+    expect(quantiteDetenue([achat(0.5), achat('0.25')])).toBe('0.75');
+  });
+});
+
+describe('règle de vente', () => {
+  const historique = [achat('1.5'), vente('0.5')];
+
+  it('accepte une vente inférieure à la quantité détenue', () => {
+    expect(() => verifierVenteAutorisee(historique, '0.4')).not.toThrow();
+  });
+
+  it('accepte une vente égale à la quantité détenue', () => {
+    expect(() => verifierVenteAutorisee(historique, '1')).not.toThrow();
+  });
+
+  it('refuse une vente supérieure à la quantité détenue', () => {
+    expect(() => verifierVenteAutorisee(historique, '1.00000001')).toThrow();
+  });
+
+  it('indique la quantité disponible dans le message', () => {
+    expect(() => verifierVenteAutorisee(historique, '2')).toThrow(/1(\D|$)/);
+  });
+
+  it('refuse toute vente sur un portefeuille vide', () => {
+    expect(() => verifierVenteAutorisee([], '0.00000001')).toThrow();
+  });
+
+  it('lève une erreur portant le statut 400', () => {
+    try {
+      verifierVenteAutorisee(historique, '99');
+      throw new Error('une erreur était attendue');
+    } catch (erreur) {
+      expect(erreur.statut).toBe(400);
+    }
+  });
+});

--- a/backend/src/services/portefeuille.js
+++ b/backend/src/services/portefeuille.js
@@ -1,0 +1,57 @@
+// Règles de gestion du portefeuille, écrites en fonctions pures : elles reçoivent un
+// tableau de transactions et rendent un résultat, sans accès à la base ni à HTTP.
+// C'est ce qui les rend testables seules, et c'est la structure que reprendra le lot
+// des calculs financiers (PRU, plus-values).
+//
+// Choix de calcul : les quantités sont converties en entiers de la plus petite unité
+// représentable (10^-8, soit le maximum de décimales accepté à la validation) et
+// accumulées en BigInt. Additionner des nombres à virgule flottante ferait apparaître
+// des écarts du type 0.1 + 0.2 = 0.30000000000000004, inacceptables sur des quantités
+// financières. Le résultat est rendu sous forme de chaîne, donc exact de bout en bout.
+
+const { ErreurValidation } = require('../erreurs');
+
+const DECIMALES = 8;
+const FACTEUR = 10n ** BigInt(DECIMALES);
+
+function versUnites(valeur) {
+  const [entier, decimales = ''] = String(valeur).trim().split('.');
+  const decimalesCompletees = decimales.padEnd(DECIMALES, '0').slice(0, DECIMALES);
+  return BigInt(entier) * FACTEUR + BigInt(decimalesCompletees);
+}
+
+function versChaine(unites) {
+  const negatif = unites < 0n;
+  const absolu = negatif ? -unites : unites;
+  const partieEntiere = absolu / FACTEUR;
+  const partieDecimale = (absolu % FACTEUR).toString().padStart(DECIMALES, '0').replace(/0+$/, '');
+
+  return `${negatif ? '-' : ''}${partieEntiere}${partieDecimale ? `.${partieDecimale}` : ''}`;
+}
+
+// Quantité restant détenue sur un actif : somme des achats moins somme des ventes.
+// Rendue en chaîne pour rester exacte.
+function quantiteDetenue(transactions) {
+  const total = transactions.reduce((cumul, transaction) => {
+    const unites = versUnites(transaction.quantite);
+    return transaction.sens === 'achat' ? cumul + unites : cumul - unites;
+  }, 0n);
+
+  return versChaine(total);
+}
+
+// Règle « on ne vend pas plus que ce que l'on détient ». Elle porte sur l'agrégat de
+// plusieurs lignes de transaction : aucune contrainte SQL ne peut l'exprimer, elle
+// est donc vérifiée ici, côté serveur (voir modele-de-donnees.md).
+function verifierVenteAutorisee(transactions, quantiteVendue) {
+  const detenu = versUnites(quantiteDetenue(transactions));
+  const vendu = versUnites(quantiteVendue);
+
+  if (vendu > detenu) {
+    throw new ErreurValidation(
+      `Quantité insuffisante : vous détenez ${versChaine(detenu)} sur cet actif.`
+    );
+  }
+}
+
+module.exports = { quantiteDetenue, verifierVenteAutorisee };

--- a/backend/src/services/transaction.js
+++ b/backend/src/services/transaction.js
@@ -1,0 +1,42 @@
+// Orchestration de l'enregistrement d'une transaction : lecture de l'historique,
+// application de la règle de vente, puis écriture. Les règles de calcul elles-mêmes
+// vivent dans portefeuille.js, qui reste sans dépendance à la base et donc testable seul.
+
+const modeleActif = require('../models/actif');
+const modeleTransaction = require('../models/transaction');
+const { verifierVenteAutorisee } = require('./portefeuille');
+const { ErreurIntrouvable } = require('../erreurs');
+
+async function enregistrer({ actifId, utilisateurId, donnees }) {
+  // Contrôle d'existence et de propriété en une seule requête filtrée.
+  const actif = await modeleActif.trouverParIdEtUtilisateur(actifId, utilisateurId);
+  if (!actif) {
+    throw new ErreurIntrouvable('Actif introuvable.');
+  }
+
+  // L'historique n'est chargé que pour une vente : un achat n'a rien à contrôler.
+  if (donnees.sens === 'vente') {
+    const historique = await modeleTransaction.listerParActifEtUtilisateur(actifId, utilisateurId);
+    verifierVenteAutorisee(historique, donnees.quantite);
+  }
+
+  return modeleTransaction.creer({
+    actifId,
+    utilisateurId,
+    sens: donnees.sens,
+    quantite: donnees.quantite,
+    prixUnitaire: donnees.prix_unitaire,
+    frais: donnees.frais,
+    dateTransaction: donnees.date_transaction,
+    note: donnees.note,
+  });
+}
+
+async function supprimer({ actifId, idTransaction, utilisateurId }) {
+  const supprimee = await modeleTransaction.supprimer(idTransaction, actifId, utilisateurId);
+  if (!supprimee) {
+    throw new ErreurIntrouvable('Transaction introuvable.');
+  }
+}
+
+module.exports = { enregistrer, supprimer };

--- a/backend/src/validation/__tests__/actif.test.js
+++ b/backend/src/validation/__tests__/actif.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { creationActif, modificationActif } from '../actif.js';
+
+describe("schéma de création d'un actif", () => {
+  const actifValide = { type: 'crypto', symbole: 'BTC', nom: 'Bitcoin' };
+
+  it('accepte les quatre types du schéma de base', () => {
+    for (const type of ['crypto', 'devise', 'metal', 'action']) {
+      expect(creationActif.safeParse({ ...actifValide, type }).success).toBe(true);
+    }
+  });
+
+  it('rejette un type hors liste', () => {
+    expect(creationActif.safeParse({ ...actifValide, type: 'obligation' }).success).toBe(false);
+  });
+
+  it('normalise le symbole en majuscules et retire les espaces', () => {
+    const resultat = creationActif.parse({ ...actifValide, symbole: '  btc  ' });
+    expect(resultat.symbole).toBe('BTC');
+  });
+
+  it('rejette un symbole vide', () => {
+    expect(creationActif.safeParse({ ...actifValide, symbole: '   ' }).success).toBe(false);
+  });
+
+  it('rejette un symbole contenant autre chose que des lettres et des chiffres', () => {
+    expect(creationActif.safeParse({ ...actifValide, symbole: 'BT-C' }).success).toBe(false);
+  });
+
+  it('rejette un nom vide', () => {
+    expect(creationActif.safeParse({ ...actifValide, nom: '' }).success).toBe(false);
+  });
+
+  // Le propriétaire vient du jeton : le fournir dans le corps doit échouer, sans quoi
+  // un utilisateur pourrait tenter de créer un actif pour le compte d'un autre.
+  it("rejette un utilisateur_id injecté dans le corps", () => {
+    const resultat = creationActif.safeParse({ ...actifValide, utilisateur_id: 1 });
+    expect(resultat.success).toBe(false);
+    expect(resultat.error.issues[0].code).toBe('unrecognized_keys');
+  });
+
+  it('rejette toute clé inconnue', () => {
+    expect(creationActif.safeParse({ ...actifValide, date_ajout: '2026-01-01' }).success).toBe(false);
+  });
+});
+
+describe("schéma de modification d'un actif", () => {
+  it('accepte un nom seul', () => {
+    expect(modificationActif.safeParse({ nom: 'Bitcoin' }).success).toBe(true);
+  });
+
+  // Le symbole et le type sont figés : les changer rendrait l'historique de
+  // transactions incohérent.
+  it('rejette une tentative de modification du symbole ou du type', () => {
+    expect(modificationActif.safeParse({ nom: 'Bitcoin', symbole: 'ETH' }).success).toBe(false);
+    expect(modificationActif.safeParse({ nom: 'Bitcoin', type: 'action' }).success).toBe(false);
+  });
+
+  it('rejette un corps vide', () => {
+    expect(modificationActif.safeParse({}).success).toBe(false);
+  });
+});

--- a/backend/src/validation/__tests__/transaction.test.js
+++ b/backend/src/validation/__tests__/transaction.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { creationTransaction } from '../transaction.js';
+
+const HIER = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+
+const transactionValide = {
+  sens: 'achat',
+  quantite: '0.5',
+  prix_unitaire: '54000.00',
+  date_transaction: HIER,
+};
+
+describe('schéma de création d\'une transaction', () => {
+  it('accepte une transaction bien formée', () => {
+    expect(creationTransaction.safeParse(transactionValide).success).toBe(true);
+  });
+
+  it('applique 0 comme montant de frais par défaut', () => {
+    const resultat = creationTransaction.parse(transactionValide);
+    expect(resultat.frais).toBe('0');
+  });
+
+  it('rejette un sens hors liste', () => {
+    expect(creationTransaction.safeParse({ ...transactionValide, sens: 'don' }).success).toBe(false);
+  });
+
+  it('rejette une quantité nulle', () => {
+    expect(creationTransaction.safeParse({ ...transactionValide, quantite: '0' }).success).toBe(false);
+  });
+
+  it('rejette une quantité négative', () => {
+    expect(creationTransaction.safeParse({ ...transactionValide, quantite: '-1' }).success).toBe(false);
+  });
+
+  it('rejette un prix unitaire négatif', () => {
+    expect(
+      creationTransaction.safeParse({ ...transactionValide, prix_unitaire: '-0.01' }).success
+    ).toBe(false);
+  });
+
+  it('accepte un prix unitaire nul', () => {
+    expect(
+      creationTransaction.safeParse({ ...transactionValide, prix_unitaire: '0' }).success
+    ).toBe(true);
+  });
+
+  it('accepte une quantité à 8 décimales', () => {
+    expect(
+      creationTransaction.safeParse({ ...transactionValide, quantite: '0.00000001' }).success
+    ).toBe(true);
+  });
+
+  it('rejette une quantité à plus de 8 décimales', () => {
+    expect(
+      creationTransaction.safeParse({ ...transactionValide, quantite: '0.000000001' }).success
+    ).toBe(false);
+  });
+
+  it('rejette un prix unitaire à plus de 2 décimales', () => {
+    expect(
+      creationTransaction.safeParse({ ...transactionValide, prix_unitaire: '10.123' }).success
+    ).toBe(false);
+  });
+
+  it('conserve la quantité sous forme de chaîne, sans conversion en flottant', () => {
+    const resultat = creationTransaction.parse({ ...transactionValide, quantite: 0.1 });
+    expect(resultat.quantite).toBe('0.1');
+    expect(typeof resultat.quantite).toBe('string');
+  });
+
+  it('rejette une date de transaction dans le futur', () => {
+    const demain = new Date(Date.now() + 24 * 3600 * 1000).toISOString();
+    expect(
+      creationTransaction.safeParse({ ...transactionValide, date_transaction: demain }).success
+    ).toBe(false);
+  });
+
+  it('rejette une date de transaction invalide', () => {
+    expect(
+      creationTransaction.safeParse({ ...transactionValide, date_transaction: 'hier' }).success
+    ).toBe(false);
+  });
+
+  // actif_id vient de l'URL, le propriétaire du jeton : ni l'un ni l'autre n'est
+  // accepté depuis le corps de la requête.
+  it("rejette un actif_id ou un utilisateur_id injecté dans le corps", () => {
+    expect(creationTransaction.safeParse({ ...transactionValide, actif_id: 1 }).success).toBe(false);
+    expect(
+      creationTransaction.safeParse({ ...transactionValide, utilisateur_id: 1 }).success
+    ).toBe(false);
+  });
+});

--- a/backend/src/validation/actif.js
+++ b/backend/src/validation/actif.js
@@ -1,0 +1,36 @@
+// Schémas de validation des actifs (D41).
+// Ni utilisateur_id ni id ne figurent dans ces schémas : le propriétaire vient du jeton
+// et l'identifiant de l'URL. .strict() rejette donc toute tentative de les fournir
+// dans le corps de la requête.
+
+const { z } = require('zod');
+
+// Les quatre types du CHECK de la table actif, ni plus ni moins.
+const TYPES_ACTIF = ['crypto', 'devise', 'metal', 'action'];
+
+const LONGUEUR_MAXIMALE_SYMBOLE = 20;
+const LONGUEUR_MAXIMALE_NOM = 100;
+
+const symbole = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .min(1, 'Le symbole est obligatoire.')
+  .max(LONGUEUR_MAXIMALE_SYMBOLE, `Le symbole ne peut pas dépasser ${LONGUEUR_MAXIMALE_SYMBOLE} caractères.`)
+  .regex(/^[A-Z0-9]+$/, 'Le symbole ne peut contenir que des lettres et des chiffres.');
+
+const nom = z
+  .string()
+  .trim()
+  .min(1, 'Le nom est obligatoire.')
+  .max(LONGUEUR_MAXIMALE_NOM, `Le nom ne peut pas dépasser ${LONGUEUR_MAXIMALE_NOM} caractères.`);
+
+const creationActif = z
+  .object({
+    type: z.enum(TYPES_ACTIF, "Le type doit valoir crypto, devise, metal ou action."),
+    symbole,
+    nom,
+  })
+  .strict();
+
+module.exports = { creationActif, TYPES_ACTIF };

--- a/backend/src/validation/actif.js
+++ b/backend/src/validation/actif.js
@@ -33,4 +33,8 @@ const creationActif = z
   })
   .strict();
 
-module.exports = { creationActif, TYPES_ACTIF };
+// Seul le nom est modifiable : changer le symbole ou le type d'un actif déjà porteur
+// de transactions rendrait son historique incohérent.
+const modificationActif = z.object({ nom }).strict();
+
+module.exports = { creationActif, modificationActif, TYPES_ACTIF };

--- a/backend/src/validation/transaction.js
+++ b/backend/src/validation/transaction.js
@@ -1,0 +1,55 @@
+// Schémas de validation des transactions (D41).
+//
+// Les montants et les quantités ne sont jamais convertis en nombre à virgule flottante :
+// ils sont normalisés en chaîne de caractères et transmis tels quels aux colonnes NUMERIC
+// de PostgreSQL (D4). Convertir en Number ferait perdre de la précision sur des quantités
+// à 8 décimales, ce qui est exactement ce que le choix de NUMERIC vise à éviter.
+
+const { z } = require('zod');
+
+const SENS_TRANSACTION = ['achat', 'vente'];
+
+const DECIMALES_QUANTITE = 8;
+const DECIMALES_PRIX = 2;
+const LONGUEUR_MAXIMALE_NOTE = 500;
+
+// Accepte un nombre ou une chaîne, et rend toujours une chaîne : la valeur d'origine
+// est préservée au caractère près.
+function nombreDecimal({ decimalesMax, strictementPositif }) {
+  const motif = new RegExp(`^\\d+(\\.\\d{1,${decimalesMax}})?$`);
+
+  return z
+    .union([z.string(), z.number()])
+    .transform((valeur) => String(valeur).trim())
+    .refine((valeur) => motif.test(valeur), {
+      message: `La valeur doit être positive et comporter au plus ${decimalesMax} décimales.`,
+    })
+    .refine((valeur) => !strictementPositif || Number(valeur) > 0, {
+      message: 'La valeur doit être strictement positive.',
+    });
+}
+
+const dateTransaction = z
+  .string()
+  .trim()
+  .refine((valeur) => !Number.isNaN(Date.parse(valeur)), {
+    message: 'La date de transaction est invalide.',
+  })
+  // Une transaction ne peut pas être enregistrée avant d'avoir eu lieu.
+  .refine((valeur) => Date.parse(valeur) <= Date.now(), {
+    message: 'La date de transaction ne peut pas être dans le futur.',
+  });
+
+// actif_id est absent du schéma : il vient de l'URL, contrôlé contre le propriétaire.
+const creationTransaction = z
+  .object({
+    sens: z.enum(SENS_TRANSACTION, 'Le sens doit valoir achat ou vente.'),
+    quantite: nombreDecimal({ decimalesMax: DECIMALES_QUANTITE, strictementPositif: true }),
+    prix_unitaire: nombreDecimal({ decimalesMax: DECIMALES_PRIX, strictementPositif: false }),
+    frais: nombreDecimal({ decimalesMax: DECIMALES_PRIX, strictementPositif: false }).default('0'),
+    date_transaction: dateTransaction,
+    note: z.string().trim().max(LONGUEUR_MAXIMALE_NOTE).optional(),
+  })
+  .strict();
+
+module.exports = { creationTransaction, SENS_TRANSACTION };

--- a/docs/cahier-des-charges.md
+++ b/docs/cahier-des-charges.md
@@ -73,9 +73,11 @@ Contexte de réalisation : projet individuel réalisé pendant la formation au T
 | POST | `/api/auth/connexion` | non | authentification, émission du JWT | 200, 400, 401 |
 | GET | `/api/actifs` | oui | liste des actifs de l'utilisateur | 200, 401 |
 | POST | `/api/actifs` | oui | création d'un actif suivi | 201, 400, 401, 409 |
-| GET | `/api/actifs/:id` | oui, propriétaire | détail d'un actif, PRU, plus-values latente et réalisée | 200, 401, 403, 404 |
-| DELETE | `/api/actifs/:id` | oui, propriétaire | suppression d'un actif (cascade) | 204, 401, 403, 404 |
-| POST | `/api/actifs/:id/transactions` | oui, propriétaire | enregistrement d'une transaction | 201, 400, 401, 403, 404 |
+| GET | `/api/actifs/:id` | oui, propriétaire | détail d'un actif, transactions, PRU, plus-values latente et réalisée | 200, 401, 404 |
+| PATCH | `/api/actifs/:id` | oui, propriétaire | modification du nom d'un actif | 200, 400, 401, 404 |
+| DELETE | `/api/actifs/:id` | oui, propriétaire | suppression d'un actif (cascade) | 204, 401, 404 |
+| POST | `/api/actifs/:id/transactions` | oui, propriétaire | enregistrement d'une transaction | 201, 400, 401, 404 |
+| DELETE | `/api/actifs/:id/transactions/:idTransaction` | oui, propriétaire | suppression d'une transaction (D51) | 204, 401, 404 |
 | GET | `/api/portefeuille` | oui | tableau de bord consolidé (valeur totale, plus-values latente et réalisée) | 200, 401 |
 | GET | `/api/portefeuille/historique` | oui | snapshots de valorisation | 200, 401 |
 | GET | `/api/alertes` | oui | liste des alertes de l'utilisateur | 200, 401 |


### PR DESCRIPTION
Closes #8, closes #73, closes #74, closes #75, closes #76, closes #77

Lot B : CRUD des actifs et enregistrement des transactions, cloisonnement garanti au niveau SQL
(filtre sur le propriétaire dans la requête, jointure sur actif pour les transactions), validation Zod stricte, règle de vente limitée à la quantité détenue extraite en fonction pure et testée.
Aucun calcul de PRU ni de plus-value dans ce lot.

## Cloisonnement

Chaque requête porte son propre filtre sur le propriétaire, dont l'identifiant vient exclusivement du jeton. La table `transaction` ne portant pas de colonne `utilisateur_id`, le filtre passe par une jointure sur `actif` dans la même requête, sans dénormaliser le modèle. Aucune ressource n'est chargée puis comparée en JavaScript.

Une ressource appartenant à un autre utilisateur renvoie **404 et non 403** : un 403 confirmerait que l'identifiant existe et permettrait d'énumérer les données des autres comptes (D52).

## Routes

| Méthode | Route | Statuts |
|---|---|---|
| GET | `/api/actifs` | 200, 401 |
| POST | `/api/actifs` | 201, 400, 401, 409 |
| GET | `/api/actifs/:id` | 200, 401, 404 |
| PATCH | `/api/actifs/:id` | 200, 400, 401, 404 |
| DELETE | `/api/actifs/:id` | 204, 401, 404 |
| POST | `/api/actifs/:id/transactions` | 201, 400, 401, 404 |
| DELETE | `/api/actifs/:id/transactions/:idTransaction` | 204, 401, 404 |

La suppression d'une transaction est ajoutée au périmètre (D51) : sans elle, une saisie erronée bloque l'actif via la règle de vente et fausserait le futur PRU.

## Exactitude des montants

Les quantités et les montants ne sont jamais convertis en nombre à virgule flottante : la validation les normalise en chaîne et les transmet tels quels aux colonnes NUMERIC. Le calcul de la quantité détenue accumule en entiers de la plus petite unité représentable, ce qui rend `0.1 + 0.2` exactement égal à `0.3`, cas couvert par un test.

## Vérification

69 tests unitaires au vert, dont la validation des schémas, le rejet d'un `utilisateur_id` injecté dans le corps, et la règle de vente sur des quantités à 8 décimales.

Idempotence du seed prouvée par comparaison des comptages des six tables sur deux exécutions consécutives.

Vérifié contre PostgreSQL, serveur démarré : liste des 6 actifs du seed pour leur propriétaire, liste vide pour un compte neuf, 404 en lecture comme en écriture sur un actif d'autrui, 409 sur doublon de symbole, 400 avec la quantité disponible sur une vente excessive, 400 sur une date future, 401 sans jeton, et 400 sur un identifiant d'URL non entier.

## Liste de contrôle

- [x] Architecture respectee : routes, middlewares, controllers, services, models
- [x] Entrees validees cote serveur (Zod strict)
- [x] Requetes SQL parametrees, aucune concatenation
- [x] Verification de propriete portee par le SQL, jamais en JavaScript
- [x] Aucun secret ni cle d'API dans le diff
- [x] Tests unitaires au vert
- [x] Messages de commit conformes a docs/convention-commits.md
