### PR TITLE
feat(back): cours des actifs, adaptateurs et cache Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Variables lues par docker-compose.yml au démarrage des services de développement.
+# Copier ce fichier vers .env à la racine et renseigner les valeurs du poste.
+# Ce .env est distinct de backend/.env : celui-ci configure les conteneurs, celui-là
+# configure l'application. Aucun des deux n'est versionné.
+
+# Identifiants du service PostgreSQL conteneurisé.
+POSTGRES_USER=capitall
+POSTGRES_PASSWORD=
+POSTGRES_DB=capitall
+
+# Ports publiés sur le poste. À changer si un serveur local occupe déjà ces ports.
+POSTGRES_PORT=5432
+REDIS_PORT=6379

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.3",
         "pg": "^8.13.1",
+        "redis": "^6.1.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -68,6 +69,79 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-6.1.0.tgz",
+      "integrity": "sha512-Rzascjd9J9bJsM45T/Z9CTg1QY/B63B6YO8QorLVMeXnbBDsKiSCVR/+GQ061hYPk8FpTzWmPY8tAv2sT+JEtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.1.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.1.0.tgz",
+      "integrity": "sha512-7u1LefkezJF0HESlhO7ZFLEPfyY+NejP3SGv+Z4pGaT3oM5GVVLa0u3f4rDLUrcw+SRo8IlX9Y8JAONeDdg1Ag==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-6.1.0.tgz",
+      "integrity": "sha512-/GFjQA6bu5pG9ClCJAI5Xx4bNXe7UTpxBBlIupBNTrn1+nY860apGnYJuaSCDV2BmEbTidpa7O2qa28oxKx+rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.1.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-6.1.0.tgz",
+      "integrity": "sha512-kS5agg+3yZbrdrt8omrew7FLCD8eOm7tarG1CROekPBRe+QGDR9aOpnHIQaYsYi6wPRTH70nQiF06AIjgURefQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.1.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-6.1.0.tgz",
+      "integrity": "sha512-uIDBtV8MmG/xpJsRqbGSO4iX6ryj37MLMP82lRpFvI7ykAVe5GyqgxigEbU+uZNv9kDPNMKw3dvI/S/J1BNBzA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.1.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -643,6 +717,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/content-disposition": {
@@ -1893,6 +1976,22 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/redis": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-6.1.0.tgz",
+      "integrity": "sha512-0kvUPM8RHP/ZMa0xYaDTcG5e8tIGW6kz6MToVT0V8iOnk6bkXp2jncGRGe2bZEk41lZwiDspUqjZCSk5ohjcKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "6.1.0",
+        "@redis/client": "6.1.0",
+        "@redis/json": "6.1.0",
+        "@redis/search": "6.1.0",
+        "@redis/time-series": "6.1.0"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/rolldown": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.3",
     "pg": "^8.13.1",
+    "redis": "^6.1.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/backend/scripts/verifier-cours.js
+++ b/backend/scripts/verifier-cours.js
@@ -1,0 +1,46 @@
+// Vérification manuelle de la chaîne de récupération des cours : adaptateurs, cache
+// et repli. Outil de mise au point et de démonstration, il n'expose aucune route et
+// n'est pas chargé par le serveur.
+//
+//   node scripts/verifier-cours.js
+//
+// Lancé deux fois de suite, il montre le cache à l'œuvre : la première exécution
+// affiche la source « fournisseur », la seconde « cache ».
+
+const { creerServiceCours } = require('../src/services/cours');
+const cacheRedis = require('../src/cache/client');
+
+const SYMBOLES = [
+  { symbole: 'BTC', type: 'crypto' },
+  { symbole: 'USD', type: 'devise' },
+  { symbole: 'XAU', type: 'metal' },
+];
+
+function formater(cours) {
+  if (cours.erreur) {
+    return `${cours.symbole.padEnd(5)} ECHEC     ${cours.erreur}`;
+  }
+  const valeur = `${Number(cours.cours_eur).toLocaleString('fr-FR')} EUR`;
+  return `${cours.symbole.padEnd(5)} ${cours.source.padEnd(11)} ${valeur.padStart(18)}   ${cours.horodatage}`;
+}
+
+(async () => {
+  const service = creerServiceCours();
+
+  console.log('Symbole  Source          Cours en euros   Horodatage');
+  console.log('-------  -----------  ----------------   ----------------------------');
+
+  for (const demande of SYMBOLES) {
+    try {
+      const cours = await service.getCours(demande.symbole, demande.type);
+      console.log(formater(cours));
+    } catch (erreur) {
+      console.log(`${demande.symbole.padEnd(5)} INDISPONIBLE  ${erreur.message}`);
+    }
+  }
+
+  console.log('');
+  console.log(`Cache Redis : ${cacheRedis.estDisponible() ? 'disponible' : 'indisponible'}`);
+
+  await cacheRedis.fermer();
+})();

--- a/backend/src/adaptateurs/__tests__/coinbase.test.js
+++ b/backend/src/adaptateurs/__tests__/coinbase.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { creerAdaptateurCoinbase } from '../coinbase.js';
+
+// Réponse réelle simplifiée : Coinbase renvoie plusieurs centaines de paires et des
+// valeurs en chaîne de caractères.
+function reponseCoinbase(rates) {
+  return { data: { currency: 'BTC', rates } };
+}
+
+describe('adaptateur Coinbase', () => {
+  it('extrait le cours en euros et rend la forme commune', async () => {
+    const recupererJson = vi.fn().mockResolvedValue(
+      reponseCoinbase({ EUR: '62704.64', USD: '73010.96', GBP: '54000.00' })
+    );
+    const adaptateur = creerAdaptateurCoinbase({ recupererJson });
+
+    const cours = await adaptateur.getCours('btc');
+
+    expect(cours.symbole).toBe('BTC');
+    expect(cours.cours_eur).toBe('62704.64');
+    expect(cours.source).toBe('coinbase');
+    expect(typeof cours.horodatage).toBe('string');
+  });
+
+  it('interroge le bon endpoint avec le symbole en majuscules', async () => {
+    const recupererJson = vi.fn().mockResolvedValue(reponseCoinbase({ EUR: '2750.00' }));
+    const adaptateur = creerAdaptateurCoinbase({ recupererJson });
+
+    await adaptateur.getCours('eth');
+
+    expect(recupererJson).toHaveBeenCalledWith(
+      'https://api.coinbase.com/v2/exchange-rates?currency=ETH'
+    );
+  });
+
+  // La valeur ne doit jamais passer par Number : sur des montants financiers, la
+  // conversion en flottant introduirait une imprécision définitive (D4).
+  it('conserve la valeur en chaîne, sans conversion', async () => {
+    const recupererJson = vi.fn().mockResolvedValue(reponseCoinbase({ EUR: '0.00000001' }));
+    const adaptateur = creerAdaptateurCoinbase({ recupererJson });
+
+    const cours = await adaptateur.getCours('SHIB');
+
+    expect(cours.cours_eur).toBe('0.00000001');
+    expect(typeof cours.cours_eur).toBe('string');
+  });
+
+  it("rejette une réponse sans ligne EUR, avec un message explicite", async () => {
+    const recupererJson = vi.fn().mockResolvedValue(reponseCoinbase({ USD: '73010.96' }));
+    const adaptateur = creerAdaptateurCoinbase({ recupererJson });
+
+    await expect(adaptateur.getCours('BTC')).rejects.toThrow(/euros pour BTC/);
+  });
+
+  it('rejette une réponse malformée', async () => {
+    const recupererJson = vi.fn().mockResolvedValue({ erreur: 'symbole inconnu' });
+    const adaptateur = creerAdaptateurCoinbase({ recupererJson });
+
+    await expect(adaptateur.getCours('INEXISTANT')).rejects.toThrow();
+  });
+});

--- a/backend/src/adaptateurs/__tests__/frankfurter.test.js
+++ b/backend/src/adaptateurs/__tests__/frankfurter.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { creerAdaptateurFrankfurter, inverserTaux } from '../frankfurter.js';
+
+function reponseFrankfurter(symbole, taux, date = '2026-07-20') {
+  return { amount: 1.0, base: 'EUR', date, rates: { [symbole]: taux } };
+}
+
+describe('adaptateur Frankfurter', () => {
+  // Garde-fou principal du lot. Frankfurter cote depuis l'euro : rates.USD = 1.25
+  // signifie qu'un euro vaut 1,25 dollar, donc qu'un dollar vaut 0,80 euro.
+  // Renvoyer 1.25 au lieu de 0.8 donnerait un portefeuille faux sans rien signaler.
+  it('inverse le taux : 1 EUR = 1.25 USD donne 1 USD = 0.8 EUR', async () => {
+    const recupererJson = vi.fn().mockResolvedValue(reponseFrankfurter('USD', 1.25));
+    const adaptateur = creerAdaptateurFrankfurter({ recupererJson });
+
+    const cours = await adaptateur.getCours('USD');
+
+    expect(cours.cours_eur).toBe('0.8');
+  });
+
+  it('inverse correctement un taux réel', () => {
+    // 1 / 1.1426 = 0.87519692... arrondi à 8 décimales
+    expect(inverserTaux(1.1426)).toBe('0.87519692');
+  });
+
+  it('rend la forme commune et la source', async () => {
+    const recupererJson = vi.fn().mockResolvedValue(reponseFrankfurter('GBP', 0.85));
+    const adaptateur = creerAdaptateurFrankfurter({ recupererJson });
+
+    const cours = await adaptateur.getCours('gbp');
+
+    expect(cours.symbole).toBe('GBP');
+    expect(cours.source).toBe('frankfurter');
+    expect(Number(cours.cours_eur)).toBeCloseTo(1 / 0.85, 6);
+  });
+
+  // Les taux BCE ne sont publiés que les jours ouvrés : une date antérieure au jour
+  // courant est le fonctionnement normal, pas une panne. Elle est remontée telle quelle.
+  it("remonte la date du taux telle quelle, même antérieure au jour courant", async () => {
+    const recupererJson = vi.fn().mockResolvedValue(reponseFrankfurter('USD', 1.1426, '2026-07-17'));
+    const adaptateur = creerAdaptateurFrankfurter({ recupererJson });
+
+    const cours = await adaptateur.getCours('USD');
+
+    expect(cours.horodatage.startsWith('2026-07-17')).toBe(true);
+  });
+
+  it("ne fait aucun appel réseau pour l'euro, qui vaut 1 par définition", async () => {
+    const recupererJson = vi.fn();
+    const adaptateur = creerAdaptateurFrankfurter({ recupererJson });
+
+    const cours = await adaptateur.getCours('EUR');
+
+    expect(cours.cours_eur).toBe('1');
+    expect(recupererJson).not.toHaveBeenCalled();
+  });
+
+  it('rejette une réponse sans taux pour le symbole demandé', async () => {
+    const recupererJson = vi.fn().mockResolvedValue({ base: 'EUR', date: '2026-07-20', rates: {} });
+    const adaptateur = creerAdaptateurFrankfurter({ recupererJson });
+
+    await expect(adaptateur.getCours('XYZ')).rejects.toThrow(/pas renvoyé de taux/);
+  });
+
+  it('expose le taux USD vers EUR pour la conversion des métaux', async () => {
+    const recupererJson = vi.fn().mockResolvedValue(reponseFrankfurter('USD', 1.25));
+    const adaptateur = creerAdaptateurFrankfurter({ recupererJson });
+
+    expect(await adaptateur.obtenirTauxUsdEur()).toBe('0.8');
+  });
+});

--- a/backend/src/adaptateurs/__tests__/metal.test.js
+++ b/backend/src/adaptateurs/__tests__/metal.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { creerAdaptateurMetal } from '../metal.js';
+
+function reponseGoldApi(price, updatedAt = '2026-07-20T17:12:30Z') {
+  return {
+    currency: 'USD',
+    currencySymbol: '$',
+    exchangeRate: 1.0,
+    name: 'Gold',
+    price,
+    symbol: 'XAU',
+    updatedAt,
+  };
+}
+
+describe('adaptateur gold-api', () => {
+  // Cas chiffré vérifiable à la main : 2000 dollars l'once, un dollar valant 0,80 euro,
+  // donne 1600 euros l'once. C'est le piège principal de ce fournisseur, dont le prix
+  // n'est jamais libellé en euros.
+  it('convertit le prix en dollars par once au taux injecté', async () => {
+    const recupererJson = vi.fn().mockResolvedValue(reponseGoldApi(2000));
+    const obtenirTauxUsdEur = vi.fn().mockResolvedValue('0.8');
+    const adaptateur = creerAdaptateurMetal({ recupererJson, obtenirTauxUsdEur });
+
+    const cours = await adaptateur.getCours('XAU');
+
+    expect(cours.cours_eur).toBe('1600.00');
+    expect(cours.symbole).toBe('XAU');
+    expect(cours.source).toBe('gold-api');
+  });
+
+  it('interroge le bon endpoint', async () => {
+    const recupererJson = vi.fn().mockResolvedValue(reponseGoldApi(1000));
+    const obtenirTauxUsdEur = vi.fn().mockResolvedValue('0.9');
+    const adaptateur = creerAdaptateurMetal({ recupererJson, obtenirTauxUsdEur });
+
+    await adaptateur.getCours('xag');
+
+    expect(recupererJson).toHaveBeenCalledWith('https://api.gold-api.com/price/XAG');
+  });
+
+  it("remonte l'horodatage du fournisseur", async () => {
+    const recupererJson = vi.fn().mockResolvedValue(reponseGoldApi(4012.300049));
+    const obtenirTauxUsdEur = vi.fn().mockResolvedValue('0.87519692');
+    const adaptateur = creerAdaptateurMetal({ recupererJson, obtenirTauxUsdEur });
+
+    const cours = await adaptateur.getCours('XAU');
+
+    expect(cours.horodatage.startsWith('2026-07-20')).toBe(true);
+  });
+
+  it('rejette une réponse sans prix exploitable', async () => {
+    const recupererJson = vi.fn().mockResolvedValue({ symbol: 'XAU', name: 'Gold' });
+    const obtenirTauxUsdEur = vi.fn().mockResolvedValue('0.8');
+    const adaptateur = creerAdaptateurMetal({ recupererJson, obtenirTauxUsdEur });
+
+    await expect(adaptateur.getCours('XAU')).rejects.toThrow(/pas renvoyé de prix/);
+  });
+
+  // Sans taux de change, la conversion est impossible : mieux vaut une erreur claire
+  // qu'un cours libellé en dollars présenté comme des euros.
+  it('rejette si le taux de change est indisponible', async () => {
+    const recupererJson = vi.fn().mockResolvedValue(reponseGoldApi(2000));
+    const obtenirTauxUsdEur = vi.fn().mockResolvedValue(null);
+    const adaptateur = creerAdaptateurMetal({ recupererJson, obtenirTauxUsdEur });
+
+    await expect(adaptateur.getCours('XAU')).rejects.toThrow(/Taux de change/);
+  });
+});

--- a/backend/src/adaptateurs/clientHttp.js
+++ b/backend/src/adaptateurs/clientHttp.js
@@ -1,0 +1,35 @@
+// Client HTTP commun aux adaptateurs de cours. Il est injecté dans chaque factory
+// plutôt qu'importé directement par les adaptateurs : c'est ce qui permet de les
+// tester sans réseau, en fournissant une simple fonction à la place.
+
+const { ErreurFournisseur } = require('../erreurs');
+
+// Un fournisseur qui ne répond pas dans ce délai est considéré indisponible : la
+// réponse à l'utilisateur passe alors par le dernier cours connu.
+const DELAI_REQUETE_MS = 5000;
+
+async function recupererJson(url, { delaiMs = DELAI_REQUETE_MS } = {}) {
+  const controleur = new AbortController();
+  const minuterie = setTimeout(() => controleur.abort(), delaiMs);
+
+  try {
+    const reponse = await fetch(url, { signal: controleur.signal });
+
+    if (!reponse.ok) {
+      throw new ErreurFournisseur(`Le fournisseur a répondu ${reponse.status}.`);
+    }
+
+    return await reponse.json();
+  } catch (erreur) {
+    if (erreur instanceof ErreurFournisseur) {
+      throw erreur;
+    }
+    // Coupure réseau, DNS, délai dépassé, JSON illisible : tous ramenés à une même
+    // erreur métier, l'appelant n'ayant pas à connaître la cause technique.
+    throw new ErreurFournisseur(`Fournisseur injoignable : ${erreur.message}`);
+  } finally {
+    clearTimeout(minuterie);
+  }
+}
+
+module.exports = { recupererJson, DELAI_REQUETE_MS };

--- a/backend/src/adaptateurs/coinbase.js
+++ b/backend/src/adaptateurs/coinbase.js
@@ -1,0 +1,42 @@
+// Adaptateur Coinbase : cours des cryptomonnaies, directement en euros.
+// Endpoint public, sans authentification.
+//
+// Factory : le client HTTP est reçu en paramètre, aucun appel réseau n'est écrit en
+// dur ici. L'adaptateur est ainsi testable sans réseau.
+
+const { ErreurFournisseur } = require('../erreurs');
+
+const BASE_URL = 'https://api.coinbase.com/v2';
+const SOURCE = 'coinbase';
+
+function creerAdaptateurCoinbase({ recupererJson }) {
+  async function getCours(symbole) {
+    const symboleNormalise = symbole.toUpperCase();
+    const reponse = await recupererJson(
+      `${BASE_URL}/exchange-rates?currency=${encodeURIComponent(symboleNormalise)}`
+    );
+
+    // La réponse contient plusieurs centaines de paires pour un seul symbole.
+    // Seule la ligne EUR est extraite ici : le reste ne quitte jamais le serveur.
+    const taux = reponse?.data?.rates?.EUR;
+
+    if (!taux) {
+      throw new ErreurFournisseur(
+        `Coinbase n'a pas renvoyé de cours en euros pour ${symboleNormalise}.`
+      );
+    }
+
+    return {
+      symbole: symboleNormalise,
+      // La valeur est déjà une chaîne côté Coinbase : elle est conservée telle quelle,
+      // sans passer par Number, pour ne pas introduire d'imprécision (D4).
+      cours_eur: String(taux),
+      horodatage: new Date().toISOString(),
+      source: SOURCE,
+    };
+  }
+
+  return { getCours, source: SOURCE };
+}
+
+module.exports = { creerAdaptateurCoinbase, BASE_URL, SOURCE };

--- a/backend/src/adaptateurs/frankfurter.js
+++ b/backend/src/adaptateurs/frankfurter.js
@@ -1,0 +1,69 @@
+// Adaptateur Frankfurter : taux de change de référence publiés par la Banque centrale
+// européenne. Sert à deux usages : le cours des devises étrangères suivies, et la
+// conversion USD vers EUR dont dépend l'adaptateur des métaux.
+
+const { ErreurFournisseur } = require('../erreurs');
+
+const BASE_URL = 'https://api.frankfurter.dev/v1';
+const SOURCE = 'frankfurter';
+
+// Nombre de décimales conservées après l'inversion du taux. La division n'a pas de
+// résultat exact en général : on fixe une précision suffisante pour un cours de
+// change, puis on retire les zéros inutiles.
+const DECIMALES_TAUX = 8;
+
+// Frankfurter cote toujours à partir de l'euro : rates.USD vaut le nombre de dollars
+// que vaut UN euro. Or un utilisateur qui détient des dollars veut savoir ce que vaut
+// UN dollar en euros, soit l'inverse. Oublier cette inversion donnerait un cours
+// faux d'un facteur proche de 1,3 sans que rien ne le signale.
+function inverserTaux(tauxDepuisEuro) {
+  const inverse = 1 / tauxDepuisEuro;
+  return inverse.toFixed(DECIMALES_TAUX).replace(/\.?0+$/, '');
+}
+
+function creerAdaptateurFrankfurter({ recupererJson }) {
+  async function getCours(symbole) {
+    const symboleNormalise = symbole.toUpperCase();
+
+    // Cas particulier : l'euro est la devise de référence, il vaut toujours 1.
+    if (symboleNormalise === 'EUR') {
+      return {
+        symbole: 'EUR',
+        cours_eur: '1',
+        horodatage: new Date().toISOString(),
+        source: SOURCE,
+      };
+    }
+
+    const reponse = await recupererJson(
+      `${BASE_URL}/latest?base=EUR&symbols=${encodeURIComponent(symboleNormalise)}`
+    );
+
+    const tauxDepuisEuro = reponse?.rates?.[symboleNormalise];
+
+    if (!tauxDepuisEuro || tauxDepuisEuro <= 0) {
+      throw new ErreurFournisseur(`Frankfurter n'a pas renvoyé de taux pour ${symboleNormalise}.`);
+    }
+
+    return {
+      symbole: symboleNormalise,
+      cours_eur: inverserTaux(tauxDepuisEuro),
+      // La date du taux est remontée telle quelle. Les taux BCE n'étant publiés que
+      // les jours ouvrés, elle est régulièrement antérieure au jour courant : c'est
+      // le fonctionnement normal du service, pas un signe d'indisponibilité.
+      horodatage: reponse.date ? new Date(reponse.date).toISOString() : new Date().toISOString(),
+      source: SOURCE,
+    };
+  }
+
+  // Exposé séparément parce que l'adaptateur des métaux en a besoin pour convertir un
+  // prix libellé en dollars, sans redemander lui-même le taux au fournisseur.
+  async function obtenirTauxUsdEur() {
+    const cours = await getCours('USD');
+    return cours.cours_eur;
+  }
+
+  return { getCours, obtenirTauxUsdEur, source: SOURCE };
+}
+
+module.exports = { creerAdaptateurFrankfurter, inverserTaux, BASE_URL, SOURCE };

--- a/backend/src/adaptateurs/index.js
+++ b/backend/src/adaptateurs/index.js
@@ -1,0 +1,49 @@
+// Assemblage des adaptateurs et routage par type d'actif.
+//
+// La logique métier appelle toujours getCours(symbole) sur l'adaptateur que lui rend
+// ce module : elle ignore quel fournisseur répond, et un changement de fournisseur ne
+// la touche pas (D5). C'est ce qui permettra d'ajouter les actions sans modifier le
+// service de cours.
+
+const { recupererJson } = require('./clientHttp');
+const { creerAdaptateurCoinbase } = require('./coinbase');
+const { creerAdaptateurFrankfurter } = require('./frankfurter');
+const { creerAdaptateurMetal } = require('./metal');
+const { ErreurFournisseur } = require('../erreurs');
+
+function creerAdaptateurs({ recupererJson: clientHttp = recupererJson, obtenirTauxUsdEur } = {}) {
+  const coinbase = creerAdaptateurCoinbase({ recupererJson: clientHttp });
+  const frankfurter = creerAdaptateurFrankfurter({ recupererJson: clientHttp });
+
+  // La conversion des métaux a besoin du taux USD vers EUR. En usage réel, le service
+  // de cours injecte ici sa propre fonction, ce qui fait passer le taux par le cache
+  // au lieu de rappeler Frankfurter à chaque cours de métal. Le repli sur l'adaptateur
+  // direct ne sert qu'aux usages sans service, comme les tests d'adaptateur isolés.
+  const metal = creerAdaptateurMetal({
+    recupererJson: clientHttp,
+    obtenirTauxUsdEur: obtenirTauxUsdEur ?? frankfurter.obtenirTauxUsdEur,
+  });
+
+  const parType = {
+    crypto: coinbase,
+    devise: frankfurter,
+    metal,
+  };
+
+  // Le type action est prévu au modèle mais son fournisseur n'est pas encore branché.
+  // L'absence est signalée explicitement plutôt que rendue par un null silencieux,
+  // qui provoquerait une erreur incompréhensible plus loin dans la chaîne.
+  function obtenirAdaptateur(type) {
+    const adaptateur = parType[type];
+
+    if (!adaptateur) {
+      throw new ErreurFournisseur(`Fournisseur non branché pour le type d'actif « ${type} ».`);
+    }
+
+    return adaptateur;
+  }
+
+  return { obtenirAdaptateur, parType };
+}
+
+module.exports = { creerAdaptateurs };

--- a/backend/src/adaptateurs/metal.js
+++ b/backend/src/adaptateurs/metal.js
@@ -1,0 +1,50 @@
+// Adaptateur gold-api : cours des métaux précieux (XAU, XAG).
+//
+// Particularité de ce fournisseur : le prix est libellé en DOLLARS PAR ONCE. La
+// conversion en euros est donc obligatoire. Le taux de change n'est pas redemandé
+// ici : la fonction obtenirTauxUsdEur est injectée dans la factory, et passe par le
+// service de cours, donc par le cache. Dupliquer l'appel Frankfurter dans cet
+// adaptateur multiplierait les appels sortants pour la même donnée.
+
+const { ErreurFournisseur } = require('../erreurs');
+
+const BASE_URL = 'https://api.gold-api.com';
+const SOURCE = 'gold-api';
+
+const DECIMALES_PRIX = 2;
+
+function creerAdaptateurMetal({ recupererJson, obtenirTauxUsdEur }) {
+  async function getCours(symbole) {
+    const symboleNormalise = symbole.toUpperCase();
+    const reponse = await recupererJson(
+      `${BASE_URL}/price/${encodeURIComponent(symboleNormalise)}`
+    );
+
+    const prixUsd = reponse?.price;
+
+    if (typeof prixUsd !== 'number' || !Number.isFinite(prixUsd) || prixUsd <= 0) {
+      throw new ErreurFournisseur(`gold-api n'a pas renvoyé de prix pour ${symboleNormalise}.`);
+    }
+
+    const tauxUsdEur = Number(await obtenirTauxUsdEur());
+
+    if (!tauxUsdEur || tauxUsdEur <= 0) {
+      throw new ErreurFournisseur(
+        'Taux de change USD vers EUR indisponible, conversion du métal impossible.'
+      );
+    }
+
+    return {
+      symbole: symboleNormalise,
+      cours_eur: (prixUsd * tauxUsdEur).toFixed(DECIMALES_PRIX),
+      horodatage: reponse.updatedAt
+        ? new Date(reponse.updatedAt).toISOString()
+        : new Date().toISOString(),
+      source: SOURCE,
+    };
+  }
+
+  return { getCours, source: SOURCE };
+}
+
+module.exports = { creerAdaptateurMetal, BASE_URL, SOURCE };

--- a/backend/src/cache/client.js
+++ b/backend/src/cache/client.js
@@ -1,0 +1,134 @@
+// Client Redis partagé. Ce module ne connaît rien aux cours : il gère uniquement la
+// connexion, sa résilience et son arrêt. Les clés métier sont l'affaire de cacheCours.
+//
+// Principe directeur : le cache est une optimisation, jamais une dépendance dure.
+// Aucune fonction d'ici ne propage d'exception à l'appelant. Si Redis est absent ou
+// lent, l'application continue en interrogeant directement les fournisseurs de cours.
+
+const { createClient } = require('redis');
+const config = require('../config');
+
+// Au-delà de ce délai, une opération de cache est abandonnée : attendre Redis plus
+// longtemps que le fournisseur lui-même n'aurait aucun sens.
+const DELAI_OPERATION_MS = 200;
+
+const RECONNEXION_DELAI_INITIAL_MS = 200;
+const RECONNEXION_DELAI_MAXIMAL_MS = 10000;
+
+let client = null;
+let connexionEnCours = null;
+// Évite de répéter le même avertissement à chaque appel lorsque Redis est arrêté.
+let indisponibiliteSignalee = false;
+
+function creerClient() {
+  const nouveauClient = createClient({
+    url: config.redisUrl,
+    socket: {
+      // Recul progressif plafonné : sans plafond, les tentatives s'espaceraient
+      // indéfiniment ; sans recul, elles saturerait le journal et le processeur.
+      reconnectStrategy: (tentatives) =>
+        Math.min(RECONNEXION_DELAI_INITIAL_MS * 2 ** tentatives, RECONNEXION_DELAI_MAXIMAL_MS),
+    },
+  });
+
+  // Sans écouteur d'erreur, le client Redis émet une exception non gérée qui arrête
+  // le processus : c'est exactement ce que l'on veut éviter.
+  nouveauClient.on('error', (erreur) => {
+    if (!indisponibiliteSignalee) {
+      console.error('Cache Redis indisponible, repli sur les fournisseurs :', erreur.message);
+      indisponibiliteSignalee = true;
+    }
+  });
+
+  nouveauClient.on('ready', () => {
+    if (indisponibiliteSignalee) {
+      console.log('Cache Redis de nouveau disponible');
+    }
+    indisponibiliteSignalee = false;
+  });
+
+  return nouveauClient;
+}
+
+// Connexion paresseuse : le client n'est créé qu'au premier usage réel du cache, et
+// une seule fois pour tout le processus.
+async function obtenirClient() {
+  if (!client) {
+    client = creerClient();
+  }
+
+  if (!client.isOpen && !connexionEnCours) {
+    connexionEnCours = client.connect().catch(() => null);
+  }
+
+  if (connexionEnCours) {
+    await connexionEnCours;
+    connexionEnCours = null;
+  }
+
+  // Le client a pu être fermé entre-temps : une opération abandonnée par le délai
+  // poursuit son cours en arrière-plan et peut reprendre la main après fermer().
+  if (!client) {
+    return null;
+  }
+
+  return client.isReady ? client : null;
+}
+
+function estDisponible() {
+  return Boolean(client && client.isReady);
+}
+
+// Enveloppe commune à toutes les opérations : borne la durée et absorbe les erreurs.
+// Rend valeurParDefaut si le cache n'a pas répondu à temps ou a échoué.
+//
+// Le délai couvre la connexion autant que l'opération elle-même. C'est indispensable :
+// lorsque Redis est arrêté, la tentative de connexion ne rend jamais la main, puisque
+// le client retente indéfiniment en arrière-plan. Ne borner que l'opération laisserait
+// l'appelant suspendu pour toujours.
+function executer(operation, valeurParDefaut = null) {
+  const tentative = (async () => {
+    const connexion = await obtenirClient();
+    if (!connexion) {
+      return valeurParDefaut;
+    }
+    return operation(connexion);
+  })().catch((erreur) => {
+    console.error('Opération de cache abandonnée :', erreur.message);
+    return valeurParDefaut;
+  });
+
+  const echeance = new Promise((resolve) => {
+    const minuterie = setTimeout(() => resolve(valeurParDefaut), DELAI_OPERATION_MS);
+    // Sans unref, cette minuterie maintiendrait le processus en vie jusqu'à son terme.
+    minuterie.unref?.();
+  });
+
+  return Promise.race([tentative, echeance]);
+}
+
+// Fermeture propre : sans elle, le processus resterait suspendu à la connexion ouverte,
+// ou aux tentatives de reconnexion si Redis est arrêté.
+async function fermer() {
+  if (!client) {
+    return;
+  }
+
+  try {
+    if (client.isReady) {
+      // Connexion établie : on laisse Redis terminer les commandes en cours.
+      await client.quit();
+    } else {
+      // Client en cours de reconnexion : quit() attendrait une connexion qui ne
+      // viendra pas. La fermeture immédiate est ici le seul moyen de rendre la main.
+      client.destroy();
+    }
+  } catch {
+    // Une fermeture qui échoue ne doit jamais empêcher l'arrêt du processus.
+  }
+
+  client = null;
+  connexionEnCours = null;
+}
+
+module.exports = { obtenirClient, estDisponible, executer, fermer, DELAI_OPERATION_MS };

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -39,6 +39,11 @@ const config = Object.freeze({
   databaseUrl: process.env.DATABASE_URL,
   jwtSecret: process.env.JWT_SECRET,
   jwtExpiration: process.env.JWT_EXPIRATION || '2h',
+  // REDIS_URL ne figure pas parmi les variables obligatoires, contrairement aux deux
+  // précédentes : le cache est une optimisation, pas une dépendance. Sans Redis
+  // joignable, l'application démarre et sert les cours en appelant directement les
+  // fournisseurs. Une valeur par défaut suffit donc en développement.
+  redisUrl: process.env.REDIS_URL || 'redis://localhost:6379',
 });
 
 module.exports = config;

--- a/backend/src/erreurs.js
+++ b/backend/src/erreurs.js
@@ -25,6 +25,14 @@ class ErreurIntrouvable extends ErreurMetier {
   }
 }
 
