### PR TITLE
feat(back): moteur de calcul et portefeuille consolidé

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,6 +10,9 @@ NODE_ENV=development
 
 # Chaîne de connexion PostgreSQL. Obligatoire, le serveur refuse de démarrer sans elle.
 # Format : postgresql://utilisateur:mot_de_passe@hote:port/base
+# Si la base tourne dans le conteneur du docker-compose, le port indiqué ici doit
+# correspondre à POSTGRES_PORT du .env de la racine, qui n'est pas nécessairement 5432
+# lorsqu'une installation locale de PostgreSQL occupe déjà ce port.
 DATABASE_URL=postgresql://utilisateur:mot_de_passe@localhost:5432/capitall
 
 # Secret de signature des jetons JWT. Obligatoire, 32 caractères au minimum.

--- a/backend/src/adaptateurs/metal.js
+++ b/backend/src/adaptateurs/metal.js
@@ -34,6 +34,12 @@ function creerAdaptateurMetal({ recupererJson, obtenirTauxUsdEur }) {
       );
     }
 
+    // Cette multiplication est faite en virgule flottante, alors que le portefeuille
+    // proscrit le flottant sur les montants (D4). La distinction est volontaire : il
+    // s'agit ici de convertir un cours, donnée déjà approximative reçue en flottant du
+    // fournisseur et rafraîchie en permanence, et non d'un montant du patrimoine.
+    // Le résultat est immédiatement arrondi au centime, puis manipulé en chaîne par le
+    // moteur de calcul. Aucune imprécision ne se propage donc aux PRU ni aux plus-values.
     return {
       symbole: symboleNormalise,
       cours_eur: (prixUsd * tauxUsdEur).toFixed(DECIMALES_PRIX),

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 
 const routeurAuthentification = require('./routes/authentification');
 const routeurActif = require('./routes/actif');
+const routeurPortefeuille = require('./routes/portefeuille');
 const gestionErreurs = require('./middlewares/gestionErreurs');
 
 const app = express();
@@ -16,6 +17,7 @@ app.get('/api/sante', (req, res) => {
 
 app.use('/api/auth', routeurAuthentification);
 app.use('/api/actifs', routeurActif);
+app.use('/api/portefeuille', routeurPortefeuille);
 
 // Toujours en dernier : Express n'y passe que si une route a appelé next(erreur).
 app.use(gestionErreurs);

--- a/backend/src/controllers/actif.js
+++ b/backend/src/controllers/actif.js
@@ -9,9 +9,11 @@
 // « cet actif ne vous appartient pas ».
 
 const modeleActif = require('../models/actif');
-const modeleTransaction = require('../models/transaction');
 const serviceTransaction = require('../services/transaction');
+const { creerServicePortefeuille } = require('../services/portefeuilleConsolide');
 const { ErreurIntrouvable } = require('../erreurs');
+
+const servicePortefeuille = creerServicePortefeuille();
 
 async function lister(req, res, next) {
   try {
@@ -36,21 +38,15 @@ async function creer(req, res, next) {
   }
 }
 
-// Détail d'un actif et historique de ses transactions. Le PRU et les plus-values
-// relèvent d'un lot dédié et ne sont volontairement pas calculés ici.
+// Détail d'un actif : position calculée (quantité détenue, PRU, plus-values), cours
+// courant avec sa source, et historique des transactions.
 async function detail(req, res, next) {
   try {
-    const actif = await modeleActif.trouverParIdEtUtilisateur(req.params.id, req.utilisateur.id);
-    if (!actif) {
-      throw new ErreurIntrouvable('Actif introuvable.');
-    }
-
-    const transactions = await modeleTransaction.listerParActifEtUtilisateur(
+    const detailActif = await servicePortefeuille.obtenirDetailActif(
       req.params.id,
       req.utilisateur.id
     );
-
-    res.status(200).json({ ...actif, transactions });
+    res.status(200).json(detailActif);
   } catch (erreur) {
     next(erreur);
   }

--- a/backend/src/controllers/portefeuille.js
+++ b/backend/src/controllers/portefeuille.js
@@ -1,0 +1,39 @@
+// Contrôleurs du portefeuille consolidé et de son historique. Le propriétaire vient
+// toujours du jeton : aucune de ces routes n'accepte d'identifiant d'utilisateur.
+
+const { creerServicePortefeuille } = require('../services/portefeuilleConsolide');
+
+const servicePortefeuille = creerServicePortefeuille();
+
+// Nombre de jours d'historique demandé, borné pour éviter une requête déraisonnable.
+const JOURS_MAXIMUM = 3650;
+
+async function consolide(req, res, next) {
+  try {
+    const portefeuille = await servicePortefeuille.obtenirPortefeuille(req.utilisateur.id);
+    res.status(200).json(portefeuille);
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+async function historique(req, res, next) {
+  try {
+    const parametre = req.query.jours;
+    let jours;
+
+    if (parametre !== undefined) {
+      if (!/^\d+$/.test(parametre) || Number(parametre) < 1 || Number(parametre) > JOURS_MAXIMUM) {
+        return res.status(400).json({ erreur: 'Le paramètre jours est invalide.' });
+      }
+      jours = Number(parametre);
+    }
+
+    const snapshots = await servicePortefeuille.obtenirHistorique(req.utilisateur.id, jours);
+    return res.status(200).json(snapshots);
+  } catch (erreur) {
+    return next(erreur);
+  }
+}
+
+module.exports = { consolide, historique };

--- a/backend/src/models/snapshot.js
+++ b/backend/src/models/snapshot.js
@@ -1,0 +1,60 @@
+// Accès à la table snapshot_valorisation : l'historique de la valeur du portefeuille.
+//
+// Un snapshot déroge volontairement à la règle « aucune valeur dérivée n'est stockée »
+// (D8, D16). La distinction tient à la reconstituabilité : le PRU se recalcule à tout
+// moment depuis les transactions, alors que la valeur du portefeuille au 12 mars ne se
+// retrouve plus une fois la journée passée, faute de conserver les cours historiques.
+// Un snapshot est donc un fait daté, pas une donnée redondante.
+
+const { query } = require('../db');
+
+// Écriture du snapshot du jour, en une seule requête.
+//
+// ON CONFLICT DO NOTHING s'appuie sur la contrainte d'unicité (utilisateur_id,
+// date_snapshot) du schéma. Un SELECT suivi d'un INSERT laisserait une fenêtre entre
+// les deux : deux onglets ouverts simultanément passeraient tous deux le contrôle
+// d'existence et la seconde insertion échouerait. Ici, c'est la base qui arbitre.
+async function enregistrerSiAbsent(utilisateurId, valeurTotaleEur) {
+  const { rows } = await query(
+    `INSERT INTO snapshot_valorisation (utilisateur_id, date_snapshot, valeur_totale_eur)
+     VALUES ($1, CURRENT_DATE, $2)
+     ON CONFLICT (utilisateur_id, date_snapshot) DO NOTHING
+     RETURNING id, to_char(date_snapshot, 'YYYY-MM-DD') AS date_snapshot, valeur_totale_eur`,
+    [utilisateurId, valeurTotaleEur]
+  );
+
+  // Aucune ligne rendue signifie qu'un snapshot existait déjà pour aujourd'hui :
+  // ce n'est pas une erreur, c'est le cas courant à partir du second chargement.
+  return rows[0] || null;
+}
+
+// Historique trié du plus ancien au plus récent, pour être tracé tel quel.
+//
+// La date est formatée en chaîne par PostgreSQL plutôt que rendue comme colonne DATE :
+// le pilote la convertirait sinon en objet Date interprété dans le fuseau du serveur,
+// et la sérialisation JSON afficherait la veille pour tout fuseau à l'est de Greenwich.
+// Une date de snapshot est un jour calendaire, pas un instant.
+async function listerParUtilisateur(utilisateurId, nombreDeJours) {
+  if (nombreDeJours) {
+    const { rows } = await query(
+      `SELECT to_char(date_snapshot, 'YYYY-MM-DD') AS date_snapshot, valeur_totale_eur
+       FROM snapshot_valorisation
+       WHERE utilisateur_id = $1
+         AND date_snapshot >= CURRENT_DATE - $2::integer
+       ORDER BY date_snapshot`,
+      [utilisateurId, nombreDeJours]
+    );
+    return rows;
+  }
+
+  const { rows } = await query(
+    `SELECT to_char(date_snapshot, 'YYYY-MM-DD') AS date_snapshot, valeur_totale_eur
+     FROM snapshot_valorisation
+     WHERE utilisateur_id = $1
+     ORDER BY date_snapshot`,
+    [utilisateurId]
+  );
+  return rows;
+}
+
+module.exports = { enregistrerSiAbsent, listerParUtilisateur };

--- a/backend/src/routes/portefeuille.js
+++ b/backend/src/routes/portefeuille.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const controleur = require('../controllers/portefeuille');
+const authentifier = require('../middlewares/authentifier');
+
+const routeur = express.Router();
+
+routeur.use(authentifier);
+
+routeur.get('/', controleur.consolide);
+routeur.get('/historique', controleur.historique);
+
+module.exports = routeur;

--- a/backend/src/services/__tests__/calculPortefeuille.test.js
+++ b/backend/src/services/__tests__/calculPortefeuille.test.js
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest';
+import { calculerPosition, valoriser, consolider } from '../calculPortefeuille.js';
+
+function achat(quantite, prix, frais = '0', date = '2026-01-01', id = 1) {
+  return { id, sens: 'achat', quantite, prix_unitaire: prix, frais, date_transaction: date };
+}
+
+function vente(quantite, prix, frais = '0', date = '2026-01-01', id = 1) {
+  return { id, sens: 'vente', quantite, prix_unitaire: prix, frais, date_transaction: date };
+}
+
+describe('calcul de position', () => {
+  it('rend une position vide sans transaction', () => {
+    const position = calculerPosition([]);
+    expect(position.quantite_detenue).toBe('0');
+    expect(position.pru).toBe('0');
+    expect(position.plus_value_realisee).toBe('0.00');
+  });
+
+  // Règle 1 : les frais entrent dans le coût de revient. 10 titres à 100 euros plus
+  // 5 euros de frais coûtent 1005 euros, soit un PRU de 100,50 et non de 100.
+  it("intègre les frais d'achat au prix de revient", () => {
+    const position = calculerPosition([achat('10', '100.00', '5.00')]);
+    expect(position.pru).toBe('100.5');
+    expect(position.cout_total).toBe('1005.00');
+  });
+
+  it('rend un PRU égal au prix quand les frais sont nuls', () => {
+    const position = calculerPosition([achat('10', '100.00')]);
+    expect(position.pru).toBe('100');
+  });
+
+  // Règle 2, cas vérifiable de tête : (1005 + 1205) / 20 = 110,50.
+  it('recalcule le PRU en moyenne pondérée à chaque achat', () => {
+    const position = calculerPosition([
+      achat('10', '100.00', '5.00', '2026-01-10', 1),
+      achat('10', '120.00', '5.00', '2026-02-10', 2),
+    ]);
+    expect(position.quantite_detenue).toBe('20');
+    expect(position.pru).toBe('110.5');
+    expect(position.cout_total).toBe('2210.00');
+  });
+
+  // Règles 3 et 4 : la vente laisse le PRU intact et dégage
+  // 5 × (150 − 110,50) − 5 = 192,50.
+  it('ne modifie pas le PRU lors d\'une vente et cumule la plus-value réalisée', () => {
+    const position = calculerPosition([
+      achat('10', '100.00', '5.00', '2026-01-10', 1),
+      achat('10', '120.00', '5.00', '2026-02-10', 2),
+      vente('5', '150.00', '5.00', '2026-03-10', 3),
+    ]);
+    expect(position.quantite_detenue).toBe('15');
+    expect(position.pru).toBe('110.5');
+    expect(position.plus_value_realisee).toBe('192.50');
+  });
+
+  it('calcule une plus-value réalisée négative sur une vente à perte', () => {
+    const position = calculerPosition([
+      achat('10', '100.00', '0', '2026-01-10', 1),
+      vente('5', '80.00', '0', '2026-02-10', 2),
+    ]);
+    expect(position.plus_value_realisee).toBe('-100.00');
+  });
+
+  // Règle 5 : après une vente totale, un rachat repart d'un PRU neuf.
+  it('remet le PRU à zéro après une vente totale, le rachat repartant de zéro', () => {
+    const position = calculerPosition([
+      achat('10', '100.00', '0', '2026-01-10', 1),
+      vente('10', '150.00', '0', '2026-02-10', 2),
+      achat('4', '200.00', '0', '2026-03-10', 3),
+    ]);
+    expect(position.quantite_detenue).toBe('4');
+    expect(position.pru).toBe('200');
+    expect(position.plus_value_realisee).toBe('500.00');
+  });
+
+  // Règle 6, garde-fou principal : saisir une transaction ancienne après coup doit
+  // donner le même résultat que l'avoir saisie dans l'ordre.
+  it('donne le même résultat quel que soit l\'ordre de saisie', () => {
+    const chronologique = [
+      achat('10', '100.00', '5.00', '2026-01-10', 1),
+      achat('10', '120.00', '5.00', '2026-02-10', 2),
+      vente('5', '150.00', '5.00', '2026-03-10', 3),
+    ];
+    const desordre = [chronologique[2], chronologique[0], chronologique[1]];
+
+    expect(calculerPosition(desordre)).toEqual(calculerPosition(chronologique));
+  });
+
+  it('départage deux transactions de même date par leur identifiant', () => {
+    const ordre = [
+      achat('10', '100.00', '0', '2026-01-10', 1),
+      vente('10', '150.00', '0', '2026-01-10', 2),
+    ];
+    const inverse = [ordre[1], ordre[0]];
+
+    expect(calculerPosition(inverse)).toEqual(calculerPosition(ordre));
+    expect(calculerPosition(inverse).plus_value_realisee).toBe('500.00');
+  });
+
+  // L'arithmétique entière doit rester exacte là où le flottant dérive.
+  it('reste exact sur des quantités à 8 décimales', () => {
+    const position = calculerPosition([
+      achat('0.1', '100.00', '0', '2026-01-10', 1),
+      achat('0.2', '100.00', '0', '2026-02-10', 2),
+    ]);
+    expect(position.quantite_detenue).toBe('0.3');
+    expect(position.pru).toBe('100');
+  });
+
+  it('gère une quantité minimale de 0,00000001', () => {
+    const position = calculerPosition([achat('0.00000001', '50000.00', '0')]);
+    expect(position.quantite_detenue).toBe('0.00000001');
+    expect(position.pru).toBe('50000');
+  });
+});
+
+describe('valorisation', () => {
+  const position = calculerPosition([
+    achat('10', '100.00', '5.00', '2026-01-10', 1),
+    achat('10', '120.00', '5.00', '2026-02-10', 2),
+    vente('5', '150.00', '5.00', '2026-03-10', 3),
+  ]);
+
+  it('calcule une plus-value latente positive', () => {
+    const valorisee = valoriser(position, '130.00');
+    expect(valorisee.valeur).toBe('1950.00');
+    expect(valorisee.plus_value_latente).toBe('292.50');
+  });
+
+  it('calcule une plus-value latente négative', () => {
+    const valorisee = valoriser(position, '100.00');
+    expect(valorisee.valeur).toBe('1500.00');
+    expect(valorisee.plus_value_latente).toBe('-157.50');
+  });
+
+  // Un cours indisponible n'est pas un cours nul : la position est rendue sans
+  // valorisation, à charge pour le front de le signaler.
+  it("laisse la position non valorisée quand le cours est absent", () => {
+    const valorisee = valoriser(position, null);
+    expect(valorisee.valeur).toBeNull();
+    expect(valorisee.plus_value_latente).toBeNull();
+    expect(valorisee.quantite_detenue).toBe('15');
+  });
+
+  it('ne calcule pas de pourcentage sur une position soldée', () => {
+    const soldee = calculerPosition([
+      achat('10', '100.00', '0', '2026-01-10', 1),
+      vente('10', '150.00', '0', '2026-02-10', 2),
+    ]);
+    expect(valoriser(soldee, '150.00').pourcentage_variation).toBeNull();
+  });
+});
+
+describe('consolidation', () => {
+  const positions = [
+    { type: 'crypto', valeur: '6000.00', cout_total: '5000.00', plus_value_latente: '1000.00', plus_value_realisee: '200.00' },
+    { type: 'action', valeur: '3000.00', cout_total: '2500.00', plus_value_latente: '500.00', plus_value_realisee: '0.00' },
+    { type: 'metal', valeur: '1000.00', cout_total: '1200.00', plus_value_latente: '-200.00', plus_value_realisee: '50.00' },
+  ];
+
+  it('additionne les valeurs, les coûts et les plus-values', () => {
+    const totaux = consolider(positions);
+    expect(totaux.valeur_totale).toBe('10000.00');
+    expect(totaux.cout_total).toBe('8700.00');
+    expect(totaux.plus_value_latente).toBe('1300.00');
+    expect(totaux.plus_value_realisee).toBe('250.00');
+  });
+
+  it('répartit par classe d\'actif', () => {
+    const { repartition } = consolider(positions);
+    const parType = Object.fromEntries(repartition.map((r) => [r.type, r.pourcentage]));
+    expect(parType.crypto).toBe('60.00');
+    expect(parType.action).toBe('30.00');
+    expect(parType.metal).toBe('10.00');
+  });
+
+  // Une répartition affichée sur un graphique doit totaliser exactement 100 :
+  // arrondir chaque part isolément produirait 99,99 % ou 100,01 %.
+  it('rend une répartition dont la somme fait exactement 100', () => {
+    const troisTiers = [
+      { type: 'crypto', valeur: '100.00', cout_total: '100.00', plus_value_latente: '0.00', plus_value_realisee: '0.00' },
+      { type: 'action', valeur: '100.00', cout_total: '100.00', plus_value_latente: '0.00', plus_value_realisee: '0.00' },
+      { type: 'metal', valeur: '100.00', cout_total: '100.00', plus_value_latente: '0.00', plus_value_realisee: '0.00' },
+    ];
+    const { repartition } = consolider(troisTiers);
+    const somme = repartition.reduce((total, part) => total + Number(part.pourcentage), 0);
+    expect(somme).toBe(100);
+  });
+
+  it('exclut de la valeur totale les positions sans cours', () => {
+    const avecTrou = [
+      positions[0],
+      { type: 'action', valeur: null, cout_total: '2500.00', plus_value_latente: null, plus_value_realisee: '0.00' },
+    ];
+    const totaux = consolider(avecTrou);
+    expect(totaux.valeur_totale).toBe('6000.00');
+    expect(totaux.repartition).toHaveLength(1);
+  });
+
+  it('rend une consolidation vide sur un portefeuille sans actif', () => {
+    const totaux = consolider([]);
+    expect(totaux.valeur_totale).toBe('0.00');
+    expect(totaux.repartition).toEqual([]);
+  });
+
+  // Les plus-values réalisées restent comptabilisées même sans cours courant :
+  // elles proviennent de ventes passées, pas d'une valorisation.
+  it('comptabilise la plus-value réalisée d\'une position non valorisée', () => {
+    const totaux = consolider([
+      { type: 'crypto', valeur: null, cout_total: '0.00', plus_value_latente: null, plus_value_realisee: '300.00' },
+    ]);
+    expect(totaux.plus_value_realisee).toBe('300.00');
+  });
+});

--- a/backend/src/services/__tests__/portefeuilleConsolide.test.js
+++ b/backend/src/services/__tests__/portefeuilleConsolide.test.js
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+// Le service tire la configuration par sa chaîne d'imports : environnement minimal
+// posé avant l'import dynamique, comme pour les autres modules qui en dépendent.
+let creerServicePortefeuille;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = 'postgresql://utilisateur:secret@localhost:5432/capitall';
+  process.env.JWT_SECRET = 'd'.repeat(32);
+  ({ creerServicePortefeuille } = await import('../portefeuilleConsolide.js'));
+});
+
+// Dépôts factices : le service reçoit ses modèles en paramètre, aucun accès à la base.
+function depotActifs(liste, actifUnique) {
+  return {
+    listerParUtilisateur: vi.fn().mockResolvedValue(liste),
+    trouverParIdEtUtilisateur: vi.fn().mockResolvedValue(actifUnique ?? null),
+  };
+}
+
+function depotTransactions(liste) {
+  return { listerParActifEtUtilisateur: vi.fn().mockResolvedValue(liste) };
+}
+
+const ACTIF_BTC = { id: 1, type: 'crypto', symbole: 'BTC', nom: 'Bitcoin', utilisateur_id: 2 };
+
+const TRANSACTIONS_BTC = [
+  { id: 1, sens: 'achat', quantite: '1', prix_unitaire: '100.00', frais: '0', date_transaction: '2026-01-10' },
+];
+
+function serviceCoursFactice(cours) {
+  return {
+    getCoursMultiples: vi.fn().mockResolvedValue(cours),
+    getCours: vi.fn().mockResolvedValue({
+      symbole: 'USD',
+      cours_eur: '0.88',
+      horodatage: '2026-07-30T00:00:00.000Z',
+      source: 'cache',
+    }),
+  };
+}
+
+function snapshotsFactices() {
+  return {
+    enregistrerSiAbsent: vi.fn().mockResolvedValue({ id: 1 }),
+    listerParUtilisateur: vi.fn().mockResolvedValue([]),
+  };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('portefeuille consolidé', () => {
+  it('valorise les actifs et enregistre le snapshot du jour', async () => {
+    const actifs = depotActifs([ACTIF_BTC]);
+    const transactions = depotTransactions(TRANSACTIONS_BTC);
+
+    const snapshots = snapshotsFactices();
+    const service = creerServicePortefeuille({
+      serviceCours: serviceCoursFactice([
+        { symbole: 'BTC', cours_eur: '150.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
+      ]),
+      snapshots,
+      actifs,
+      transactions,
+    });
+
+    const portefeuille = await service.obtenirPortefeuille(2);
+
+    expect(portefeuille.valeur_totale).toBe('150.00');
+    expect(portefeuille.plus_value_latente).toBe('50.00');
+    expect(portefeuille.actifs[0].symbole).toBe('BTC');
+    expect(snapshots.enregistrerSiAbsent).toHaveBeenCalledWith(2, '150.00');
+  });
+
+  it('expose le taux de change pour la bascule d\'affichage', async () => {
+    const actifs = depotActifs([]);
+    const transactions = depotTransactions([]);
+
+    const service = creerServicePortefeuille({
+      serviceCours: serviceCoursFactice([]),
+      snapshots: snapshotsFactices(),
+      actifs,
+      transactions,
+    });
+
+    const portefeuille = await service.obtenirPortefeuille(2);
+
+    expect(portefeuille.taux_affichage.usd_vers_eur).toBe('0.88');
+    expect(portefeuille.taux_affichage.eur_vers_usd).not.toBeNull();
+  });
+
+  // Un cours manquant ne doit pas priver l'utilisateur du reste de son portefeuille.
+  it('signale les cours indisponibles sans invalider la réponse', async () => {
+    const actifs = depotActifs([ACTIF_BTC]);
+    const transactions = depotTransactions(TRANSACTIONS_BTC);
+
+    const service = creerServicePortefeuille({
+      serviceCours: serviceCoursFactice([{ symbole: 'BTC', erreur: 'fournisseur injoignable' }]),
+      snapshots: snapshotsFactices(),
+      actifs,
+      transactions,
+    });
+
+    const portefeuille = await service.obtenirPortefeuille(2);
+
+    expect(portefeuille.cours_indisponibles).toContain('BTC');
+    expect(portefeuille.actifs[0].valeur).toBeNull();
+    expect(portefeuille.actifs[0].quantite_detenue).toBe('1');
+  });
+
+  // Un point faux dans l'historique est pire qu'un trou dans la courbe.
+  it("n'enregistre aucun snapshot si aucun cours n'est disponible", async () => {
+    const actifs = depotActifs([ACTIF_BTC]);
+    const transactions = depotTransactions(TRANSACTIONS_BTC);
+
+    const snapshots = snapshotsFactices();
+    const service = creerServicePortefeuille({
+      serviceCours: serviceCoursFactice([{ symbole: 'BTC', erreur: 'injoignable' }]),
+      snapshots,
+      actifs,
+      transactions,
+    });
+
+    await service.obtenirPortefeuille(2);
+
+    expect(snapshots.enregistrerSiAbsent).not.toHaveBeenCalled();
+  });
+
+  // L'historisation est un effet de bord : son échec ne prive pas l'utilisateur
+  // de son portefeuille.
+  it("rend le portefeuille même si l'écriture du snapshot échoue", async () => {
+    const actifs = depotActifs([ACTIF_BTC]);
+    const transactions = depotTransactions(TRANSACTIONS_BTC);
+
+    const snapshots = snapshotsFactices();
+    snapshots.enregistrerSiAbsent.mockRejectedValue(new Error('base indisponible'));
+
+    const service = creerServicePortefeuille({
+      serviceCours: serviceCoursFactice([
+        { symbole: 'BTC', cours_eur: '150.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
+      ]),
+      snapshots,
+      actifs,
+      transactions,
+    });
+
+    const portefeuille = await service.obtenirPortefeuille(2);
+
+    expect(portefeuille.valeur_totale).toBe('150.00');
+  });
+
+  it('rend un portefeuille vide sans erreur pour un compte neuf', async () => {
+    const actifs = depotActifs([]);
+    const transactions = depotTransactions([]);
+
+    const service = creerServicePortefeuille({
+      serviceCours: serviceCoursFactice([]),
+      snapshots: snapshotsFactices(),
+      actifs,
+      transactions,
+    });
+
+    const portefeuille = await service.obtenirPortefeuille(9);
+
+    expect(portefeuille.valeur_totale).toBe('0.00');
+    expect(portefeuille.actifs).toEqual([]);
+    expect(portefeuille.repartition).toEqual([]);
+  });
+
+  it('ne demande les cours qu\'une seule fois pour tout le portefeuille', async () => {
+    const actifs = depotActifs([
+      ACTIF_BTC,
+      { id: 2, type: 'crypto', symbole: 'ETH', nom: 'Ethereum', utilisateur_id: 2 },
+    ]);
+    const transactions = depotTransactions(TRANSACTIONS_BTC);
+
+    const serviceCours = serviceCoursFactice([
+      { symbole: 'BTC', cours_eur: '150.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
+      { symbole: 'ETH', cours_eur: '10.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
+    ]);
+    const service = creerServicePortefeuille({ serviceCours, snapshots: snapshotsFactices(), actifs, transactions });
+
+    await service.obtenirPortefeuille(2);
+
+    expect(serviceCours.getCoursMultiples).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("détail d'un actif", () => {
+  it('rend la position, le cours et les transactions', async () => {
+    const actifs = depotActifs([], ACTIF_BTC);
+    const transactions = depotTransactions(TRANSACTIONS_BTC);
+
+    const serviceCours = serviceCoursFactice([]);
+    serviceCours.getCours = vi.fn().mockResolvedValue({
+      symbole: 'BTC',
+      cours_eur: '150.00',
+      horodatage: '2026-07-30T10:00:00Z',
+      source: 'fournisseur',
+    });
+
+    const service = creerServicePortefeuille({ serviceCours, snapshots: snapshotsFactices(), actifs, transactions });
+    const detail = await service.obtenirDetailActif(1, 2);
+
+    expect(detail.pru).toBe('100');
+    expect(detail.valeur).toBe('150.00');
+    expect(detail.source_cours).toBe('fournisseur');
+    expect(detail.transactions).toHaveLength(1);
+  });
+
+  it("refuse un actif appartenant à un autre utilisateur", async () => {
+    const actifs = depotActifs([], null);
+    const transactions = depotTransactions([]);
+
+    const service = creerServicePortefeuille({
+      serviceCours: serviceCoursFactice([]),
+      snapshots: snapshotsFactices(),
+      actifs,
+      transactions,
+    });
+
+    await expect(service.obtenirDetailActif(999, 2)).rejects.toThrow(/introuvable/);
+  });
+});

--- a/backend/src/services/calculPortefeuille.js
+++ b/backend/src/services/calculPortefeuille.js
@@ -1,0 +1,194 @@
+// Moteur de calcul du portefeuille : prix de revient unitaire moyen pondéré (PRU),
+// plus-value réalisée, plus-value latente et consolidation.
+//
+// Toutes les fonctions de ce module sont pures : elles reçoivent des transactions et
+// un cours, elles rendent un résultat. Aucune base, aucun appel réseau, aucun cache.
+// C'est ce qui permet de les tester seules et de dérouler un calcul au tableau.
+//
+// Les six règles appliquées sont celles actées en D54 :
+//   1. le PRU intègre les frais d'achat, il représente le coût de revient réel ;
+//   2. un achat recalcule le PRU en moyenne pondérée ;
+//   3. une vente ne modifie pas le PRU, seulement la quantité détenue ;
+//   4. la plus-value réalisée d'une vente vaut
+//      quantité × (prix de vente − PRU) − frais de vente, cumulée sur l'actif ;
+//   5. une vente totale suivie d'un rachat repart d'un PRU neuf ;
+//   6. les transactions sont traitées par ordre chronologique, l'identifiant
+//      départageant les transactions de même date.
+//
+// Les valeurs entrent et sortent en chaînes de caractères ; à l'intérieur, tout est
+// entier (src/utils/decimal.js).
+
+const {
+  ECHELLE_QUANTITE,
+  ECHELLE_MONTANT,
+  ECHELLE_PRU,
+  versUnites,
+  versChaine,
+  formater,
+  convertirEchelle,
+  multiplier,
+  diviser,
+} = require('../utils/decimal');
+
+// Règle 6. Le tri est fait ici et non laissé au SQL : saisir après coup une
+// transaction ancienne doit donner le même résultat que l'avoir saisie dans l'ordre.
+// Le calcul ne doit pas dépendre de l'ordre de frappe.
+function trierChronologiquement(transactions) {
+  return [...transactions].sort((a, b) => {
+    const dateA = new Date(a.date_transaction).getTime();
+    const dateB = new Date(b.date_transaction).getTime();
+    if (dateA !== dateB) {
+      return dateA - dateB;
+    }
+    return Number(a.id ?? 0) - Number(b.id ?? 0);
+  });
+}
+
+function calculerPosition(transactions) {
+  // Quantité et PRU sont tenus à l'échelle des quantités et du PRU, soit 8 décimales.
+  let quantite = 0n;
+  let pru = 0n;
+  let plusValueRealisee = 0n;
+
+  for (const transaction of trierChronologiquement(transactions)) {
+    const quantiteTransaction = versUnites(transaction.quantite, ECHELLE_QUANTITE);
+    // Prix et frais sont saisis à 2 décimales, remontés à 8 pour rester homogènes
+    // avec le PRU pendant le calcul.
+    const prixUnitaire = convertirEchelle(
+      versUnites(transaction.prix_unitaire, ECHELLE_MONTANT),
+      ECHELLE_MONTANT,
+      ECHELLE_PRU
+    );
+    const frais = convertirEchelle(
+      versUnites(transaction.frais ?? '0', ECHELLE_MONTANT),
+      ECHELLE_MONTANT,
+      ECHELLE_PRU
+    );
+
+    if (transaction.sens === 'achat') {
+      // Règles 1 et 2 : moyenne pondérée, frais d'achat inclus au coût de revient.
+      const coutExistant = multiplier(pru, quantite, ECHELLE_PRU);
+      const coutAchat = multiplier(prixUnitaire, quantiteTransaction, ECHELLE_PRU) + frais;
+      const nouvelleQuantite = quantite + quantiteTransaction;
+
+      // Un achat de quantité nulle est refusé à la validation ; la garde évite
+      // malgré tout toute division par zéro sur une donnée inattendue.
+      pru = nouvelleQuantite === 0n ? 0n : diviser(coutExistant + coutAchat, nouvelleQuantite, ECHELLE_PRU);
+      quantite = nouvelleQuantite;
+    } else {
+      // Règles 3 et 4 : le PRU ne bouge pas, la plus-value réalisée est cumulée.
+      const gainUnitaire = prixUnitaire - pru;
+      plusValueRealisee += multiplier(gainUnitaire, quantiteTransaction, ECHELLE_PRU) - frais;
+      quantite -= quantiteTransaction;
+
+      // Règle 5 : position soldée, le PRU repart de zéro pour un éventuel rachat.
+      if (quantite <= 0n) {
+        quantite = 0n;
+        pru = 0n;
+      }
+    }
+  }
+
+  return {
+    quantite_detenue: versChaine(quantite, ECHELLE_QUANTITE),
+    pru: versChaine(pru, ECHELLE_PRU),
+    // Ce que représente encore la position au prix de revient, frais compris.
+    cout_total: formater(multiplier(pru, quantite, ECHELLE_PRU), ECHELLE_PRU, ECHELLE_MONTANT),
+    plus_value_realisee: formater(plusValueRealisee, ECHELLE_PRU, ECHELLE_MONTANT),
+  };
+}
+
+// Valorisation d'une position à un cours donné. Un cours absent ne vaut pas zéro :
+// la position est alors rendue sans valorisation, à charge pour le front de signaler
+// que le cours est momentanément indisponible.
+function valoriser(position, coursEur) {
+  if (coursEur === null || coursEur === undefined || coursEur === '') {
+    return { ...position, valeur: null, plus_value_latente: null, pourcentage_variation: null };
+  }
+
+  const quantite = versUnites(position.quantite_detenue, ECHELLE_QUANTITE);
+  const pru = versUnites(position.pru, ECHELLE_PRU);
+  const cours = versUnites(coursEur, ECHELLE_PRU);
+
+  const valeur = multiplier(cours, quantite, ECHELLE_PRU);
+  const plusValueLatente = multiplier(cours - pru, quantite, ECHELLE_PRU);
+  const coutTotal = multiplier(pru, quantite, ECHELLE_PRU);
+
+  // Le pourcentage n'a de sens que si un coût existe : sur une position soldée ou
+  // sur un actif reçu sans coût, il n'est pas défini.
+  const pourcentage =
+    coutTotal === 0n
+      ? null
+      : formater(diviser(plusValueLatente * 100n, coutTotal, ECHELLE_PRU), ECHELLE_PRU, ECHELLE_MONTANT);
+
+  return {
+    ...position,
+    valeur: formater(valeur, ECHELLE_PRU, ECHELLE_MONTANT),
+    plus_value_latente: formater(plusValueLatente, ECHELLE_PRU, ECHELLE_MONTANT),
+    pourcentage_variation: pourcentage,
+  };
+}
+
+// Consolidation de l'ensemble des positions valorisées.
+function consolider(positionsValorisees) {
+  let valeurTotale = 0n;
+  let coutTotal = 0n;
+  let latenteTotale = 0n;
+  let realiseeTotale = 0n;
+
+  const valeurParType = new Map();
+
+  for (const position of positionsValorisees) {
+    realiseeTotale += versUnites(position.plus_value_realisee ?? '0', ECHELLE_MONTANT);
+
+    // Une position sans cours n'entre ni dans la valeur totale ni dans la
+    // répartition : l'y compter pour zéro fausserait les deux.
+    if (position.valeur === null || position.valeur === undefined) {
+      continue;
+    }
+
+    const valeur = versUnites(position.valeur, ECHELLE_MONTANT);
+    valeurTotale += valeur;
+    coutTotal += versUnites(position.cout_total ?? '0', ECHELLE_MONTANT);
+    latenteTotale += versUnites(position.plus_value_latente ?? '0', ECHELLE_MONTANT);
+
+    valeurParType.set(position.type, (valeurParType.get(position.type) ?? 0n) + valeur);
+  }
+
+  return {
+    valeur_totale: formater(valeurTotale, ECHELLE_MONTANT, ECHELLE_MONTANT),
+    cout_total: formater(coutTotal, ECHELLE_MONTANT, ECHELLE_MONTANT),
+    plus_value_latente: formater(latenteTotale, ECHELLE_MONTANT, ECHELLE_MONTANT),
+    plus_value_realisee: formater(realiseeTotale, ECHELLE_MONTANT, ECHELLE_MONTANT),
+    repartition: repartir(valeurParType, valeurTotale),
+  };
+}
+
+// Répartition en pourcentages dont la somme fait exactement 100.
+//
+// Arrondir chaque part indépendamment produirait un total à 99,98 % ou 100,01 %,
+// impossible à défendre sur un graphique de répartition. La dernière part reçoit
+// donc le reliquat : c'est la méthode dite du plus grand reste, appliquée simplement.
+function repartir(valeurParType, valeurTotale) {
+  if (valeurTotale === 0n) {
+    return [];
+  }
+
+  const parts = [...valeurParType.entries()].sort((a, b) => (b[1] > a[1] ? 1 : -1));
+  const cent = versUnites('100', ECHELLE_MONTANT);
+
+  let cumul = 0n;
+  return parts.map(([type, valeur], index) => {
+    const dernier = index === parts.length - 1;
+    const pourcentage = dernier ? cent - cumul : diviser(valeur * 100n, valeurTotale, ECHELLE_MONTANT);
+    cumul += pourcentage;
+
+    return {
+      type,
+      valeur: formater(valeur, ECHELLE_MONTANT, ECHELLE_MONTANT),
+      pourcentage: formater(pourcentage, ECHELLE_MONTANT, ECHELLE_MONTANT),
+    };
+  });
+}
+
+module.exports = { calculerPosition, valoriser, consolider, trierChronologiquement };

--- a/backend/src/services/portefeuille.js
+++ b/backend/src/services/portefeuille.js
@@ -1,55 +1,35 @@
 // Règles de gestion du portefeuille, écrites en fonctions pures : elles reçoivent un
 // tableau de transactions et rendent un résultat, sans accès à la base ni à HTTP.
-// C'est ce qui les rend testables seules, et c'est la structure que reprendra le lot
-// des calculs financiers (PRU, plus-values).
+// C'est ce qui les rend testables seules, et ce qui permet de dérouler le calcul
+// devant un jury sans démarrer l'application.
 //
-// Choix de calcul : les quantités sont converties en entiers de la plus petite unité
-// représentable (10^-8, soit le maximum de décimales accepté à la validation) et
-// accumulées en BigInt. Additionner des nombres à virgule flottante ferait apparaître
-// des écarts du type 0.1 + 0.2 = 0.30000000000000004, inacceptables sur des quantités
-// financières. Le résultat est rendu sous forme de chaîne, donc exact de bout en bout.
+// L'arithmétique exacte est portée par src/utils/decimal.js, partagé avec le moteur
+// de calcul du PRU et des plus-values.
 
 const { ErreurValidation } = require('../erreurs');
-
-const DECIMALES = 8;
-const FACTEUR = 10n ** BigInt(DECIMALES);
-
-function versUnites(valeur) {
-  const [entier, decimales = ''] = String(valeur).trim().split('.');
-  const decimalesCompletees = decimales.padEnd(DECIMALES, '0').slice(0, DECIMALES);
-  return BigInt(entier) * FACTEUR + BigInt(decimalesCompletees);
-}
-
-function versChaine(unites) {
-  const negatif = unites < 0n;
-  const absolu = negatif ? -unites : unites;
-  const partieEntiere = absolu / FACTEUR;
-  const partieDecimale = (absolu % FACTEUR).toString().padStart(DECIMALES, '0').replace(/0+$/, '');
-
-  return `${negatif ? '-' : ''}${partieEntiere}${partieDecimale ? `.${partieDecimale}` : ''}`;
-}
+const { ECHELLE_QUANTITE, versUnites, versChaine } = require('../utils/decimal');
 
 // Quantité restant détenue sur un actif : somme des achats moins somme des ventes.
-// Rendue en chaîne pour rester exacte.
+// Rendue en chaîne pour rester exacte de bout en bout.
 function quantiteDetenue(transactions) {
   const total = transactions.reduce((cumul, transaction) => {
-    const unites = versUnites(transaction.quantite);
+    const unites = versUnites(transaction.quantite, ECHELLE_QUANTITE);
     return transaction.sens === 'achat' ? cumul + unites : cumul - unites;
   }, 0n);
 
-  return versChaine(total);
+  return versChaine(total, ECHELLE_QUANTITE);
 }
 
 // Règle « on ne vend pas plus que ce que l'on détient ». Elle porte sur l'agrégat de
 // plusieurs lignes de transaction : aucune contrainte SQL ne peut l'exprimer, elle
 // est donc vérifiée ici, côté serveur (voir modele-de-donnees.md).
 function verifierVenteAutorisee(transactions, quantiteVendue) {
-  const detenu = versUnites(quantiteDetenue(transactions));
-  const vendu = versUnites(quantiteVendue);
+  const detenu = versUnites(quantiteDetenue(transactions), ECHELLE_QUANTITE);
+  const vendu = versUnites(quantiteVendue, ECHELLE_QUANTITE);
 
   if (vendu > detenu) {
     throw new ErreurValidation(
-      `Quantité insuffisante : vous détenez ${versChaine(detenu)} sur cet actif.`
+      `Quantité insuffisante : vous détenez ${versChaine(detenu, ECHELLE_QUANTITE)} sur cet actif.`
     );
   }
 }

--- a/backend/src/services/portefeuilleConsolide.js
+++ b/backend/src/services/portefeuilleConsolide.js
@@ -1,0 +1,174 @@
+// Orchestration du portefeuille consolidé : charge les données de l'utilisateur,
+// demande les cours, applique le moteur de calcul, consolide, puis historise.
+//
+// Le moteur (calculPortefeuille.js) reste pur : c'est ici, et seulement ici, que la
+// base et le service de cours sont sollicités.
+
+const modeleActif = require('../models/actif');
+const modeleTransaction = require('../models/transaction');
+const modeleSnapshot = require('../models/snapshot');
+const { creerServiceCours } = require('./cours');
+const { calculerPosition, valoriser, consolider } = require('./calculPortefeuille');
+const { ECHELLE_PRU, versUnites, versChaine, diviser } = require('../utils/decimal');
+const { ErreurIntrouvable } = require('../erreurs');
+
+// Les modèles et le service de cours sont injectables : le service s'exécute alors
+// sans base ni réseau dans les tests, avec le même code qu'en production.
+function creerServicePortefeuille({
+  serviceCours = creerServiceCours(),
+  snapshots = modeleSnapshot,
+  actifs: depotActifs = modeleActif,
+  transactions: depotTransactions = modeleTransaction,
+} = {}) {
+  // Charge les positions d'un utilisateur, valorisées au cours courant.
+  async function construirePositions(utilisateurId) {
+    const actifs = await depotActifs.listerParUtilisateur(utilisateurId);
+
+    if (actifs.length === 0) {
+      return { positions: [], coursIndisponibles: [] };
+    }
+
+    // Un seul aller-retour pour tous les cours : getCoursMultiples déduplique les
+    // symboles, deux actifs pouvant partager une même devise de conversion.
+    const cours = await serviceCours.getCoursMultiples(
+      actifs.map((actif) => ({ symbole: actif.symbole, type: actif.type }))
+    );
+    const coursParSymbole = new Map(cours.map((c) => [c.symbole, c]));
+
+    const coursIndisponibles = [];
+
+    const positions = await Promise.all(
+      actifs.map(async (actif) => {
+        const transactions = await depotTransactions.listerParActifEtUtilisateur(
+          actif.id,
+          utilisateurId
+        );
+
+        const position = calculerPosition(transactions);
+        const coursActif = coursParSymbole.get(actif.symbole);
+
+        // Un cours manquant n'invalide pas la réponse : l'actif est renvoyé sans
+        // valorisation et son symbole est signalé au front.
+        if (!coursActif || coursActif.erreur) {
+          coursIndisponibles.push(actif.symbole);
+        }
+
+        const valorisee = valoriser(position, coursActif?.erreur ? null : coursActif?.cours_eur);
+
+        return {
+          id: actif.id,
+          type: actif.type,
+          symbole: actif.symbole,
+          nom: actif.nom,
+          cours_eur: coursActif?.erreur ? null : (coursActif?.cours_eur ?? null),
+          source_cours: coursActif?.erreur ? null : (coursActif?.source ?? null),
+          horodatage_cours: coursActif?.erreur ? null : (coursActif?.horodatage ?? null),
+          ...valorisee,
+        };
+      })
+    );
+
+    return { positions, coursIndisponibles };
+  }
+
+  // Taux de change exposé pour la bascule d'affichage euro/dollar (D43).
+  //
+  // Borne de D43 : aucune conversion n'est faite côté serveur. Tous les montants
+  // renvoyés restent en euros, devise de référence des calculs et du stockage (D11).
+  // Le front applique ce taux à l'affichage seulement, sans que rien ne soit recalculé
+  // ni stocké dans une seconde devise.
+  async function obtenirTauxAffichage() {
+    try {
+      const cours = await serviceCours.getCours('USD', 'devise');
+
+      // getCours rend la valeur d'un dollar en euros ; le front convertit des euros
+      // vers des dollars, il a donc besoin de l'inverse. Les deux sens sont exposés
+      // pour lever toute ambiguïté sur celui à appliquer.
+      const usdVersEur = versUnites(cours.cours_eur, ECHELLE_PRU);
+      const eurVersUsd =
+        usdVersEur === 0n
+          ? null
+          : versChaine(diviser(versUnites('1', ECHELLE_PRU), usdVersEur, ECHELLE_PRU), ECHELLE_PRU);
+
+      return {
+        eur_vers_usd: eurVersUsd,
+        usd_vers_eur: cours.cours_eur,
+        horodatage: cours.horodatage,
+      };
+    } catch (erreur) {
+      console.error('Taux de change indisponible pour la bascule d\'affichage :', erreur.message);
+      return null;
+    }
+  }
+
+  async function obtenirPortefeuille(utilisateurId) {
+    const { positions, coursIndisponibles } = await construirePositions(utilisateurId);
+    const totaux = consolider(positions);
+    const tauxAffichage = await obtenirTauxAffichage();
+
+    await historiser(utilisateurId, totaux.valeur_totale, positions, coursIndisponibles);
+
+    return {
+      ...totaux,
+      actifs: positions,
+      cours_indisponibles: coursIndisponibles,
+      taux_affichage: tauxAffichage,
+    };
+  }
+
+  // Écriture paresseuse du snapshot du jour (D49) : déclenchée par la consultation,
+  // sans tâche planifiée à maintenir.
+  async function historiser(utilisateurId, valeurTotale, positions, coursIndisponibles) {
+    // Un portefeuille dont aucun cours n'a pu être obtenu vaudrait zéro dans
+    // l'historique. Un trou dans la courbe est préférable à un point faux.
+    if (positions.length > 0 && coursIndisponibles.length === positions.length) {
+      console.error(
+        "Snapshot non enregistré : aucun cours disponible, la valeur du jour serait fausse."
+      );
+      return;
+    }
+
+    try {
+      await snapshots.enregistrerSiAbsent(utilisateurId, valeurTotale);
+    } catch (erreur) {
+      // L'historisation est un effet de bord : son échec ne doit jamais priver
+      // l'utilisateur de son portefeuille.
+      console.error("Enregistrement du snapshot impossible :", erreur.message);
+    }
+  }
+
+  // Détail d'un actif : position, valorisation et historique de ses transactions.
+  async function obtenirDetailActif(actifId, utilisateurId) {
+    const actif = await depotActifs.trouverParIdEtUtilisateur(actifId, utilisateurId);
+    if (!actif) {
+      throw new ErreurIntrouvable('Actif introuvable.');
+    }
+
+    const transactions = await depotTransactions.listerParActifEtUtilisateur(actifId, utilisateurId);
+    const position = calculerPosition(transactions);
+
+    let coursActif = null;
+    try {
+      coursActif = await serviceCours.getCours(actif.symbole, actif.type);
+    } catch (erreur) {
+      console.error(`Cours indisponible pour ${actif.symbole} :`, erreur.message);
+    }
+
+    return {
+      ...actif,
+      cours_eur: coursActif?.cours_eur ?? null,
+      source_cours: coursActif?.source ?? null,
+      horodatage_cours: coursActif?.horodatage ?? null,
+      ...valoriser(position, coursActif?.cours_eur ?? null),
+      transactions,
+    };
+  }
+
+  async function obtenirHistorique(utilisateurId, nombreDeJours) {
+    return snapshots.listerParUtilisateur(utilisateurId, nombreDeJours);
+  }
+
+  return { obtenirPortefeuille, obtenirDetailActif, obtenirHistorique };
+}
+
+module.exports = { creerServicePortefeuille };

--- a/backend/src/utils/decimal.js
+++ b/backend/src/utils/decimal.js
@@ -1,0 +1,148 @@
+// Arithmétique décimale exacte, en entiers.
+//
+// Aucun montant du projet n'est calculé en virgule flottante (D4). Un nombre est
+// représenté par un entier BigInt exprimé dans une unité fixe : à l'échelle 8, la
+// valeur 1,5 est portée par l'entier 150000000. Les additions et soustractions sont
+// alors exactes, et 0,1 + 0,2 rend exactement 0,3 là où le flottant donnerait
+// 0,30000000000000004.
+//
+// Échelles retenues, alignées sur les colonnes du schéma PostgreSQL :
+//   - quantités      : 8 décimales, comme NUMERIC(24,8) de transaction.quantite ;
+//   - prix, montants : 2 décimales, comme NUMERIC(18,2) de transaction.prix_unitaire ;
+//   - PRU            : 8 décimales. Le PRU n'est pas un prix affiché mais un diviseur
+//                      de calcul : arrondi à 2 décimales, il fausserait la plus-value
+//                      d'un actif coté très haut ou très bas. Un PRU de bitcoin à
+//                      deux décimales, ou celui d'un jeton à 0,00000012 euro, serait
+//                      inexploitable.
+//
+// Règle d'arrondi de la division : arrondi au plus proche, les demis s'éloignant de
+// zéro (« demi-supérieur en valeur absolue »). C'est la règle usuelle en comptabilité,
+// et elle traite symétriquement les gains et les pertes.
+
+const ECHELLE_QUANTITE = 8;
+const ECHELLE_MONTANT = 2;
+const ECHELLE_PRU = 8;
+
+function facteur(echelle) {
+  return 10n ** BigInt(echelle);
+}
+
+// Accepte une chaîne ou un nombre, rend l'entier correspondant à l'échelle demandée.
+// Les décimales au-delà de l'échelle sont tronquées : elles ne sont pas représentables.
+function versUnites(valeur, echelle) {
+  const texte = String(valeur).trim();
+  const negatif = texte.startsWith('-');
+  const [entier, decimales = ''] = (negatif ? texte.slice(1) : texte).split('.');
+
+  const decimalesAjustees = decimales.padEnd(echelle, '0').slice(0, echelle);
+  const unites = BigInt(entier || '0') * facteur(echelle) + BigInt(decimalesAjustees || '0');
+
+  return negatif ? -unites : unites;
+}
+
+// Rend la représentation textuelle, sans zéros décimaux inutiles.
+function versChaine(unites, echelle) {
+  const negatif = unites < 0n;
+  const absolu = negatif ? -unites : unites;
+
+  const partieEntiere = absolu / facteur(echelle);
+  const partieDecimale = (absolu % facteur(echelle))
+    .toString()
+    .padStart(echelle, '0')
+    .replace(/0+$/, '');
+
+  return `${negatif ? '-' : ''}${partieEntiere}${partieDecimale ? `.${partieDecimale}` : ''}`;
+}
+
+// Rend la valeur avec un nombre fixe de décimales, pour l'affichage d'un montant.
+function formater(unites, echelle, decimales) {
+  const arrondi = convertirEchelle(unites, echelle, decimales);
+  const negatif = arrondi < 0n;
+  const absolu = negatif ? -arrondi : arrondi;
+
+  const partieEntiere = absolu / facteur(decimales);
+  const partieDecimale = (absolu % facteur(decimales)).toString().padStart(decimales, '0');
+
+  return `${negatif ? '-' : ''}${partieEntiere}${decimales > 0 ? `.${partieDecimale}` : ''}`;
+}
+
+// Division entière arrondie au plus proche, les demis s'éloignant de zéro.
+function diviserEntiers(numerateur, denominateur) {
+  if (denominateur === 0n) {
+    throw new Error('Division par zéro dans un calcul décimal.');
+  }
+
+  const quotient = numerateur / denominateur;
+  const reste = numerateur % denominateur;
+
+  if (reste === 0n) {
+    return quotient;
+  }
+
+  const resteDouble = (reste < 0n ? -reste : reste) * 2n;
+  const denominateurAbsolu = denominateur < 0n ? -denominateur : denominateur;
+
+  if (resteDouble < denominateurAbsolu) {
+    return quotient;
+  }
+
+  const memeSigne = numerateur < 0n === denominateur < 0n;
+  return memeSigne ? quotient + 1n : quotient - 1n;
+}
+
+// Passe une valeur d'une échelle à une autre, en arrondissant si l'échelle diminue.
+function convertirEchelle(unites, echelleSource, echelleCible) {
+  if (echelleCible === echelleSource) {
+    return unites;
+  }
+  if (echelleCible > echelleSource) {
+    return unites * facteur(echelleCible - echelleSource);
+  }
+  return diviserEntiers(unites, facteur(echelleSource - echelleCible));
+}
+
+function additionner(a, b) {
+  return a + b;
+}
+
+function soustraire(a, b) {
+  return a - b;
+}
+
+// Les deux opérandes sont à la même échelle : leur produit est à l'échelle double,
+// il faut donc le ramener à l'échelle voulue.
+function multiplier(a, b, echelle) {
+  return diviserEntiers(a * b, facteur(echelle));
+}
+
+// Même raisonnement en sens inverse : le numérateur est remonté d'une échelle avant
+// division, pour que le quotient soit lui-même à l'échelle voulue.
+function diviser(a, b, echelle) {
+  return diviserEntiers(a * facteur(echelle), b);
+}
+
+function comparer(a, b) {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function estZero(unites) {
+  return unites === 0n;
+}
+
+module.exports = {
+  ECHELLE_QUANTITE,
+  ECHELLE_MONTANT,
+  ECHELLE_PRU,
+  versUnites,
+  versChaine,
+  formater,
+  convertirEchelle,
+  additionner,
+  soustraire,
+  multiplier,
+  diviser,
+  comparer,
+  estZero,
+};

--- a/docs/jeu-essai-calculs.md
+++ b/docs/jeu-essai-calculs.md
@@ -1,0 +1,109 @@
+# Jeu d'essai des calculs de portefeuille
+
+Ce document déroule, sur un scénario volontairement simple, la façon dont CapitAll calcule le prix de revient unitaire moyen pondéré (PRU), la plus-value réalisée et la plus-value latente. Les nombres ont été choisis pour être vérifiables de tête.
+
+Le scénario est repris à l'identique dans les tests automatisés (`backend/src/services/__tests__/calculPortefeuille.test.js`) : le document et le code disent la même chose.
+
+## Les six règles appliquées
+
+| # | Règle | Pourquoi |
+|---|---|---|
+| 1 | Le PRU intègre les frais d'achat | Le coût de revient réel comprend ce qu'il a fallu payer pour acquérir le titre. Exclure les frais reviendrait à sous-estimer le prix payé et à afficher une plus-value flatteuse. |
+| 2 | Un achat recalcule le PRU en moyenne pondérée | C'est la convention de l'administration fiscale française et des courtiers. Elle donne un prix de revient unique par ligne, indépendant de l'ordre des ventes. |
+| 3 | Une vente ne modifie pas le PRU | Vendre ne change pas ce qu'ont coûté les titres restants. Seule la quantité détenue diminue. |
+| 4 | La plus-value réalisée vaut `quantité × (prix de vente − PRU) − frais de vente` | C'est le gain effectivement encaissé sur les titres cédés, net des frais de la vente. |
+| 5 | Une vente totale suivie d'un rachat repart d'un PRU neuf | La position précédente est soldée : le nouveau lot n'a aucun lien de coût avec l'ancien. |
+| 6 | Les transactions sont traitées par ordre chronologique | Saisir après coup une transaction ancienne doit donner le même résultat que l'avoir saisie dans l'ordre. Sans ce tri, le calcul dépendrait de l'ordre de frappe. |
+
+Ces règles sont figées ; le moteur de calcul les applique sans variante.
+
+## Scénario
+
+Un utilisateur suit un actif fictif. Il réalise trois opérations, puis consulte son portefeuille alors que le cours vaut 130,00 euros.
+
+| Date | Opération | Quantité | Prix unitaire | Frais |
+|---|---|---|---|---|
+| 10/01/2026 | Achat | 10 | 100,00 € | 5,00 € |
+| 10/02/2026 | Achat | 10 | 120,00 € | 5,00 € |
+| 10/03/2026 | Vente | 5 | 150,00 € | 5,00 € |
+
+## Déroulé, ligne par ligne
+
+| Après l'opération | Quantité détenue | PRU | Coût total | Plus-value réalisée cumulée |
+|---|---|---|---|---|
+| Achat du 10/01 | 10 | 100,50 € | 1 005,00 € | 0,00 € |
+| Achat du 10/02 | 20 | 110,50 € | 2 210,00 € | 0,00 € |
+| Vente du 10/03 | 15 | 110,50 € | 1 657,50 € | 192,50 € |
+
+## Le calcul du PRU après le second achat, en toutes lettres
+
+C'est la ligne la plus instructive du scénario, celle où la moyenne pondérée entre en jeu.
+
+Avant cette opération, l'utilisateur détient **10 titres** dont le prix de revient unitaire est de **100,50 €**. Ce PRU vient du premier achat : 10 titres à 100,00 € coûtent 1 000,00 €, auxquels s'ajoutent 5,00 € de frais, soit **1 005,00 € pour 10 titres**, donc 100,50 € l'unité (règle 1).
+
+Le second achat porte sur **10 titres à 120,00 €**, soit 1 200,00 €, plus 5,00 € de frais : **1 205,00 €**.
+
+Le nouveau PRU est le coût total divisé par la quantité totale (règle 2) :
+
+```
+PRU = (100,50 × 10 + 120,00 × 10 + 5,00) / (10 + 10)
+    = (1 005,00 + 1 205,00) / 20
+    = 2 210,00 / 20
+    = 110,50 €
+```
+
+L'utilisateur détient désormais **20 titres à 110,50 € de prix de revient**, pour un coût total de **2 210,00 €**.
+
+On notera que le PRU obtenu n'est pas la moyenne arithmétique des deux prix d'achat (110,00 €) : les frais des deux opérations, 10,00 € au total, ajoutent 0,50 € par titre.
+
+## La vente et la plus-value réalisée
+
+La vente du 10/03 porte sur 5 titres à 150,00 €, avec 5,00 € de frais. Le PRU reste à 110,50 € (règle 3), seule la quantité détenue passe de 20 à 15.
+
+La plus-value réalisée se calcule sur les seuls titres cédés (règle 4) :
+
+```
+Plus-value réalisée = 5 × (150,00 − 110,50) − 5,00
+                    = 5 × 39,50 − 5,00
+                    = 197,50 − 5,00
+                    = 192,50 €
+```
+
+Ce gain est acquis : il ne dépend plus d'aucun cours futur.
+
+## Valorisation finale
+
+Le cours de l'actif vaut **130,00 €** au moment de la consultation. L'utilisateur détient 15 titres à 110,50 € de prix de revient.
+
+```
+Valeur de la position   = 15 × 130,00 = 1 950,00 €
+Plus-value latente      = 15 × (130,00 − 110,50) = 15 × 19,50 = 292,50 €
+Variation               = 292,50 / 1 657,50 = 17,65 %
+```
+
+La plus-value latente est **potentielle** : elle varie à chaque mouvement de cours et ne devient acquise qu'à la vente. C'est la raison pour laquelle les deux plus-values sont présentées séparément et jamais additionnées en un chiffre unique.
+
+## Récapitulatif de la position
+
+| Grandeur | Valeur |
+|---|---|
+| Quantité détenue | 15 |
+| Prix de revient unitaire | 110,50 € |
+| Coût total de la position | 1 657,50 € |
+| Valeur au cours de 130,00 € | 1 950,00 € |
+| Plus-value latente | 292,50 € (+17,65 %) |
+| Plus-value réalisée | 192,50 € |
+
+## Exactitude des calculs
+
+Aucun montant n'est calculé en virgule flottante. Les quantités et les montants sont convertis en entiers exprimés dans une unité fixe (huit décimales pour les quantités et le PRU, deux pour les montants), puis manipulés en arithmétique entière exacte.
+
+Ce choix n'est pas théorique : en virgule flottante, `0,1 + 0,2` vaut `0,30000000000000004`. Sur un portefeuille de cryptomonnaies, où les quantités comportent couramment huit décimales, l'écart se propage à chaque opération. Un test dédié vérifie que l'addition de 0,1 et 0,2 rend exactement 0,3.
+
+Le PRU est conservé à huit décimales et non à deux : arrondi au centime, le prix de revient d'un actif coté très haut ou très bas serait faussé, et l'erreur se reporterait sur la plus-value.
+
+## Ce qui est stocké et ce qui ne l'est pas
+
+Le PRU et les plus-values ne sont **jamais enregistrés en base**. Ils sont recalculés depuis les transactions à chaque consultation : une valeur stockée pourrait diverger de l'historique dont elle est censée découler, par exemple après la correction d'une transaction saisie par erreur.
+
+La seule valeur dérivée conservée est le **snapshot de valorisation journalier**, et pour une raison précise : la valeur du portefeuille à une date passée n'est plus reconstituable une fois la journée écoulée, faute de conserver les cours historiques de chaque fournisseur. Un snapshot est donc un fait daté, pas une redondance.


### PR DESCRIPTION
Closes #83, closes #18, closes #19, closes #20, closes #24, closes #25, closes #21, closes #82

Lot D : moteur de calcul du PRU moyen pondéré et des plus-values latente et réalisée selon D54,
en fonctions pures et en arithmétique entière exacte ; portefeuille consolidé avec répartition par
classe et taux EUR/USD pour la bascule d'affichage (D43) ; snapshots de valorisation en écriture
paresseuse (D49) et endpoint d'historique ; jeu d'essai documenté pour le dossier de projet.
Aucune valeur dérivée n'est stockée hors snapshot (D8).

## Arithmétique exacte

Aucun montant n'est calculé en virgule flottante. `src/utils/decimal.js` porte l'arithmétique
entière : quantités et PRU à 8 décimales, montants à 2, arrondi de division au plus proche avec
les demis s'éloignant de zéro. Le PRU est tenu à 8 décimales et non à 2 : arrondi au centime, le
prix de revient d'un actif coté très haut ou très bas fausserait la plus-value.

Seule exception, documentée en commentaire : la conversion du cours des métaux dans son adaptateur,
qui porte sur une donnée déjà approximative reçue du fournisseur et immédiatement arrondie au centime.

## Moteur de calcul

`calculPortefeuille.js` ne contient que des fonctions pures : ni base, ni réseau, ni cache. Les six
règles de D54 sont appliquées telles qu'actées, et le tri chronologique est fait par le moteur et non
par le SQL, pour qu'une transaction saisie après coup donne le même résultat que si elle avait été
saisie dans l'ordre.

La répartition par classe d'actif totalise exactement 100 % : la dernière part reçoit le reliquat
d'arrondi, un graphique affichant 99,98 % n'étant pas défendable.

## Comportements de bord traités

- Cours indisponible : l'actif est renvoyé sans valorisation, jamais valorisé à zéro, et son symbole
  apparaît dans `cours_indisponibles`. Une valeur inconnue n'est pas une valeur nulle.
- Snapshot : écrit en une requête avec `ON CONFLICT DO NOTHING`, ce qui évite la fenêtre de
  concurrence d'un SELECT suivi d'un INSERT. Son échec ne fait jamais échouer la lecture du
  portefeuille, et aucun snapshot n'est écrit si tous les cours manquent.
- Dates de snapshot formatées en `YYYY-MM-DD` par PostgreSQL : rendues comme colonne DATE, le
  pilote les convertissait en instant et la sérialisation JSON affichait la veille.

## Vérification

125 tests unitaires au vert, dont le moteur couvert sans base ni réseau : moyenne pondérée vérifiée
à la main, transactions dans le désordre, vente totale puis rachat, quantités à 8 décimales,
cours absent, répartition dont la somme fait exactement 100.

Vérifié en conditions réelles sur la base amorcée : portefeuille consolidé des six actifs du seed,
répartition à 100 %, taux d'affichage présent. **PRU recalculé à la main sur le bitcoin depuis le
seed — 45 325 / 0,8 = 56 656,25 — écart nul avec la valeur renvoyée**, de même pour la plus-value
réalisée (1 360,75). Snapshot non dupliqué après quatre appels successifs, historique complet,
portefeuille toujours servi Redis arrêté, portefeuille vide sans erreur sur un compte neuf.

## Liste de contrôle

- [x] Aucun montant calcule en virgule flottante
- [x] PRU et plus-values jamais stockes (D8), snapshot excepte (D16)
- [x] Moteur de calcul en fonctions pures, testable sans base
- [x] Cloisonnement inchange, filtre sur le proprietaire dans le SQL
- [x] Aucun secret ni cle d'API dans le diff
- [x] Tests unitaires au vert
- [x] Messages de commit conformes a docs/convention-commits.md
