### PR TITLE
fix(back): activation des comptes et refus de connexion désactivée

### DIFF
--- a/backend/db/README.md
+++ b/backend/db/README.md
@@ -1,0 +1,53 @@
+# Base de données
+
+Trois éléments, aux rôles distincts.
+
+| Fichier | Rôle |
+|---|---|
+| `schema.sql` | état courant du schéma, à exécuter sur une base vide |
+| `seed.sql` | jeu de données de démonstration, idempotent, rejouable |
+| `migrations/` | évolutions du schéma survenues après sa première mise en service |
+
+## Convention de migration
+
+Tant que la base n'existait que sur le poste de développement, la faire évoluer revenait
+à rejouer `schema.sql`, qui commence par supprimer les tables. Cette facilité disparaît
+dès qu'une base contient des données à conserver : il faut alors décrire la modification
+plutôt que reconstruire l'ensemble.
+
+Chaque évolution du schéma donne donc lieu à deux écritures :
+
+1. `schema.sql` est mis à jour pour refléter l'état courant. Une base créée à partir de
+   zéro doit toujours obtenir la structure la plus récente en une seule exécution.
+2. Un fichier est ajouté dans `migrations/`, nommé `AAAA-MM-JJ_objet.sql`, contenant la
+   modification incrémentale correspondante. Il permet de faire évoluer une base déjà
+   peuplée sans perdre ses données.
+
+Les deux chemins mènent à la même structure : c'est la condition pour qu'une base créée
+la semaine dernière et une base créée aujourd'hui se comportent de la même façon.
+
+Les migrations sont écrites de façon rejouable, au moyen de clauses telles que
+`IF NOT EXISTS`. Exécuter deux fois la même migration ne doit produire ni erreur ni
+double effet, pour la même raison qui rend `seed.sql` idempotent : on doit pouvoir
+relancer sans réfléchir à ce qui a déjà été appliqué.
+
+Elles sont conservées après application. Elles constituent l'historique des décisions
+prises sur le modèle de données, au même titre que l'historique des commits pour le code.
+
+## Ordre d'exécution sur une base neuve
+
+```bash
+psql -d capitall -f backend/db/schema.sql
+psql -d capitall -f backend/db/seed.sql
+```
+
+Les migrations n'ont pas à être rejouées dans ce cas : `schema.sql` les intègre déjà.
+
+## Sur une base existante
+
+```bash
+psql -d capitall -f backend/db/migrations/2026-08-06_activation-compte.sql
+```
+
+Un rôle propriétaire est nécessaire : le rôle applicatif `capitall_app` est volontairement
+limité aux opérations de lecture et d'écriture, sans droit de modification du schéma.

