### PR TITLE
feat(back): alertes de seuil et évaluation au chargement du portefeuille

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const routeurAuthentification = require('./routes/authentification');
 const routeurActif = require('./routes/actif');
 const routeurPortefeuille = require('./routes/portefeuille');
+const routeurAlerte = require('./routes/alerte');
 const gestionErreurs = require('./middlewares/gestionErreurs');
 
 const app = express();
@@ -18,6 +19,7 @@ app.get('/api/sante', (req, res) => {
 app.use('/api/auth', routeurAuthentification);
 app.use('/api/actifs', routeurActif);
 app.use('/api/portefeuille', routeurPortefeuille);
+app.use('/api/alertes', routeurAlerte);
 
 // Toujours en dernier : Express n'y passe que si une route a appelé next(erreur).
 app.use(gestionErreurs);

--- a/backend/src/controllers/alerte.js
+++ b/backend/src/controllers/alerte.js
@@ -1,0 +1,39 @@
+// Contrôleurs des alertes. Le propriétaire vient toujours du jeton : aucune de ces
+// routes n'accepte d'identifiant d'utilisateur en entrée.
+
+const serviceAlerte = require('../services/alerte');
+
+async function lister(req, res, next) {
+  try {
+    const alertes = await serviceAlerte.lister(req.utilisateur.id);
+    res.status(200).json(alertes);
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+async function creer(req, res, next) {
+  try {
+    const alerte = await serviceAlerte.creer({
+      utilisateurId: req.utilisateur.id,
+      donnees: req.body,
+    });
+    res.status(201).json(alerte);
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+async function desactiver(req, res, next) {
+  try {
+    const alerte = await serviceAlerte.desactiver({
+      id: req.params.id,
+      utilisateurId: req.utilisateur.id,
+    });
+    res.status(200).json(alerte);
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+module.exports = { lister, creer, desactiver };

--- a/backend/src/models/alerte.js
+++ b/backend/src/models/alerte.js
@@ -1,0 +1,102 @@
+// Accès aux données de la table alerte. Comme partout, le cloisonnement est porté par
+// le SQL : chaque requête filtre sur le propriétaire, dont l'identifiant vient du jeton.
+
+const { query } = require('../db');
+
+const CHAMPS = `al.id, al.utilisateur_id, al.actif_id, al.type_cible, al.sens_seuil,
+                al.valeur_seuil, al.statut, al.date_creation, al.date_declenchement`;
+
+// Jointure à gauche : une alerte sur le capital total ne cible aucun actif, elle ne
+// doit pas disparaître de la liste pour autant.
+async function listerParUtilisateur(utilisateurId) {
+  const { rows } = await query(
+    `SELECT ${CHAMPS}, a.symbole, a.nom AS nom_actif
+     FROM alerte al
+     LEFT JOIN actif a ON a.id = al.actif_id
+     WHERE al.utilisateur_id = $1
+     ORDER BY
+       CASE al.statut WHEN 'declenchee' THEN 0 WHEN 'active' THEN 1 ELSE 2 END,
+       al.date_declenchement DESC NULLS LAST,
+       al.date_creation DESC`,
+    [utilisateurId]
+  );
+  return rows;
+}
+
+async function listerActivesParUtilisateur(utilisateurId) {
+  const { rows } = await query(
+    `SELECT ${CHAMPS}, a.symbole
+     FROM alerte al
+     LEFT JOIN actif a ON a.id = al.actif_id
+     WHERE al.utilisateur_id = $1 AND al.statut = 'active'`,
+    [utilisateurId]
+  );
+  return rows;
+}
+
+// Création d'une alerte ciblant un actif. Même motif que les transactions du lot B :
+// le SELECT qui alimente l'INSERT ne rend une ligne que si l'actif appartient au
+// demandeur. Si ce n'est pas le cas, rien n'est inséré et la fonction rend null.
+async function creerSurActif({ utilisateurId, actifId, sensSeuil, valeurSeuil }) {
+  const { rows } = await query(
+    `INSERT INTO alerte (utilisateur_id, actif_id, type_cible, sens_seuil, valeur_seuil)
+     SELECT $1, a.id, 'actif', $3, $4
+     FROM actif a
+     WHERE a.id = $2 AND a.utilisateur_id = $1
+     RETURNING id, utilisateur_id, actif_id, type_cible, sens_seuil, valeur_seuil,
+               statut, date_creation, date_declenchement`,
+    [utilisateurId, actifId, sensSeuil, valeurSeuil]
+  );
+  return rows[0] || null;
+}
+
+// Alerte sur le capital total : aucun actif à contrôler, l'identifiant du propriétaire
+// vient directement du jeton.
+async function creerSurCapitalTotal({ utilisateurId, sensSeuil, valeurSeuil }) {
+  const { rows } = await query(
+    `INSERT INTO alerte (utilisateur_id, actif_id, type_cible, sens_seuil, valeur_seuil)
+     VALUES ($1, NULL, 'capital_total', $2, $3)
+     RETURNING id, utilisateur_id, actif_id, type_cible, sens_seuil, valeur_seuil,
+               statut, date_creation, date_declenchement`,
+    [utilisateurId, sensSeuil, valeurSeuil]
+  );
+  return rows[0];
+}
+
+async function desactiver(id, utilisateurId) {
+  const { rows } = await query(
+    `UPDATE alerte
+     SET statut = 'desactivee'
+     WHERE id = $1 AND utilisateur_id = $2
+     RETURNING id, utilisateur_id, actif_id, type_cible, sens_seuil, valeur_seuil,
+               statut, date_creation, date_declenchement`,
+    [id, utilisateurId]
+  );
+  return rows[0] || null;
+}
+
+// Marquage groupé des alertes franchies, en une seule requête. Une boucle d'UPDATE
+// ferait autant d'allers-retours que d'alertes ; ANY($2) traite le lot d'un coup.
+// Le filtre sur le statut évite d'écraser une date de déclenchement déjà posée.
+async function marquerDeclenchees(utilisateurId, identifiants) {
+  if (identifiants.length === 0) {
+    return 0;
+  }
+
+  const { rowCount } = await query(
+    `UPDATE alerte
+     SET statut = 'declenchee', date_declenchement = now()
+     WHERE utilisateur_id = $1 AND id = ANY($2::int[]) AND statut = 'active'`,
+    [utilisateurId, identifiants]
+  );
+  return rowCount;
+}
+
+module.exports = {
+  listerParUtilisateur,
+  listerActivesParUtilisateur,
+  creerSurActif,
+  creerSurCapitalTotal,
+  desactiver,
+  marquerDeclenchees,
+};

--- a/backend/src/routes/alerte.js
+++ b/backend/src/routes/alerte.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const controleur = require('../controllers/alerte');
+const valider = require('../middlewares/valider');
+const validerParamId = require('../middlewares/validerParamId');
+const authentifier = require('../middlewares/authentifier');
+const { creationAlerte, modificationAlerte } = require('../validation/alerte');
+
+const routeur = express.Router();
+
+routeur.use(authentifier);
+
+routeur.get('/', controleur.lister);
+routeur.post('/', valider(creationAlerte), controleur.creer);
+routeur.patch('/:id', validerParamId('id'), valider(modificationAlerte), controleur.desactiver);
+
+module.exports = routeur;

--- a/backend/src/services/__tests__/evaluationAlertes.test.js
+++ b/backend/src/services/__tests__/evaluationAlertes.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { evaluerAlertes, estFranchi } from '../evaluationAlertes.js';
+
+function alerteActif(sensSeuil, valeurSeuil, { id = 1, actifId = 10, statut = 'active' } = {}) {
+  return {
+    id,
+    type_cible: 'actif',
+    actif_id: actifId,
+    symbole: 'BTC',
+    sens_seuil: sensSeuil,
+    valeur_seuil: valeurSeuil,
+    statut,
+  };
+}
+
+function alerteCapital(sensSeuil, valeurSeuil, { id = 2, statut = 'active' } = {}) {
+  return {
+    id,
+    type_cible: 'capital_total',
+    actif_id: null,
+    sens_seuil: sensSeuil,
+    valeur_seuil: valeurSeuil,
+    statut,
+  };
+}
+
+describe('franchissement de seuil', () => {
+  describe('sens au-dessus', () => {
+    it('franchit sur une valeur strictement supérieure', () => {
+      expect(estFranchi('au_dessus', '70000.01', '70000.00')).toBe(true);
+    });
+
+    // Le cas d'égalité est le point de D56 : l'utilisateur qui fixe 70 000 attend
+    // d'être prévenu quand le cours atteint 70 000, pas quand il le dépasse.
+    it('franchit sur une valeur égale au seuil', () => {
+      expect(estFranchi('au_dessus', '70000.00', '70000.00')).toBe(true);
+    });
+
+    it('ne franchit pas sur une valeur inférieure', () => {
+      expect(estFranchi('au_dessus', '69999.99', '70000.00')).toBe(false);
+    });
+  });
+
+  describe('sens en-dessous', () => {
+    it('franchit sur une valeur strictement inférieure', () => {
+      expect(estFranchi('en_dessous', '49999.99', '50000.00')).toBe(true);
+    });
+
+    it('franchit sur une valeur égale au seuil', () => {
+      expect(estFranchi('en_dessous', '50000.00', '50000.00')).toBe(true);
+    });
+
+    it('ne franchit pas sur une valeur supérieure', () => {
+      expect(estFranchi('en_dessous', '50000.01', '50000.00')).toBe(false);
+    });
+  });
+
+  it('compare sans imprécision sur des valeurs à décimales', () => {
+    expect(estFranchi('au_dessus', '0.3', '0.30000000')).toBe(true);
+    expect(estFranchi('au_dessus', '0.29999999', '0.3')).toBe(false);
+  });
+});
+
+describe('évaluation des alertes', () => {
+  it('rend une liste vide sans alerte active', () => {
+    expect(evaluerAlertes([], { capitalTotal: '50000.00', coursParActif: {} })).toEqual([]);
+  });
+
+  // Point d'interprétation retenu : une alerte sur actif se compare au COURS, pas à
+  // la valeur de la position. Ici la position vaut 120 000 (2 unités à 60 000) alors
+  // que le cours est de 60 000 : un seuil à 70 000 ne doit pas être franchi.
+  it('évalue une alerte sur actif au cours et non à la valeur de la position', () => {
+    const franchies = evaluerAlertes([alerteActif('au_dessus', '70000.00')], {
+      capitalTotal: '120000.00',
+      coursParActif: { 10: '60000.00' },
+    });
+
+    expect(franchies).toEqual([]);
+  });
+
+  it('franchit une alerte sur actif quand le cours atteint le seuil', () => {
+    const franchies = evaluerAlertes([alerteActif('au_dessus', '70000.00')], {
+      capitalTotal: '10.00',
+      coursParActif: { 10: '70000.00' },
+    });
+
+    expect(franchies).toHaveLength(1);
+    expect(franchies[0].valeur_observee).toBe('70000.00');
+    expect(franchies[0].symbole).toBe('BTC');
+  });
+
+  it('franchit une alerte sur le capital total', () => {
+    const franchies = evaluerAlertes([alerteCapital('au_dessus', '45000.00')], {
+      capitalTotal: '58566.64',
+      coursParActif: {},
+    });
+
+    expect(franchies).toHaveLength(1);
+    expect(franchies[0].type_cible).toBe('capital_total');
+    expect(franchies[0].actif_id).toBeNull();
+  });
+
+  // Déclencher sur une valeur inconnue serait le pire comportement possible (D56).
+  it("n'évalue pas une alerte dont le cours est indisponible", () => {
+    const franchies = evaluerAlertes([alerteActif('au_dessus', '1.00')], {
+      capitalTotal: '58566.64',
+      coursParActif: {},
+    });
+
+    expect(franchies).toEqual([]);
+  });
+
+  // Réévaluer effacerait la date de premier franchissement, qui est l'information utile.
+  it('ne réévalue pas une alerte déjà déclenchée', () => {
+    const franchies = evaluerAlertes(
+      [alerteActif('au_dessus', '1.00', { statut: 'declenchee' })],
+      { capitalTotal: '10.00', coursParActif: { 10: '70000.00' } }
+    );
+
+    expect(franchies).toEqual([]);
+  });
+
+  it('ignore une alerte désactivée', () => {
+    const franchies = evaluerAlertes(
+      [alerteActif('au_dessus', '1.00', { statut: 'desactivee' })],
+      { capitalTotal: '10.00', coursParActif: { 10: '70000.00' } }
+    );
+
+    expect(franchies).toEqual([]);
+  });
+
+  it('ne retient que les alertes effectivement franchies parmi plusieurs', () => {
+    const franchies = evaluerAlertes(
+      [
+        alerteActif('au_dessus', '70000.00', { id: 1, actifId: 10 }),
+        alerteActif('au_dessus', '90000.00', { id: 2, actifId: 10 }),
+        alerteCapital('au_dessus', '45000.00', { id: 3 }),
+        alerteCapital('en_dessous', '10000.00', { id: 4 }),
+      ],
+      { capitalTotal: '58566.64', coursParActif: { 10: '75000.00' } }
+    );
+
+    expect(franchies.map((a) => a.id).sort()).toEqual([1, 3]);
+  });
+
+  it('conserve le seuil et la valeur observée dans le franchissement', () => {
+    const [franchissement] = evaluerAlertes([alerteCapital('au_dessus', '45000.00')], {
+      capitalTotal: '58566.64',
+      coursParActif: {},
+    });
+
+    expect(franchissement.valeur_seuil).toBe('45000.00');
+    expect(franchissement.valeur_observee).toBe('58566.64');
+    expect(franchissement.sens_seuil).toBe('au_dessus');
+  });
+});

--- a/backend/src/services/__tests__/portefeuilleConsolide.test.js
+++ b/backend/src/services/__tests__/portefeuilleConsolide.test.js
@@ -22,6 +22,13 @@ function depotTransactions(liste) {
   return { listerParActifEtUtilisateur: vi.fn().mockResolvedValue(liste) };
 }
 
+function depotAlertes(actives = []) {
+  return {
+    listerActivesParUtilisateur: vi.fn().mockResolvedValue(actives),
+    marquerDeclenchees: vi.fn().mockResolvedValue(actives.length),
+  };
+}
+
 const ACTIF_BTC = { id: 1, type: 'crypto', symbole: 'BTC', nom: 'Bitcoin', utilisateur_id: 2 };
 
 const TRANSACTIONS_BTC = [
@@ -185,6 +192,93 @@ describe('portefeuille consolidé', () => {
     await service.obtenirPortefeuille(2);
 
     expect(serviceCours.getCoursMultiples).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('évaluation des alertes au chargement', () => {
+  it('signale les alertes franchies et les marque déclenchées', async () => {
+    const actifs = depotActifs([ACTIF_BTC]);
+    const transactions = depotTransactions(TRANSACTIONS_BTC);
+    const alertes = depotAlertes([
+      {
+        id: 7,
+        type_cible: 'capital_total',
+        actif_id: null,
+        sens_seuil: 'au_dessus',
+        valeur_seuil: '100.00',
+        statut: 'active',
+      },
+    ]);
+
+    const service = creerServicePortefeuille({
+      serviceCours: serviceCoursFactice([
+        { symbole: 'BTC', cours_eur: '150.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
+      ]),
+      snapshots: snapshotsFactices(),
+      actifs,
+      transactions,
+      alertes,
+    });
+
+    const portefeuille = await service.obtenirPortefeuille(2);
+
+    expect(portefeuille.alertes_declenchees).toHaveLength(1);
+    expect(portefeuille.alertes_declenchees[0].valeur_observee).toBe('150.00');
+    expect(alertes.marquerDeclenchees).toHaveBeenCalledWith(2, [7]);
+  });
+
+  it("ne marque rien quand aucun seuil n'est franchi", async () => {
+    const actifs = depotActifs([ACTIF_BTC]);
+    const transactions = depotTransactions(TRANSACTIONS_BTC);
+    const alertes = depotAlertes([
+      {
+        id: 8,
+        type_cible: 'capital_total',
+        actif_id: null,
+        sens_seuil: 'au_dessus',
+        valeur_seuil: '999999.00',
+        statut: 'active',
+      },
+    ]);
+
+    const service = creerServicePortefeuille({
+      serviceCours: serviceCoursFactice([
+        { symbole: 'BTC', cours_eur: '150.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
+      ]),
+      snapshots: snapshotsFactices(),
+      actifs,
+      transactions,
+      alertes,
+    });
+
+    const portefeuille = await service.obtenirPortefeuille(2);
+
+    expect(portefeuille.alertes_declenchees).toEqual([]);
+    expect(alertes.marquerDeclenchees).not.toHaveBeenCalled();
+  });
+
+  // L'évaluation est un effet de bord, au même titre que l'historisation : son échec
+  // ne doit pas priver l'utilisateur de son portefeuille.
+  it("rend le portefeuille même si l'évaluation des alertes échoue", async () => {
+    const actifs = depotActifs([ACTIF_BTC]);
+    const transactions = depotTransactions(TRANSACTIONS_BTC);
+    const alertes = depotAlertes();
+    alertes.listerActivesParUtilisateur.mockRejectedValue(new Error('base indisponible'));
+
+    const service = creerServicePortefeuille({
+      serviceCours: serviceCoursFactice([
+        { symbole: 'BTC', cours_eur: '150.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
+      ]),
+      snapshots: snapshotsFactices(),
+      actifs,
+      transactions,
+      alertes,
+    });
+
+    const portefeuille = await service.obtenirPortefeuille(2);
+
+    expect(portefeuille.valeur_totale).toBe('150.00');
+    expect(portefeuille.alertes_declenchees).toEqual([]);
   });
 });
 

--- a/backend/src/services/alerte.js
+++ b/backend/src/services/alerte.js
@@ -1,0 +1,47 @@
+// Logique métier des alertes : aiguillage entre les deux cibles et traduction des
+// absences en erreurs métier. Les règles de franchissement vivent dans
+// evaluationAlertes.js, qui reste pur.
+
+const modeleAlerte = require('../models/alerte');
+const { ErreurIntrouvable } = require('../erreurs');
+
+async function creer({ utilisateurId, donnees }) {
+  if (donnees.type_cible === 'capital_total') {
+    return modeleAlerte.creerSurCapitalTotal({
+      utilisateurId,
+      sensSeuil: donnees.sens_seuil,
+      valeurSeuil: donnees.valeur_seuil,
+    });
+  }
+
+  const alerte = await modeleAlerte.creerSurActif({
+    utilisateurId,
+    actifId: donnees.actif_id,
+    sensSeuil: donnees.sens_seuil,
+    valeurSeuil: donnees.valeur_seuil,
+  });
+
+  // Aucune ligne insérée : l'actif n'existe pas ou appartient à quelqu'un d'autre.
+  // Les deux cas sont indiscernables pour l'appelant, conformément à D52.
+  if (!alerte) {
+    throw new ErreurIntrouvable('Actif introuvable.');
+  }
+
+  return alerte;
+}
+
+async function desactiver({ id, utilisateurId }) {
+  const alerte = await modeleAlerte.desactiver(id, utilisateurId);
+
+  if (!alerte) {
+    throw new ErreurIntrouvable('Alerte introuvable.');
+  }
+
+  return alerte;
+}
+
+async function lister(utilisateurId) {
+  return modeleAlerte.listerParUtilisateur(utilisateurId);
+}
+
+module.exports = { creer, desactiver, lister };

--- a/backend/src/services/evaluationAlertes.js
+++ b/backend/src/services/evaluationAlertes.js
@@ -1,0 +1,71 @@
+// Évaluation des alertes de seuil, en fonction pure : elle reçoit les alertes actives
+// et un contexte de valeurs observées, elle rend la liste des franchissements. Aucune
+// base, aucun appel de cours, aucun effet de bord. Le chargement des alertes et leur
+// marquage relèvent du service de portefeuille.
+//
+// Aucune tâche de fond n'évalue les alertes (D50) : l'évaluation a lieu au chargement
+// du tableau de bord, quand les valeurs viennent d'être calculées.
+
+const { ECHELLE_PRU, versUnites, comparer } = require('../utils/decimal');
+
+// Franchissement inclusif (D56) : un seuil « au-dessus » de 70 000 se déclenche
+// lorsque la valeur atteint 70 000, pas seulement lorsqu'elle le dépasse. C'est ce
+// qu'attend l'utilisateur qui a fixé ce seuil.
+function estFranchi(sensSeuil, valeurObservee, valeurSeuil) {
+  const observee = versUnites(valeurObservee, ECHELLE_PRU);
+  const seuil = versUnites(valeurSeuil, ECHELLE_PRU);
+  const position = comparer(observee, seuil);
+
+  return sensSeuil === 'au_dessus' ? position >= 0 : position <= 0;
+}
+
+// Valeur à comparer au seuil, selon la cible de l'alerte.
+//
+// Pour une alerte sur un actif, c'est le COURS COURANT de cet actif, et non la valeur
+// de la position détenue. Un seuil de prix porte sur le prix : un utilisateur qui
+// demande à être prévenu quand le bitcoin atteint 70 000 euros parle du cours, pas de
+// ce que vaut son portefeuille de bitcoins. Les deux diffèrent dès que la quantité
+// détenue n'est pas exactement 1, et un test couvre précisément ce cas.
+function valeurObservee(alerte, contexte) {
+  if (alerte.type_cible === 'capital_total') {
+    return contexte.capitalTotal ?? null;
+  }
+
+  return contexte.coursParActif?.[alerte.actif_id] ?? null;
+}
+
+function evaluerAlertes(alertesActives, contexte) {
+  const franchissements = [];
+
+  for (const alerte of alertesActives) {
+    // Une alerte déjà déclenchée n'est pas réévaluée (D56) : sa date de premier
+    // franchissement est l'information utile, la réévaluer l'écraserait.
+    if (alerte.statut !== 'active') {
+      continue;
+    }
+
+    const observee = valeurObservee(alerte, contexte);
+
+    // Cours indisponible : l'alerte n'est pas évaluée du tout. Déclencher sur une
+    // valeur inconnue, ou la traiter comme nulle, serait le pire des comportements.
+    if (observee === null || observee === undefined || observee === '') {
+      continue;
+    }
+
+    if (estFranchi(alerte.sens_seuil, observee, alerte.valeur_seuil)) {
+      franchissements.push({
+        id: alerte.id,
+        type_cible: alerte.type_cible,
+        actif_id: alerte.actif_id ?? null,
+        symbole: alerte.symbole ?? null,
+        sens_seuil: alerte.sens_seuil,
+        valeur_seuil: alerte.valeur_seuil,
+        valeur_observee: String(observee),
+      });
+    }
+  }
+
+  return franchissements;
+}
+
+module.exports = { evaluerAlertes, estFranchi };

--- a/backend/src/services/portefeuilleConsolide.js
+++ b/backend/src/services/portefeuilleConsolide.js
@@ -7,6 +7,8 @@
 const modeleActif = require('../models/actif');
 const modeleTransaction = require('../models/transaction');
 const modeleSnapshot = require('../models/snapshot');
+const modeleAlerte = require('../models/alerte');
+const { evaluerAlertes } = require('./evaluationAlertes');
 const { creerServiceCours } = require('./cours');
 const { calculerPosition, valoriser, consolider } = require('./calculPortefeuille');
 const { ECHELLE_PRU, versUnites, versChaine, diviser } = require('../utils/decimal');
@@ -19,6 +21,7 @@ function creerServicePortefeuille({
   snapshots = modeleSnapshot,
   actifs: depotActifs = modeleActif,
   transactions: depotTransactions = modeleTransaction,
+  alertes: depotAlertes = modeleAlerte,
 } = {}) {
   // Charge les positions d'un utilisateur, valorisées au cours courant.
   async function construirePositions(utilisateurId) {
@@ -107,13 +110,48 @@ function creerServicePortefeuille({
     const tauxAffichage = await obtenirTauxAffichage();
 
     await historiser(utilisateurId, totaux.valeur_totale, positions, coursIndisponibles);
+    const alertesDeclenchees = await traiterAlertes(utilisateurId, totaux.valeur_totale, positions);
 
     return {
       ...totaux,
       actifs: positions,
       cours_indisponibles: coursIndisponibles,
       taux_affichage: tauxAffichage,
+      alertes_declenchees: alertesDeclenchees,
     };
+  }
+
+  // Évaluation des alertes au chargement du tableau de bord (D50).
+  //
+  // Comme l'historisation, c'est un effet de bord : un échec est journalisé et la
+  // réponse part quand même. Priver l'utilisateur de son portefeuille parce qu'une
+  // alerte n'a pas pu être évaluée serait disproportionné.
+  async function traiterAlertes(utilisateurId, capitalTotal, positions) {
+    try {
+      const actives = await depotAlertes.listerActivesParUtilisateur(utilisateurId);
+      if (actives.length === 0) {
+        return [];
+      }
+
+      // Les alertes sur actif se comparent au cours, pas à la valeur de la position.
+      const coursParActif = Object.fromEntries(
+        positions.filter((p) => p.cours_eur !== null).map((p) => [p.id, p.cours_eur])
+      );
+
+      const franchies = evaluerAlertes(actives, { capitalTotal, coursParActif });
+
+      if (franchies.length > 0) {
+        await depotAlertes.marquerDeclenchees(
+          utilisateurId,
+          franchies.map((alerte) => alerte.id)
+        );
+      }
+
+      return franchies;
+    } catch (erreur) {
+      console.error("Évaluation des alertes impossible :", erreur.message);
+      return [];
+    }
   }
 
   // Écriture paresseuse du snapshot du jour (D49) : déclenchée par la consultation,

--- a/backend/src/validation/__tests__/alerte.test.js
+++ b/backend/src/validation/__tests__/alerte.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { creationAlerte, modificationAlerte } from '../alerte.js';
+
+const ALERTE_ACTIF = {
+  type_cible: 'actif',
+  sens_seuil: 'au_dessus',
+  valeur_seuil: '70000.00',
+  actif_id: 1,
+};
+
+const ALERTE_CAPITAL = {
+  type_cible: 'capital_total',
+  sens_seuil: 'en_dessous',
+  valeur_seuil: '45000.00',
+};
+
+describe("schéma de création d'une alerte", () => {
+  it('accepte une alerte sur un actif', () => {
+    expect(creationAlerte.safeParse(ALERTE_ACTIF).success).toBe(true);
+  });
+
+  it('accepte une alerte sur le capital total', () => {
+    expect(creationAlerte.safeParse(ALERTE_CAPITAL).success).toBe(true);
+  });
+
+  // Reprise de la contrainte CHECK du schéma : actif_id est renseigné si et seulement
+  // si la cible est un actif. Le contrôler ici permet un message compréhensible plutôt
+  // qu'une erreur de contrainte brute remontée par PostgreSQL.
+  it("rejette une alerte sur actif sans actif_id", () => {
+    const { actif_id, ...sansActif } = ALERTE_ACTIF;
+    const resultat = creationAlerte.safeParse(sansActif);
+
+    expect(resultat.success).toBe(false);
+    expect(resultat.error.issues[0].message).toMatch(/préciser l'actif/);
+  });
+
+  it("rejette une alerte sur le capital total accompagnée d'un actif_id", () => {
+    const resultat = creationAlerte.safeParse({ ...ALERTE_CAPITAL, actif_id: 1 });
+
+    expect(resultat.success).toBe(false);
+    expect(resultat.error.issues[0].message).toMatch(/aucun actif/);
+  });
+
+  it('rejette un seuil nul', () => {
+    expect(creationAlerte.safeParse({ ...ALERTE_ACTIF, valeur_seuil: '0' }).success).toBe(false);
+  });
+
+  it('rejette un seuil négatif', () => {
+    expect(creationAlerte.safeParse({ ...ALERTE_ACTIF, valeur_seuil: '-10.00' }).success).toBe(false);
+  });
+
+  it('rejette un seuil à plus de deux décimales', () => {
+    expect(creationAlerte.safeParse({ ...ALERTE_ACTIF, valeur_seuil: '70000.123' }).success).toBe(
+      false
+    );
+  });
+
+  it('conserve le seuil en chaîne, sans conversion en flottant', () => {
+    const resultat = creationAlerte.parse({ ...ALERTE_ACTIF, valeur_seuil: 70000.5 });
+    expect(resultat.valeur_seuil).toBe('70000.5');
+    expect(typeof resultat.valeur_seuil).toBe('string');
+  });
+
+  it('rejette une cible hors liste', () => {
+    expect(creationAlerte.safeParse({ ...ALERTE_ACTIF, type_cible: 'devise' }).success).toBe(false);
+  });
+
+  it('rejette un sens hors liste', () => {
+    expect(creationAlerte.safeParse({ ...ALERTE_ACTIF, sens_seuil: 'egal' }).success).toBe(false);
+  });
+
+  // Le statut est fixé par le serveur, le propriétaire vient du jeton : ni l'un ni
+  // l'autre n'est accepté depuis le corps de la requête.
+  it('rejette un statut ou un utilisateur_id injecté', () => {
+    expect(creationAlerte.safeParse({ ...ALERTE_ACTIF, statut: 'declenchee' }).success).toBe(false);
+    expect(creationAlerte.safeParse({ ...ALERTE_ACTIF, utilisateur_id: 1 }).success).toBe(false);
+  });
+});
+
+describe("schéma de modification d'une alerte", () => {
+  it('accepte la désactivation', () => {
+    expect(modificationAlerte.safeParse({ statut: 'desactivee' }).success).toBe(true);
+  });
+
+  // La réactivation n'est pas au périmètre : elle poserait la question de la date de
+  // déclenchement d'une alerte déjà franchie.
+  it('rejette une réactivation', () => {
+    expect(modificationAlerte.safeParse({ statut: 'active' }).success).toBe(false);
+  });
+
+  it('rejette un statut arbitraire', () => {
+    expect(modificationAlerte.safeParse({ statut: 'archivee' }).success).toBe(false);
+  });
+
+  it('rejette toute clé inconnue', () => {
+    expect(
+      modificationAlerte.safeParse({ statut: 'desactivee', valeur_seuil: '1.00' }).success
+    ).toBe(false);
+  });
+});

--- a/backend/src/validation/alerte.js
+++ b/backend/src/validation/alerte.js
@@ -1,0 +1,57 @@
+// Schémas de validation des alertes de seuil (D15, D41).
+//
+// Ni utilisateur_id ni statut ne figurent dans le schéma de création : le premier vient
+// du jeton, le second est fixé par le serveur. .strict() rejette donc toute tentative
+// de les fournir dans le corps de la requête.
+
+const { z } = require('zod');
+
+const TYPES_CIBLE = ['actif', 'capital_total'];
+const SENS_SEUIL = ['au_dessus', 'en_dessous'];
+
+const DECIMALES_SEUIL = 2;
+
+// Le seuil est normalisé en chaîne et transmis tel quel à la colonne NUMERIC : le
+// convertir en nombre réintroduirait l'imprécision que le projet écarte partout (D4).
+const valeurSeuil = z
+  .union([z.string(), z.number()])
+  .transform((valeur) => String(valeur).trim())
+  .refine((valeur) => new RegExp(`^\\d+(\\.\\d{1,${DECIMALES_SEUIL}})?$`).test(valeur), {
+    message: `Le seuil doit être positif et comporter au plus ${DECIMALES_SEUIL} décimales.`,
+  })
+  .refine((valeur) => Number(valeur) > 0, {
+    message: 'Le seuil doit être strictement positif.',
+  });
+
+const creationAlerte = z
+  .object({
+    type_cible: z.enum(TYPES_CIBLE, 'La cible doit valoir actif ou capital_total.'),
+    sens_seuil: z.enum(SENS_SEUIL, 'Le sens doit valoir au_dessus ou en_dessous.'),
+    valeur_seuil: valeurSeuil,
+    actif_id: z.int().positive("L'identifiant d'actif est invalide.").optional(),
+  })
+  .strict()
+  // Reprise fidèle de la contrainte CHECK du schéma : actif_id est renseigné si et
+  // seulement si la cible est un actif. Détecter le cas ici plutôt que de laisser
+  // PostgreSQL rejeter l'insertion permet de rendre un message compréhensible, et
+  // évite d'exposer une erreur de contrainte brute à l'utilisateur.
+  .refine((donnees) => donnees.type_cible !== 'actif' || donnees.actif_id !== undefined, {
+    message: "Une alerte ciblant un actif doit préciser l'actif concerné.",
+    path: ['actif_id'],
+  })
+  .refine((donnees) => donnees.type_cible !== 'capital_total' || donnees.actif_id === undefined, {
+    message: "Une alerte sur le capital total ne cible aucun actif en particulier.",
+    path: ['actif_id'],
+  });
+
+// Seule la désactivation est exposée. La contrainte CHECK du schéma autorise aussi le
+// retour au statut 'active', mais réactiver une alerte déjà déclenchée poserait la
+// question de sa date de déclenchement : le cas n'est pas au périmètre du MVP et
+// l'API ne l'ouvre donc pas, plutôt que de laisser passer un comportement non défini.
+const modificationAlerte = z
+  .object({
+    statut: z.literal('desactivee', 'Seule la désactivation est possible.'),
+  })
+  .strict();
+
+module.exports = { creationAlerte, modificationAlerte, TYPES_CIBLE, SENS_SEUIL };


### PR DESCRIPTION
Closes #22, closes #23, closes #85

Lot E : création, consultation et désactivation des alertes, cloisonnées au niveau SQL ; évaluation à la volée au chargement du portefeuille (D50), franchissement inclusif (D56), en fonction pure et en arithmétique exacte. Une alerte déclenchée n'est plus réévaluée, une alerte sans cours n'est pas évaluée. L'évaluation ne peut pas faire échouer la lecture du portefeuille.
Ce lot clôt le socle back-end du MVP.

## Franchissement (D56)

Le seuil est **inclusif** dans les deux sens : `au_dessus` se déclenche dès que la valeur atteint le seuil, `en_dessous` dès qu'elle lui est inférieure ou égale. Un utilisateur qui fixe 70 000 attend d'être prévenu quand le cours atteint 70 000, pas quand il le dépasse d'un centime. Les trois cas — supérieur, égal, inférieur — sont couverts par des tests dans chaque sens.

Une alerte sur un actif se compare au **cours courant**, jamais à la valeur de la position détenue : un seuil de prix porte sur le prix. Un test construit volontairement le cas où les deux diffèrent (position à 120 000 pour un cours à 60 000) et vérifie qu'un seuil à 70 000 n'est pas franchi.

## Cloisonnement

Même motif qu'aux lots précédents : la création d'une alerte ciblant un actif passe par un `INSERT ... SELECT ... WHERE a.utilisateur_id = $1`, qui n'insère rien si l'actif ne lui appartient pas. La désactivation filtre sur `(id, utilisateur_id)`. Dans les deux cas, l'absence de ligne est traduite en **404 et non 403** (D52).

## Validation

La contrainte croisée du schéma est reprise à la validation : `actif_id` est obligatoire si et seulement si la cible est un actif, avec un message explicite dans les deux sens. Détecter le cas en amont évite d'exposer une erreur de contrainte PostgreSQL brute.

Seule la désactivation est exposée. La réactivation d'une alerte déclenchée poserait la question de sa date de premier franchissement : le cas n'est pas au périmètre et l'API ne l'ouvre pas plutôt que de laisser passer un comportement non défini.

## Effet de bord, jamais le service rendu

Comme l'historisation du lot D, l'évaluation est enveloppée : son échec est journalisé et la réponse part quand même. Le marquage des alertes franchies se fait en une seule requête groupée, filtrée sur le propriétaire et sur le statut `active`, ce qui protège la date de déclenchement déjà posée.

## Vérification

159 tests unitaires au vert, dont 34 pour ce lot, sans base ni cours réels.

Vérifié en conditions réelles sur la base amorcée : les deux alertes du seed listées, l'alerte de capital total franchie au chargement du portefeuille (58 685,68 pour un seuil de 45 000) et passée à `declenchee` en base avec sa date, **date inchangée au second chargement**, 404 sur un actif d'autrui, 400 explicites sur les deux violations de la contrainte croisée, désactivation effective et réactivation refusée, et la démonstration complète d'un seuil volontairement franchissable sur le bitcoin.

## Liste de contrôle

- [x] Cloisonnement porte par le SQL, 404 et non 403
- [x] Evaluation en fonction pure, testable sans base
- [x] Comparaisons en arithmetique exacte, aucun flottant
- [x] Aucune tache planifiee ni worker
- [x] L'evaluation ne peut pas faire echouer la lecture du portefeuille
- [x] Tests unitaires au vert
- [x] Messages de commit conformes a docs/convention-commits.md