+// Un fournisseur de cours externe est indisponible ou a renvoyé une réponse
+// inexploitable. 503 : le défaut est passager et ne vient pas de la requête du client.
+class ErreurFournisseur extends ErreurMetier {
+  constructor(message) {
+    super(message, 503);
+  }
+}
+
 // Ressource déjà existante, typiquement un email déjà inscrit.
 class ErreurConflit extends ErreurMetier {
   constructor(message) {
@@ -51,6 +59,7 @@ module.exports = {
   ErreurValidation,
   ErreurIntrouvable,
   ErreurConflit,
+  ErreurFournisseur,
   ErreurAuthentification,
   ErreurAutorisation,
 };

--- a/backend/src/services/__tests__/cours.test.js
+++ b/backend/src/services/__tests__/cours.test.js
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+
+// Le service tire la configuration par sa chaîne d'imports (cache Redis). Un
+// environnement minimal est posé avant l'import dynamique, comme pour les autres
+// modules dépendant de la configuration.
+let creerServiceCours;
+let DUREES_VIE_SECONDES;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = 'postgresql://utilisateur:secret@localhost:5432/capitall';
+  process.env.JWT_SECRET = 'c'.repeat(32);
+  ({ creerServiceCours, DUREES_VIE_SECONDES } = await import('../cours.js'));
+});
+
+const COURS_BTC = {
+  symbole: 'BTC',
+  cours_eur: '62704.64',
+  horodatage: '2026-07-29T10:00:00.000Z',
+  source: 'coinbase',
+};
+
+// Doublure de cache : ni Redis ni réseau, les tests restent unitaires.
+function creerCacheFactice({ enCache = null, dernierConnu = null } = {}) {
+  return {
+    lireCoursCache: vi.fn().mockResolvedValue(enCache),
+    ecrireCoursCache: vi.fn().mockResolvedValue(undefined),
+    lireDernierCoursConnu: vi.fn().mockResolvedValue(dernierConnu),
+    ecrireDernierCoursConnu: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function creerAdaptateursFactices(getCours) {
+  return { obtenirAdaptateur: vi.fn().mockReturnValue({ getCours }) };
+}
+
+let getCoursAdaptateur;
+
+beforeEach(() => {
+  getCoursAdaptateur = vi.fn().mockResolvedValue(COURS_BTC);
+});
+
+describe('service de cours', () => {
+  it("sert depuis le cache sans appeler le fournisseur", async () => {
+    const cache = creerCacheFactice({ enCache: COURS_BTC });
+    const service = creerServiceCours({
+      adaptateurs: creerAdaptateursFactices(getCoursAdaptateur),
+      cache,
+    });
+
+    const cours = await service.getCours('BTC', 'crypto');
+
+    expect(cours.source).toBe('cache');
+    expect(cours.cours_eur).toBe('62704.64');
+    // Le point essentiel : aucun appel sortant lorsque le cache répond.
+    expect(getCoursAdaptateur).not.toHaveBeenCalled();
+  });
+
+  it("appelle le fournisseur quand le cache est vide, puis écrit les deux clés", async () => {
+    const cache = creerCacheFactice();
+    const service = creerServiceCours({
+      adaptateurs: creerAdaptateursFactices(getCoursAdaptateur),
+      cache,
+    });
+
+    const cours = await service.getCours('BTC', 'crypto');
+
+    expect(cours.source).toBe('fournisseur');
+    expect(getCoursAdaptateur).toHaveBeenCalledTimes(1);
+    expect(cache.ecrireCoursCache).toHaveBeenCalledTimes(1);
+    expect(cache.ecrireDernierCoursConnu).toHaveBeenCalledTimes(1);
+  });
+
+  // TTL différenciés par classe d'actif (D21).
+  it('transmet le TTL correspondant au type demandé', async () => {
+    const cas = [
+      ['crypto', DUREES_VIE_SECONDES.crypto],
+      ['devise', DUREES_VIE_SECONDES.devise],
+      ['metal', DUREES_VIE_SECONDES.metal],
+    ];
+
+    for (const [type, ttlAttendu] of cas) {
+      const cache = creerCacheFactice();
+      const service = creerServiceCours({
+        adaptateurs: creerAdaptateursFactices(getCoursAdaptateur),
+        cache,
+      });
+
+      await service.getCours('SYM', type);
+
+      expect(cache.ecrireCoursCache).toHaveBeenCalledWith('SYM', expect.anything(), ttlAttendu);
+    }
+  });
+
+  it('respecte les valeurs de TTL actées en D21', () => {
+    expect(DUREES_VIE_SECONDES.crypto).toBe(120);
+    expect(DUREES_VIE_SECONDES.devise).toBe(3600);
+    expect(DUREES_VIE_SECONDES.metal).toBe(600);
+    expect(DUREES_VIE_SECONDES.action).toBe(300);
+  });
+
+  it("renvoie le dernier cours connu quand le fournisseur échoue", async () => {
+    const cache = creerCacheFactice({ dernierConnu: COURS_BTC });
+    const enEchec = vi.fn().mockRejectedValue(new Error('fournisseur injoignable'));
+    const service = creerServiceCours({
+      adaptateurs: creerAdaptateursFactices(enEchec),
+      cache,
+    });
+
+    const cours = await service.getCours('BTC', 'crypto');
+
+    expect(cours.source).toBe('repli');
+    // L'horodatage d'origine est conservé : le front doit pouvoir afficher la date
+    // réelle du cours, pas celle de la tentative ratée.
+    expect(cours.horodatage).toBe(COURS_BTC.horodatage);
+  });
+
+  it("lève une erreur quand le fournisseur échoue et que le repli est vide", async () => {
+    const cache = creerCacheFactice();
+    const enEchec = vi.fn().mockRejectedValue(new Error('fournisseur injoignable'));
+    const service = creerServiceCours({
+      adaptateurs: creerAdaptateursFactices(enEchec),
+      cache,
+    });
+
+    await expect(service.getCours('BTC', 'crypto')).rejects.toThrow(/aucun cours connu/);
+  });
+
+  it("signale explicitement qu'aucun fournisseur n'est branché pour les actions", async () => {
+    const cache = creerCacheFactice();
+    const adaptateurs = {
+      obtenirAdaptateur: vi.fn().mockImplementation(() => {
+        throw new Error('Fournisseur non branché pour le type d\'actif « action ».');
+      }),
+    };
+    const service = creerServiceCours({ adaptateurs, cache });
+
+    await expect(service.getCours('AAPL', 'action')).rejects.toThrow(/non branché/);
+  });
+});
+
+describe('cours multiples', () => {
+  it('déduplique les symboles avant d\'appeler le fournisseur', async () => {
+    const cache = creerCacheFactice();
+    const service = creerServiceCours({
+      adaptateurs: creerAdaptateursFactices(getCoursAdaptateur),
+      cache,
+    });
+
+    const resultats = await service.getCoursMultiples([
+      { symbole: 'BTC', type: 'crypto' },
+      { symbole: 'btc', type: 'crypto' },
+      { symbole: 'ETH', type: 'crypto' },
+    ]);
+
+    expect(resultats).toHaveLength(2);
+    expect(getCoursAdaptateur).toHaveBeenCalledTimes(2);
+  });
+
+  // Un symbole en échec ne doit pas priver le tableau de bord de tous les autres.
+  it("isole l'échec d'un symbole sans faire échouer les autres", async () => {
+    const cache = creerCacheFactice();
+    const capricieux = vi
+      .fn()
+      .mockResolvedValueOnce(COURS_BTC)
+      .mockRejectedValueOnce(new Error('injoignable'));
+    const service = creerServiceCours({
+      adaptateurs: creerAdaptateursFactices(capricieux),
+      cache,
+    });
+
+    const resultats = await service.getCoursMultiples([
+      { symbole: 'BTC', type: 'crypto' },
+      { symbole: 'ETH', type: 'crypto' },
+    ]);
+
+    expect(resultats).toHaveLength(2);
+    expect(resultats.filter((r) => r.erreur)).toHaveLength(1);
+  });
+});

--- a/backend/src/services/cacheCours.js
+++ b/backend/src/services/cacheCours.js
@@ -1,89 +1,65 @@
-// Cache Redis pour les cours récupérés auprès des fournisseurs externes (D14).
-// Le service de cours interroge ce cache avant d'appeler un adaptateur ; il y écrit
-// systématiquement le résultat d'un appel réussi, avec une durée de vie courte.
-// Dépendance : paquet npm "redis" (client officiel, v4+). URL de connexion fournie
-// par la variable d'environnement REDIS_URL (ex. redis://redis:6379 en docker-compose).
+// Cache Redis des cours récupérés auprès des fournisseurs externes (D14).
+// Ce module ne gère que les clés et leur durée de vie ; la connexion et sa résilience
+// sont l'affaire de src/cache/client.js.
+//
+// Deux familles de clés, aux rôles distincts :
+//   cours:{SYMBOLE}                avec TTL, le cours frais servi en priorité
+//   cours:dernier-connu:{SYMBOLE}  sans TTL, filet de sécurité quand un fournisseur
+//                                  est indisponible (cas-utilisation.md : « le dernier
+//                                  cours connu est affiché avec sa date »)
+//
+// Aucune fonction ne lève d'exception : une panne de cache dégrade vers un appel
+// direct au fournisseur, elle ne fait jamais échouer la requête de l'utilisateur.
 
-const { createClient } = require('redis');
+const cache = require('../cache/client');
 
-const DUREE_VIE_SECONDES = 120;
 const PREFIXE_CLE = 'cours';
-
-let client;
-
-function obtenirClient() {
-  if (!client) {
-    client = createClient({ url: process.env.REDIS_URL });
-    client.on('error', (erreur) => {
-      console.error('Erreur de connexion Redis', erreur);
-    });
-  }
-  return client;
-}
-
-async function connecter() {
-  const c = obtenirClient();
-  if (!c.isOpen) {
-    await c.connect();
-  }
-  return c;
-}
 
 function construireCle(symbole) {
   return `${PREFIXE_CLE}:${symbole.toUpperCase()}`;
 }
 
-// Renvoie { symbole, cours_eur, horodatage } si le cours est en cache, sinon null.
-// Ne lève jamais d'exception : une indisponibilité de Redis doit dégrader vers un
-// appel direct au fournisseur, pas faire échouer la requête de l'utilisateur.
+function construireCleDernierConnu(symbole) {
+  return `${PREFIXE_CLE}:dernier-connu:${symbole.toUpperCase()}`;
+}
+
+function analyser(valeur) {
+  if (!valeur) {
+    return null;
+  }
+  try {
+    return JSON.parse(valeur);
+  } catch {
+    // Une valeur illisible est traitée comme une absence de cache plutôt que comme
+    // une erreur : le cours sera simplement redemandé au fournisseur.
+    return null;
+  }
+}
+
 async function lireCoursCache(symbole) {
-  try {
-    const c = await connecter();
-    const valeur = await c.get(construireCle(symbole));
-    return valeur ? JSON.parse(valeur) : null;
-  } catch (erreur) {
-    console.error(`Lecture cache impossible pour ${symbole}`, erreur);
-    return null;
-  }
+  const valeur = await cache.executer((client) => client.get(construireCle(symbole)));
+  return analyser(valeur);
 }
 
-// Écrit le cours en cache avec la durée de vie par défaut. Échec silencieux pour
-// la même raison que lireCoursCache : le cache est une optimisation, pas une
-// dépendance dure du calcul de portefeuille.
-async function ecrireCoursCache(symbole, cours) {
-  try {
-    const c = await connecter();
-    await c.set(construireCle(symbole), JSON.stringify(cours), {
-      EX: DUREE_VIE_SECONDES,
-    });
-  } catch (erreur) {
-    console.error(`Écriture cache impossible pour ${symbole}`, erreur);
-  }
+// La durée de vie est désormais reçue en paramètre : elle dépend de la classe d'actif
+// (D21), le service de cours étant seul à connaître le type du symbole demandé.
+async function ecrireCoursCache(symbole, cours, dureeVieSecondes) {
+  await cache.executer((client) =>
+    client.set(construireCle(symbole), JSON.stringify(cours), { EX: dureeVieSecondes })
+  );
 }
 
-// Dernier cours connu, même expiré, utilisé en repli quand un fournisseur est
-// indisponible (cas-utilisation.md : "le dernier cours connu est affiché avec sa date").
-// Repose sur une seconde clé à durée de vie longue, mise à jour à chaque écriture réussie.
 async function lireDernierCoursConnu(symbole) {
-  try {
-    const c = await connecter();
-    const valeur = await c.get(`${PREFIXE_CLE}:dernier-connu:${symbole.toUpperCase()}`);
-    return valeur ? JSON.parse(valeur) : null;
-  } catch (erreur) {
-    console.error(`Lecture du dernier cours connu impossible pour ${symbole}`, erreur);
-    return null;
-  }
+  const valeur = await cache.executer((client) => client.get(construireCleDernierConnu(symbole)));
+  return analyser(valeur);
 }
 
+// Pas de TTL sur cette clé : elle sert de filet de sécurité de longue durée, remplacée
+// à chaque appel réussi d'un fournisseur.
 async function ecrireDernierCoursConnu(symbole, cours) {
-  try {
-    const c = await connecter();
-    // Pas de TTL ici : cette clé sert de filet de sécurité de longue durée,
-    // remplacée à chaque nouvel appel fournisseur réussi.
-    await c.set(`${PREFIXE_CLE}:dernier-connu:${symbole.toUpperCase()}`, JSON.stringify(cours));
-  } catch (erreur) {
-    console.error(`Écriture du dernier cours connu impossible pour ${symbole}`, erreur);
-  }
+  await cache.executer((client) =>
+    client.set(construireCleDernierConnu(symbole), JSON.stringify(cours))
+  );
 }
 
 module.exports = {

--- a/backend/src/services/cours.js
+++ b/backend/src/services/cours.js
@@ -1,0 +1,112 @@
+// Point d'entrée unique des cours. Tout le reste du back-end passe par ici : jamais
+// par un adaptateur directement, et jamais par le cache directement.
+//
+// Les cours ne sont appelés que côté serveur (D6). Aucune URL de fournisseur ne
+// remonte jusqu'au front, qui ne voit que la forme commune renvoyée ci-dessous.
+
+const cacheCours = require('./cacheCours');
+const { creerAdaptateurs } = require('../adaptateurs');
+const { ErreurFournisseur } = require('../erreurs');
+
+// Durées de vie du cache par classe d'actif (D21). Elles suivent le rythme réel de
+// publication de chaque source : les taux BCE ne bougent qu'une fois par jour ouvré,
+// une cryptomonnaie cote en continu. Regroupées ici, jamais recopiées ailleurs.
+const DUREES_VIE_SECONDES = {
+  crypto: 120,
+  devise: 3600,
+  metal: 600,
+  // Préparé pour les actions, dont le fournisseur sera branché ultérieurement.
+  action: 300,
+};
+
+const DUREE_VIE_PAR_DEFAUT = 300;
+
+function creerServiceCours({ adaptateurs, cache = cacheCours } = {}) {
+  // Référence au service lui-même, renseignée en fin de fonction. Elle permet à
+  // l'adaptateur des métaux d'obtenir le taux de change en repassant par ce service,
+  // donc par le cache, plutôt qu'en rappelant Frankfurter à chaque cours de métal.
+  let service;
+
+  const jeuAdaptateurs =
+    adaptateurs ??
+    creerAdaptateurs({
+      obtenirTauxUsdEur: async () => {
+        const cours = await service.getCours('USD', 'devise');
+        return cours.cours_eur;
+      },
+    });
+
+  async function getCours(symbole, type) {
+    const symboleNormalise = symbole.toUpperCase();
+
+    // 1. Le cache d'abord : un cours frais évite un appel sortant.
+    const enCache = await cache.lireCoursCache(symboleNormalise);
+    if (enCache) {
+      return { ...enCache, source: 'cache' };
+    }
+
+    // 2. Sinon, le fournisseur correspondant au type d'actif.
+    const adaptateur = jeuAdaptateurs.obtenirAdaptateur(type);
+
+    try {
+      const cours = await adaptateur.getCours(symboleNormalise);
+
+      // 3. Deux écritures : le cours frais avec son TTL, et le filet de sécurité sans
+      // expiration qui servira si le fournisseur tombe.
+      await cache.ecrireCoursCache(
+        symboleNormalise,
+        cours,
+        DUREES_VIE_SECONDES[type] ?? DUREE_VIE_PAR_DEFAUT
+      );
+      await cache.ecrireDernierCoursConnu(symboleNormalise, cours);
+
+      return { ...cours, source: 'fournisseur' };
+    } catch (erreur) {
+      // 4. Fournisseur indisponible : plutôt qu'une erreur, le dernier cours connu,
+      // signalé comme tel avec son horodatage d'origine. Le front peut alors afficher
+      // « dernier cours connu le ... », comportement prévu par cas-utilisation.md.
+      const dernierConnu = await cache.lireDernierCoursConnu(symboleNormalise);
+
+      if (dernierConnu) {
+        console.error(
+          `Cours ${symboleNormalise} indisponible, repli sur le dernier cours connu :`,
+          erreur.message
+        );
+        return { ...dernierConnu, source: 'repli' };
+      }
+
+      // 5. Ni fournisseur ni repli : il n'y a rien à afficher, l'appelant doit le savoir.
+      throw new ErreurFournisseur(
+        `Cours indisponible pour ${symboleNormalise} et aucun cours connu en cache.`
+      );
+    }
+  }
+
+  // Le tableau de bord demandera plusieurs cours d'un coup. La déduplication évite
+  // d'appeler deux fois le même symbole, cas fréquent lorsque plusieurs actifs
+  // partagent une même devise de conversion.
+  async function getCoursMultiples(demandes) {
+    const uniques = new Map();
+    for (const { symbole, type } of demandes) {
+      uniques.set(`${type}:${symbole.toUpperCase()}`, { symbole: symbole.toUpperCase(), type });
+    }
+
+    const resultats = await Promise.all(
+      [...uniques.values()].map(async ({ symbole, type }) => {
+        try {
+          return await getCours(symbole, type);
+        } catch (erreur) {
+          // Un symbole en échec ne doit pas priver le tableau de bord des autres.
+          return { symbole, type, erreur: erreur.message };
+        }
+      })
+    );
+
+    return resultats;
+  }
+
+  service = { getCours, getCoursMultiples };
+  return service;
+}
+
+module.exports = { creerServiceCours, DUREES_VIE_SECONDES };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+# Environnement de développement : base de données et cache uniquement.
+# Le front et l'API tournent sur le poste (npm run dev) et se connectent à ces deux
+# services. La mise en conteneurs des images applicatives relève du déploiement et
+# sera traitée avec les Dockerfile.
+
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: capitall-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - '${POSTGRES_PORT:-5432}:5432'
+    volumes:
+      - donnees-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: capitall-redis
+    restart: unless-stopped
+    ports:
+      - '${REDIS_PORT:-6379}:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    # Volontairement sans volume : le cache est jetable. Le perdre n'a aucune
+    # conséquence fonctionnelle, les cours sont simplement récupérés à nouveau
+    # auprès des fournisseurs au prochain appel.
+
+volumes:
+  donnees-postgres:

--- a/docs/cahier-des-charges.md
+++ b/docs/cahier-des-charges.md
@@ -90,7 +90,7 @@ Contexte de réalisation : projet individuel réalisé pendant la formation au T
 | GET | `/api/admin/comptes` | oui, admin | liste des comptes (sans données patrimoniales) | 200, 401, 403 |
 | PATCH | `/api/admin/comptes/:id` | oui, admin | désactivation d'un compte | 200, 401, 403, 404 |
 
-Chaque endpoint documentera son DTO d'entrée et de sortie au fil du développement (collection Insomnia comme preuve d'examen, voir plan du dossier de projet).
+Chaque endpoint documentera son DTO d'entrée et de sortie au fil du développement (collection Thunder Client comme preuve d'examen, voir plan du dossier de projet).
 
 **Contraintes de sécurité.**
 

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -17,11 +17,11 @@ Initialisation et fondations back-end (semaine courte, 3 jours).
 - exécution du script `backend/db/schema.sql`, création de l'utilisateur applicatif, script de seed (compte admin, annonces et jeu de données d'exemple)
 - connexion PostgreSQL, authentification (inscription, connexion, bcrypt, JWT, middleware), middleware de rôle
 - CRUD actifs et transactions avec vérification de propriété
-- collection Insomnia au fil de l'eau
+- collection Thunder Client au fil de l'eau
 - maquettes Figma des 5 écrans : à terminer sur cette période, en parallèle, sans attendre
 
 CP visées : CP1, CP2, CP5, CP6 (partiel).
-Captures : structure du dépôt et premiers commits, schéma dans pgAdmin, appels Insomnia d'inscription et de connexion.
+Captures : structure du dépôt et premiers commits, schéma dans pgAdmin, appels Thunder Client d'inscription et de connexion.
 
 ## Semaine 2 - du lundi 27 juillet au dimanche 2 août
 
@@ -34,7 +34,7 @@ Logique métier et intégration des fournisseurs de cours.
 - démarrage du front : Vite, routing, page de connexion et d'inscription, liste des actifs connectée à l'API
 
 CP visées : CP6, CP7.
-Captures : clé Redis en CLI (`GET` et `TTL`), tests unitaires au vert, appel Insomnia du portefeuille.
+Captures : clé Redis en CLI (`GET` et `TTL`), tests unitaires au vert, appel Thunder Client du portefeuille.
 
 ## Semaine 3 - du lundi 3 au dimanche 9 août
 


### PR DESCRIPTION
Closes #3, closes #78, closes #57, closes #13, closes #14, closes #15, closes #16, closes #17, closes #80

Lot C : docker-compose de développement (PostgreSQL et Redis), client Redis résilient, adaptateurs
Coinbase, Frankfurter et gold-api derrière une interface commune, service de cours avec TTL
différenciés par classe d'actif (D21) et repli sur le dernier cours connu. Redis reste une optimisation : l'application fonctionne sans lui. Aucun calcul de portefeuille dans ce lot.

## Interface commune

Chaque adaptateur est une factory recevant ses dépendances en paramètre, et rend toujours la même forme : `{ symbole, cours_eur, horodatage, source }`, où `cours_eur` est une chaîne. La logique métier ignore quel fournisseur a répondu (D5), et les cours ne sont appelés que côté serveur (D6) : aucune URL de fournisseur ne remonte au front.

Le type `action` n'a pas encore d'adaptateur : il lève une erreur explicite « fournisseur non branché » plutôt que de rendre un `null` silencieux.

## Deux pièges traités explicitement

- **Frankfurter cote depuis l'euro.** `rates.USD` vaut le nombre de dollars que vaut un euro. Un utilisateur qui détient des dollars veut l'inverse : le calcul `1 / rates.USD` est écrit et commenté, et couvert par un test chiffré (1 EUR = 1,25 USD donne 1 USD = 0,80 EUR). Sans cette inversion, le portefeuille serait faux d'un facteur proche de 1,3 sans que rien ne le signale.
- **gold-api cote en dollars par once.** La conversion en euros est obligatoire et passe par le taux Frankfurter, injecté dans la factory. Le service de cours fournit ce taux en repassant par lui-même, donc par le cache : le taux n'est pas redemandé au fournisseur à chaque cours de métal.

## Stratégie de cache

Cache d'abord, fournisseur ensuite, deux écritures en cas de succès : `cours:{SYMBOLE}` avec le TTL de la classe d'actif, et `cours:dernier-connu:{SYMBOLE}` sans expiration. Si le fournisseur échoue, le dernier cours connu est renvoyé avec `source: 'repli'` et son horodatage d'origine, pour que le front puisse afficher « dernier cours connu le … ». Si même le repli est vide, l'erreur remonte.

TTL conformes à D21, regroupés dans une seule constante : crypto 120 s, devise 3600 s, métal 600 s, action 300 s (préparé, inutilisé ici).

## Vérification

95 tests unitaires au vert, sans réseau ni Redis (dépendances injectées).

Vérifié en conditions réelles avec les deux services du compose :
- premier passage cache vide : les trois cours arrivent avec `source: fournisseur` ;
- second passage immédiat : les trois arrivent avec `source: cache` ;
- `GET cours:BTC` et `TTL` en ligne de commande montrent les durées différenciées (94 s pour la crypto, 3574 s pour la devise, 573 s pour le métal) et la clé de repli sans expiration (`-1`) ;
- Redis arrêté : les trois cours sont toujours servis, le cache est signalé indisponible, l'application ne plante pas ;
- Redis redémarré : reprise automatique, sans intervention.

Ordres de grandeur contrôlés : l'once d'or à environ 4067 USD convertie au taux 0,879 donne bien environ 3574 EUR.

## Liste de contrôle

- [x] Cours appeles exclusivement cote serveur
- [x] Interface commune stricte, valeurs en chaine
- [x] Redis reste une optimisation, jamais une dependance dure
- [x] Aucun secret ni cle d'API dans le diff
- [x] Tests unitaires au vert
- [x] Messages de commit conformes a docs/convention-commits.md