--- a/backend/db/migrations/2026-08-06_activation-compte.sql
+++ b/backend/db/migrations/2026-08-06_activation-compte.sql
@@ -1,0 +1,22 @@
+-- Migration : activation des comptes utilisateurs
+-- Date : 06/08/2026
+--
+-- Ajoute la colonne permettant de désactiver un compte sans supprimer de données.
+-- Un compte désactivé ne peut plus se connecter ; l'opération est réversible.
+--
+-- Le modèle ne comportait aucun moyen de représenter cette désactivation, alors que
+-- le rôle d'administration prévoit de la déclencher. La désactivation logique a été
+-- préférée à une suppression : elle conserve l'historique des transactions, dont
+-- dépendent tous les calculs de prix de revient.
+--
+-- À exécuter sur une base existante, avec un rôle propriétaire :
+--   psql -d capitall -f backend/db/migrations/2026-08-06_activation-compte.sql
+--
+-- Les bases créées après cette date à partir de schema.sql comportent déjà la colonne :
+-- IF NOT EXISTS rend cette migration sans effet dans ce cas, et rejouable sans risque.
+
+ALTER TABLE utilisateur
+    ADD COLUMN IF NOT EXISTS actif BOOLEAN NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN utilisateur.actif IS
+    'Faux si le compte est désactivé : la connexion est alors refusée, sans suppression de données.';

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -16,6 +16,9 @@ CREATE TABLE utilisateur (
     mot_de_passe_hache  VARCHAR(255) NOT NULL,
     pseudo              VARCHAR(100) NOT NULL,
     role                VARCHAR(20) NOT NULL DEFAULT 'utilisateur' CHECK (role IN ('utilisateur', 'admin')),
+    -- Désactivation logique d'un compte : la connexion est refusée, mais aucune donnée
+    -- n'est supprimée et l'opération reste réversible. Un compte est actif à la création.
+    actif               BOOLEAN NOT NULL DEFAULT true,
     date_inscription    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/backend/db/seed.sql
+++ b/backend/db/seed.sql
@@ -7,8 +7,9 @@
 -- être rejoué autant que nécessaire pour repartir d'un état propre.
 --
 -- Comptes de démonstration (mots de passe destinés au développement uniquement) :
---   admin@capitall.fr  / Admin1234!   (rôle admin)
---   user@capitall.fr   / User1234!    (rôle utilisateur, porteur du portefeuille)
+--   admin@capitall.fr    / Admin1234!    (rôle admin)
+--   user@capitall.fr     / User1234!     (rôle utilisateur, porteur du portefeuille)
+--   suspendu@capitall.fr / Suspendu1234! (compte désactivé : la connexion est refusée)
 
 -- pgcrypto fournit crypt() et gen_salt() : le hachage bcrypt est réellement calculé
 -- en base, avec le même algorithme ($2a$, coût 10) que celui utilisé côté serveur.
@@ -20,9 +21,13 @@ TRUNCATE TABLE annonce, snapshot_valorisation, alerte, transaction, actif, utili
     RESTART IDENTITY CASCADE;
 
 -- Utilisateurs. Le rôle est fixé ici (jamais via une entrée applicative, D23).
-INSERT INTO utilisateur (email, mot_de_passe_hache, pseudo, role) VALUES
-    ('admin@capitall.fr', crypt('Admin1234!', gen_salt('bf', 10)), 'Administrateur CapitAll', 'admin'),
-    ('user@capitall.fr',  crypt('User1234!',  gen_salt('bf', 10)), 'Camille Durand',          'utilisateur');
+--
+-- Le troisième compte est volontairement désactivé : il rend le refus de connexion
+-- démontrable sans avoir à modifier la base à la main avant chaque vérification.
+INSERT INTO utilisateur (email, mot_de_passe_hache, pseudo, role, actif) VALUES
+    ('admin@capitall.fr',    crypt('Admin1234!',    gen_salt('bf', 10)), 'Administrateur CapitAll', 'admin',       true),
+    ('user@capitall.fr',     crypt('User1234!',     gen_salt('bf', 10)), 'Camille Durand',          'utilisateur', true),
+    ('suspendu@capitall.fr', crypt('Suspendu1234!', gen_salt('bf', 10)), 'Compte suspendu',         'utilisateur', false);
 
 -- Actifs suivis par le compte utilisateur, couvrant les quatre classes.
 INSERT INTO actif (utilisateur_id, type, symbole, nom)

--- a/backend/src/models/utilisateur.js
+++ b/backend/src/models/utilisateur.js
@@ -6,7 +6,7 @@
 
 const { query } = require('../db');
 
-const CHAMPS_PUBLICS = 'id, email, pseudo, role, date_inscription';
+const CHAMPS_PUBLICS = 'id, email, pseudo, role, actif, date_inscription';
 
 // La colonne role n'est jamais alimentée depuis une entrée utilisateur (D23) :
 // elle prend la valeur par défaut du schéma, donc 'utilisateur'.

--- a/backend/src/services/__tests__/authentification.test.js
+++ b/backend/src/services/__tests__/authentification.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import bcrypt from 'bcrypt';
+
+// Le modèle est fourni au service sous forme de doublure : ces tests portent sur les
+// règles métier, pas sur l'accès aux données, et n'ont donc besoin d'aucune base.
+const modeleFactice = {
+  trouverParEmail: vi.fn(),
+  creerUtilisateur: vi.fn(),
+  trouverParId: vi.fn(),
+};
+
+const MOT_DE_PASSE = 'motdepasse-solide';
+
+let connecter;
+let hachage;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = 'postgresql://utilisateur:secret@localhost:5432/capitall';
+  process.env.JWT_SECRET = 'e'.repeat(32);
+  const { creerServiceAuthentification } = await import('../authentification.js');
+  ({ connecter } = creerServiceAuthentification({ utilisateurs: modeleFactice }));
+  // Haché une seule fois : bcrypt au coût 10 est volontairement lent.
+  hachage = await bcrypt.hash(MOT_DE_PASSE, 10);
+});
+
+function compte({ actif = true } = {}) {
+  return {
+    id: 2,
+    email: 'camille@example.fr',
+    pseudo: 'Camille',
+    role: 'utilisateur',
+    actif,
+    mot_de_passe_hache: hachage,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('connexion', () => {
+  it('émet un jeton pour un compte actif', async () => {
+    modeleFactice.trouverParEmail.mockResolvedValue(compte());
+
+    const resultat = await connecter({ email: 'camille@example.fr', motDePasse: MOT_DE_PASSE });
+
+    expect(resultat.token).toBeTruthy();
+    expect(resultat.utilisateur.email).toBe('camille@example.fr');
+  });
+
+  it('ne renvoie jamais le hachage du mot de passe', async () => {
+    modeleFactice.trouverParEmail.mockResolvedValue(compte());
+
+    const resultat = await connecter({ email: 'camille@example.fr', motDePasse: MOT_DE_PASSE });
+
+    expect(resultat.utilisateur.mot_de_passe_hache).toBeUndefined();
+  });
+});
+
+describe('compte désactivé', () => {
+  it('refuse la connexion même avec les bons identifiants', async () => {
+    modeleFactice.trouverParEmail.mockResolvedValue(compte({ actif: false }));
+
+    await expect(
+      connecter({ email: 'camille@example.fr', motDePasse: MOT_DE_PASSE })
+    ).rejects.toThrow(/désactivé/i);
+  });
+
+  // 403 et non 401 : l'identité est établie, c'est l'accès qui est refusé.
+  it('rend le statut 403', async () => {
+    modeleFactice.trouverParEmail.mockResolvedValue(compte({ actif: false }));
+
+    try {
+      await connecter({ email: 'camille@example.fr', motDePasse: MOT_DE_PASSE });
+      throw new Error('une erreur était attendue');
+    } catch (erreur) {
+      expect(erreur.statut).toBe(403);
+    }
+  });
+
+  // Le contrôle du compte désactivé se fait après la comparaison de mot de passe :
+  // un mauvais mot de passe sur un compte désactivé doit donc produire l'échec
+  // générique, et surtout ne pas révéler que ce compte existe.
+  it("garde le message générique lorsque le mot de passe est faux sur un compte désactivé", async () => {
+    modeleFactice.trouverParEmail.mockResolvedValue(compte({ actif: false }));
+
+    await expect(
+      connecter({ email: 'camille@example.fr', motDePasse: 'mauvais-mot-de-passe' })
+    ).rejects.toThrow(/incorrect/i);
+  });
+});
+
+describe("protection contre l'énumération des comptes", () => {
+  async function messageEchec(identifiants) {
+    try {
+      await connecter(identifiants);
+      throw new Error('une erreur était attendue');
+    } catch (erreur) {
+      return erreur.message;
+    }
+  }
+
+  // Non-régression du comportement le plus important de cette fonction : les deux
+  // causes d'échec doivent être indiscernables, faute de quoi il devient possible de
+  // découvrir quelles adresses correspondent à un compte.
+  it('rend un message rigoureusement identique sur adresse inconnue et sur mot de passe incorrect', async () => {
+    modeleFactice.trouverParEmail.mockResolvedValue(null);
+    const messageInconnu = await messageEchec({
+      email: 'inconnu@example.fr',
+      motDePasse: MOT_DE_PASSE,
+    });
+
+    modeleFactice.trouverParEmail.mockResolvedValue(compte());
+    const messageMauvaisMotDePasse = await messageEchec({
+      email: 'camille@example.fr',
+      motDePasse: 'mauvais-mot-de-passe',
+    });
+
+    expect(messageInconnu).toBe(messageMauvaisMotDePasse);
+  });
+
+  it('rend le statut 401 dans les deux cas', async () => {
+    modeleFactice.trouverParEmail.mockResolvedValue(null);
+    await expect(connecter({ email: 'x@y.fr', motDePasse: MOT_DE_PASSE })).rejects.toMatchObject({
+      statut: 401,
+    });
+
+    modeleFactice.trouverParEmail.mockResolvedValue(compte());
+    await expect(
+      connecter({ email: 'camille@example.fr', motDePasse: 'faux' })
+    ).rejects.toMatchObject({ statut: 401 });
+  });
+
+  // La comparaison bcrypt doit avoir lieu même sur une adresse inconnue : sans elle,
+  // la réponse serait immédiate et l'écart de temps trahirait l'absence de compte.
+  it('compare un hachage même lorsque le compte est introuvable', async () => {
+    const comparer = vi.spyOn(bcrypt, 'compare');
+    modeleFactice.trouverParEmail.mockResolvedValue(null);
+
+    await expect(
+      connecter({ email: 'inconnu@example.fr', motDePasse: MOT_DE_PASSE })
+    ).rejects.toThrow();
+
+    expect(comparer).toHaveBeenCalledTimes(1);
+    comparer.mockRestore();
+  });
+});

--- a/backend/src/services/authentification.js
+++ b/backend/src/services/authentification.js
@@ -5,7 +5,7 @@ const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 const config = require('../config');
 const modeleUtilisateur = require('../models/utilisateur');
-const { ErreurConflit, ErreurAuthentification } = require('../erreurs');
+const { ErreurConflit, ErreurAuthentification, ErreurAutorisation } = require('../erreurs');
 
 const COUT_HACHAGE = 10;
 
@@ -14,65 +14,94 @@ const CODE_VIOLATION_UNICITE = '23505';
 
 const LONGUEUR_MAXIMALE_PSEUDO = 100;
 
+// Hachage neutre, servant de comparaison de repli quand l'email est inconnu.
+// Sans lui, une réponse immédiate sur email inexistant et une réponse retardée par
+// bcrypt sur email existant permettraient de déterminer quels comptes existent.
+// Calculé une seule fois au chargement du module : bcrypt est volontairement lent.
+const HACHAGE_FACTICE = bcrypt.hashSync('comparaison-a-temps-constant', COUT_HACHAGE);
+
+const MESSAGE_ECHEC = 'Email ou mot de passe incorrect.';
+
 // Le pseudo est facultatif à l'inscription alors que la colonne est obligatoire :
 // à défaut, on reprend la partie locale de l'email.
 function pseudoParDefaut(email) {
   return email.split('@')[0].slice(0, LONGUEUR_MAXIMALE_PSEUDO);
 }
 
-async function inscrire({ email, motDePasse, pseudo }) {
-  const motDePasseHache = await bcrypt.hash(motDePasse, COUT_HACHAGE);
+// Le modèle est reçu en paramètre, comme dans les services de portefeuille et de cours :
+// le service s'exécute alors sans base dans les tests, avec le code de production.
+function creerServiceAuthentification({ utilisateurs = modeleUtilisateur } = {}) {
+  async function inscrire({ email, motDePasse, pseudo }) {
+    const motDePasseHache = await bcrypt.hash(motDePasse, COUT_HACHAGE);
 
-  try {
-    return await modeleUtilisateur.creerUtilisateur({
-      email,
-      motDePasseHache,
-      pseudo: pseudo || pseudoParDefaut(email),
-    });
-  } catch (erreur) {
-    // Deux inscriptions simultanées sur le même email passeraient toutes deux un
-    // contrôle préalable en lecture : c'est la contrainte d'unicité de la base qui
-    // fait foi, et sa violation est traduite ici en erreur métier.
-    if (erreur.code === CODE_VIOLATION_UNICITE) {
-      throw new ErreurConflit('Cet email est déjà utilisé.');
+    try {
+      return await utilisateurs.creerUtilisateur({
+        email,
+        motDePasseHache,
+        pseudo: pseudo || pseudoParDefaut(email),
+      });
+    } catch (erreur) {
+      // Deux inscriptions simultanées sur le même email passeraient toutes deux un
+      // contrôle préalable en lecture : c'est la contrainte d'unicité de la base qui
+      // fait foi, et sa violation est traduite ici en erreur métier.
+      if (erreur.code === CODE_VIOLATION_UNICITE) {
+        throw new ErreurConflit('Cet email est déjà utilisé.');
+      }
+      throw erreur;
     }
-    throw erreur;
-  }
-}
-
-// Hachage neutre, servant de comparaison de repli quand l'email est inconnu.
-// Sans lui, une réponse immédiate sur email inexistant et une réponse retardée par
-// bcrypt sur email existant permettraient de déterminer quels comptes existent.
-const HACHAGE_FACTICE = bcrypt.hashSync('comparaison-a-temps-constant', COUT_HACHAGE);
-
-const MESSAGE_ECHEC = 'Email ou mot de passe incorrect.';
-
-async function connecter({ email, motDePasse }) {
-  const utilisateur = await modeleUtilisateur.trouverParEmail(email);
-  const hachageAComparer = utilisateur ? utilisateur.mot_de_passe_hache : HACHAGE_FACTICE;
-
-  const motDePasseValide = await bcrypt.compare(motDePasse, hachageAComparer);
-
-  // Un seul message pour les deux causes d'échec : rien n'indique si c'est l'email
-  // ou le mot de passe qui est en cause.
-  if (!utilisateur || !motDePasseValide) {
-    throw new ErreurAuthentification(MESSAGE_ECHEC);
   }
 
-  const token = jwt.sign({ sub: utilisateur.id, role: utilisateur.role }, config.jwtSecret, {
-    algorithm: 'HS256',
-    expiresIn: config.jwtExpiration,
-  });
+  async function connecter({ email, motDePasse }) {
+    const utilisateur = await utilisateurs.trouverParEmail(email);
+    const hachageAComparer = utilisateur ? utilisateur.mot_de_passe_hache : HACHAGE_FACTICE;
 
-  return {
-    token,
-    utilisateur: {
-      id: utilisateur.id,
-      email: utilisateur.email,
-      pseudo: utilisateur.pseudo,
-      role: utilisateur.role,
-    },
-  };
+    const motDePasseValide = await bcrypt.compare(motDePasse, hachageAComparer);
+
+    // Un seul message pour les deux causes d'échec : rien n'indique si c'est l'email
+    // ou le mot de passe qui est en cause.
+    if (!utilisateur || !motDePasseValide) {
+      throw new ErreurAuthentification(MESSAGE_ECHEC);
+    }
+
+    // Le contrôle du compte désactivé vient volontairement APRÈS la comparaison de mot
+    // de passe. Placé avant, il court-circuiterait bcrypt et rendrait la réponse sur un
+    // compte désactivé plus rapide que sur un compte actif : l'écart de temps
+    // permettrait de découvrir quels comptes existent, soit exactement la fuite que le
+    // hachage factice ci-dessus neutralise.
+    //
+    // À ce stade les identifiants sont reconnus valides : la personne a prouvé qu'elle
+    // possède le compte, et lui dire qu'il est désactivé ne lui apprend rien qu'elle
+    // ignore. Un message distinct est donc préférable ici, un échec générique la
+    // laisserait chercher une faute de saisie inexistante. Le statut 403 traduit la
+    // situation : l'identité est établie, c'est l'accès qui est refusé.
+    if (!utilisateur.actif) {
+      throw new ErreurAutorisation('Ce compte a été désactivé.');
+    }
+
+    const token = jwt.sign({ sub: utilisateur.id, role: utilisateur.role }, config.jwtSecret, {
+      algorithm: 'HS256',
+      expiresIn: config.jwtExpiration,
+    });
+
+    return {
+      token,
+      utilisateur: {
+        id: utilisateur.id,
+        email: utilisateur.email,
+        pseudo: utilisateur.pseudo,
+        role: utilisateur.role,
+      },
+    };
+  }
+
+  return { inscrire, connecter };
 }
 
-module.exports = { inscrire, connecter };
+// Instance par défaut, utilisée par les contrôleurs : leur code reste inchangé.
+const service = creerServiceAuthentification();
+
+module.exports = {
+  creerServiceAuthentification,
+  inscrire: service.inscrire,
+  connecter: service.connecter,
+};

--- a/docs/cahier-des-charges.md
+++ b/docs/cahier-des-charges.md
@@ -130,7 +130,7 @@ Un périmètre se définit autant par ce qu'il exclut que par ce qu'il inclut.
 ### 4.7 Administration
 
 - En tant qu'administrateur, je veux publier, modifier, épingler et supprimer des annonces, afin de communiquer avec les utilisateurs. Contraintes : titre et contenu obligatoires, action réservée au rôle d'administration.
-- En tant qu'administrateur, je veux lister les comptes et désactiver un compte en cas d'abus, afin d'assurer la gestion du service. Contraintes : aucune donnée patrimoniale n'est visible dans cette liste ; la désactivation est logique et réversible, elle ne supprime aucune donnée et empêche seulement la connexion (D60).
+- En tant qu'administrateur, je veux lister les comptes et désactiver un compte en cas d'abus, afin d'assurer la gestion du service. Contraintes : aucune donnée patrimoniale n'est visible dans cette liste ; la désactivation est logique et réversible, elle ne supprime aucune donnée et empêche seulement la connexion (D60). Le refus intervient après la vérification du mot de passe, afin de ne pas révéler par un temps de réponse plus court qu'un compte existe.
 
 ### 4.8 Règles de gestion
 
@@ -150,6 +150,7 @@ Ces règles s'appliquent en toute circonstance et sont vérifiées côté serveu
 | RG10 | Un seuil est franchi de manière inclusive : atteindre le seuil suffit à déclencher l'alerte | alertes |
 | RG11 | Une alerte déjà déclenchée n'est plus réévaluée, et une alerte dont le cours est indisponible n'est pas évaluée | alertes |
 | RG12 | Le rôle d'un compte n'est accepté dans aucune entrée utilisateur | sécurité |
+| RG13 | Un compte désactivé ne peut plus se connecter ; la désactivation est réversible et ne supprime aucune donnée | comptes |
 
 La règle RG3 ne peut pas être exprimée par une contrainte de base de données : elle porte sur la somme de plusieurs lignes et non sur une ligne isolée. Elle est donc vérifiée dans la couche métier. Cette distinction entre ce que le modèle relationnel garantit et ce qui relève de l'application est assumée et documentée.
 
@@ -331,7 +332,7 @@ Le produit est considéré comme conforme si l'ensemble des critères suivants e
 | C3 | Aucun utilisateur n'accède à une donnée d'un autre, y compris en interrogeant directement l'interface de programmation | appels forgés avec le jeton d'un second compte |
 | C4 | L'application reste utilisable lorsqu'un fournisseur de cours est indisponible | fournisseur simulé en échec, puis panne réelle constatée |
 | C5 | L'application reste utilisable lorsque le cache est arrêté | service de cache stoppé puis redémarré |
-| C6 | Les règles de gestion RG1 à RG12 sont toutes vérifiées côté serveur | tests unitaires et appels de contrôle |
+| C6 | Les règles de gestion RG1 à RG13 sont toutes vérifiées côté serveur | tests unitaires et appels de contrôle |
 | C7 | Les contrastes atteignent le seuil requis et aucune information n'est portée par la seule couleur | mesure par outil dédié, capture à l'appui |
 | C8 | L'ensemble se déploie sur une machine vierge à partir du dépôt et de la documentation | installation complète suivie pas à pas |
 
@@ -350,7 +351,7 @@ Correspondance entre les besoins exprimés, les moyens techniques et les compét
 | Suivre l'évolution dans le temps | historique | RG8 | CP5, CP7 |
 | Être averti au franchissement d'un seuil | alertes | RG9, RG10, RG11 | CP7 |
 | Être informé des évolutions du service | annonces | aucune | CP3, CP7 |
-| Administrer le service sans accéder aux données patrimoniales | administration | RG1, RG12 | CP7 |
+| Administrer le service sans accéder aux données patrimoniales | administration | RG1, RG12, RG13 | CP7 |
 | Consulter depuis un mobile | interface complète | aucune | CP2, CP3, CP4 |
 | Installer et redéployer l'application | composition de services et documentation | aucune | CP1, CP8 |
 

--- a/docs/conception/modele-de-donnees.md
+++ b/docs/conception/modele-de-donnees.md
@@ -2,7 +2,7 @@
 
 ## Modèle conceptuel de données (MCD, formalisme Merise)
 
-Six entités couvrent le périmètre du MVP. Les trois premières (utilisateur, actif, transaction) forment le socle initial. Deux entités complémentaires ont été ajoutées le 14/07/2026 (D15, D16) pour les alertes de seuil et l'historique de valorisation, puis une sixième le 16/07/2026 (D22) pour les annonces internes publiées par l'administrateur. La même date, le type d'actif `action` a été ajouté (D20, réintégration de la bourse au MVP) et la colonne `role` sur l'utilisateur (D23).
+Six entités couvrent le périmètre du MVP. Les trois premières (utilisateur, actif, transaction) forment le socle initial. Deux entités complémentaires ont été ajoutées le 14/07/2026 (D15, D16) pour les alertes de seuil et l'historique de valorisation, puis une sixième le 16/07/2026 (D22) pour les annonces internes publiées par l'administrateur. La même date, le type d'actif `action` a été ajouté (D20, réintégration de la bourse au MVP) et la colonne `role` sur l'utilisateur (D23). Le 06/08/2026, la colonne `actif` a complété l'utilisateur (D60), le modèle ne permettant jusque-là pas de représenter la désactivation d'un compte que le rôle d'administration prévoit pourtant de déclencher.
 
 ### Entités
 
@@ -12,6 +12,7 @@ Six entités couvrent le périmètre du MVP. Les trois premières (utilisateur, 
 - mot_de_passe (haché, jamais stocké en clair)
 - pseudo
 - role (utilisateur / admin)
+- actif (le compte est-il utilisable)
 - date_inscription
 
 **ACTIF**
@@ -79,7 +80,7 @@ Notation relationnelle, clés primaires soulignées par convention # , clés ét
 ```
 utilisateur (#id, email UNIQUE NOT NULL, mot_de_passe_hache NOT NULL,
              pseudo NOT NULL, role NOT NULL DEFAULT 'utilisateur',
-             date_inscription NOT NULL)
+             actif NOT NULL DEFAULT true, date_inscription NOT NULL)
 
 actif (#id, ->utilisateur_id NOT NULL, type NOT NULL, symbole NOT NULL,
        nom NOT NULL, date_ajout NOT NULL,
@@ -105,6 +106,7 @@ Contraintes de domaine prévues pour le MPD (PostgreSQL) :
 
 - `type` restreint à ('crypto', 'devise', 'metal', 'action') par contrainte CHECK
 - `role` restreint à ('utilisateur', 'admin') par contrainte CHECK, défaut 'utilisateur'
+- `actif` booléen non nul, défaut `true` : un compte est utilisable dès sa création
 - `sens` restreint à ('achat', 'vente') par contrainte CHECK
 - `type_cible` restreint à ('actif', 'capital_total') par contrainte CHECK
 - `sens_seuil` restreint à ('au_dessus', 'en_dessous') par contrainte CHECK
@@ -135,6 +137,7 @@ erDiagram
         string mot_de_passe_hache
         string pseudo
         string role
+        boolean actif
         timestamp date_inscription
     }
     ACTIF {


### PR DESCRIPTION
Closes #93

Applique D60, actée le 30/07 et jamais implémentée : la table `utilisateur` ne comportait aucun moyen de représenter une désactivation, alors que le cahier des charges expose `PATCH /api/admin/comptes/:id` et que D23 fonde en partie le rôle d'administration sur cette capacité.

## Ordre des contrôles à la connexion

Le point délicat du lot. La fonction de connexion neutralise l'énumération de comptes par une comparaison bcrypt systématique, avec un hachage factice lorsque l'adresse est inconnue.

Le contrôle du compte désactivé intervient **après** cette comparaison, jamais avant. Placé avant, il court-circuiterait bcrypt et rendrait la réponse sur un compte désactivé nettement plus rapide que sur un compte actif : l'écart de temps permettrait de découvrir quels comptes existent, soit exactement la fuite que le hachage factice neutralise.

Une fois les identifiants reconnus valides, la personne a prouvé qu'elle possède le compte : un message distinct devient légitime et préférable, un échec générique la laisserait chercher une faute de saisie inexistante. Le statut retenu est **403** et non 401 : l'identité est établie, c'est l'accès qui est refusé.

Mesures relevées en conditions réelles, cinq appels par cas :

| Cas | Temps moyen |
|---|---|
| adresse inconnue, mot de passe faux | 115 ms |
| compte actif, mot de passe faux | 119 ms |
| compte désactivé, mot de passe faux | 99 ms |
| compte désactivé, mot de passe correct | 124 ms |

Tous les cas passent par bcrypt et restent dans le même ordre de grandeur. Un contrôle placé avant la comparaison ferait tomber le troisième cas à quelques millisecondes.

## Convention de migration

Le projet ne disposait que de `schema.sql` et `seed.sql` : faire évoluer la base revenait à tout reconstruire, ce qui cesse d'être acceptable dès qu'elle contient des données à conserver. Une convention est établie et documentée dans `backend/db/README.md` : `schema.sql` reflète l'état courant, `migrations/` conserve les évolutions incrémentales sous la forme `AAAA-MM-JJ_objet.sql`, et les deux chemins mènent à la même structure.

La migration est écrite de façon rejouable (`ADD COLUMN IF NOT EXISTS`), pour la même raison qui rend le jeu de données idempotent.

## Vérifications

167 tests au vert côté serveur, dont huit nouveaux sur le service d'authentification, et trois exécutions consécutives pour écarter toute instabilité. Les 159 tests antérieurs sont inchangés.

Vérifié contre une base réelle :
- schéma et jeu de données chargés sur base neuve, trois comptes dont un désactivé ;
- jeu de données rejoué : toujours trois comptes, un désactivé, idempotence préservée ;
- migration appliquée deux fois sur une base déjà à jour : sans effet ni erreur ;
- **migration appliquée sur une base dépourvue de la colonne** : colonne rétablie, données préservées, comptes existants actifs par défaut ;
- connexion : 200 sur compte actif, 403 avec message distinct sur compte désactivé, 401 générique identique sur mot de passe faux et sur adresse inconnue.

Le service d'authentification devient une fabrique recevant son modèle en paramètre, à l'image des services de portefeuille et de cours : c'était la condition pour le tester sans base. Les contrôleurs sont inchangés, l'instance par défaut étant exportée comme auparavant.

## Hors périmètre

La route `PATCH /api/admin/comptes/:id` n'est pas implémentée : elle relève de l'espace d'administration prévu en S4 (issue #48). Ce lot fournit la capacité, pas son point d'entrée.

## Liste de contrôle

- [x] Colonne au schema, migration datee et rejouable
- [x] Jeu de donnees idempotent, compte desactive inclus
- [x] Controle place apres la comparaison bcrypt, commente dans le code
- [x] Message d'echec identique entre adresse inconnue et mot de passe incorrect
- [x] Tests au vert, sans regression
- [x] Documentation du modele et du cahier des charges a jour
