### PR TITLE
feat(front): socle de l'interface et parcours d'authentification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,212 @@
 # CapitAll
 
-Application web mobile-first de suivi de patrimoine multi-actifs : cryptomonnaies, devises étrangères, métaux précieux et une sélection d'actions américaines.
+Application web de suivi de patrimoine multi-actifs, conçue pour le mobile en premier lieu. Elle réunit sur un même tableau de bord des cryptomonnaies, des devises étrangères, des métaux précieux et une sélection d'actions américaines.
 
-CapitAll centralise les actifs suivis par l'utilisateur, enregistre ses transactions d'achat et de vente, récupère automatiquement les cours auprès d'API publiques et calcule le prix de revient moyen pondéré (PRU), la plus-value latente et la plus-value réalisée, par actif et sur l'ensemble du portefeuille. Le tout est présenté dans un tableau de bord consolidé, calculé en euros et affichable en euro ou en dollar.
+CapitAll enregistre les transactions d'achat et de vente de l'utilisateur, récupère automatiquement les cours auprès de fournisseurs publics, puis calcule le prix de revient moyen pondéré, la plus-value latente et la plus-value réalisée, actif par actif et sur l'ensemble du portefeuille. L'objectif est de remplacer le tableur que tiennent à la main la plupart des épargnants diversifiés, avec des cours recopiés au gré des connexions et des calculs approximatifs.
 
-Projet réalisé dans le cadre du Titre Professionnel Développeur Web et Web Mobile (DWWM, niveau 5).
+Projet réalisé dans le cadre du titre professionnel Développeur Web et Web Mobile, niveau 5.
+
+## Aperçu
+
+<!-- Captures à insérer en fin de développement : tableau de bord desktop, tableau de bord mobile, détail d'un actif. Dossier docs/images/. -->
+
+*Captures d'écran ajoutées à la finalisation de l'interface.*
 
 ## Fonctionnalités
 
-- inscription et connexion sécurisées (JWT, bcrypt), cloisonnement strict des données par utilisateur
-- gestion des actifs suivis sur quatre classes : crypto, devise, métal précieux, action
-- enregistrement des transactions d'achat et de vente
-- calcul automatique du PRU, de la plus-value latente et de la plus-value réalisée
-- tableau de bord consolidé : valeur totale, répartition, courbe d'évolution, bascule d'affichage euro/dollar
-- alertes de seuil (sur un actif ou sur le capital total)
-- historique de valorisation journalière du portefeuille
-- annonces internes publiées par l'administrateur
+**Portefeuille**
+
+- suivi d'actifs sur quatre classes : cryptomonnaie, devise, métal précieux, action
+- enregistrement des achats et des ventes, avec quantité, prix unitaire, frais et date
+- calcul du prix de revient moyen pondéré, frais d'achat inclus
+- distinction entre plus-value latente, sur ce qui est encore détenu, et plus-value réalisée, effectivement encaissée lors d'une vente
+- tableau de bord consolidé : valeur totale, coût de revient, répartition par classe d'actif, courbe d'évolution
+- affichage au choix en euro ou en dollar, sans recalcul ni appel supplémentaire
+
+**Cours**
+
+- récupération automatique auprès de fournisseurs publics, interrogés exclusivement côté serveur
+- mise en cache avec des durées de vie adaptées à chaque classe d'actif
+- repli sur le dernier cours connu lorsqu'un fournisseur est indisponible, signalé comme tel avec sa date
+
+**Suivi**
+
+- alertes de seuil sur le cours d'un actif ou sur le capital total, évaluées automatiquement
+- historique de valorisation journalier, alimenté à la première consultation de chaque jour
+- fil d'annonces internes publiées par l'administration
+
+**Sécurité**
+
+- authentification par jeton, mots de passe hachés
+- cloisonnement strict des données par utilisateur, appliqué au niveau des requêtes de base de données
+- trois niveaux de contrôle d'accès : authentification, propriété de la ressource, rôle
+
+## Architecture
+
+```
+Navigateur (React 18 + Vite)
+        |  requêtes JSON, jeton dans l'en-tête Authorization
+        v
+API REST (Node.js + Express)
+   routes -> intergiciels -> contrôleurs -> services -> modèles
+        |                          |                        |
+        v                          v                        v
+   PostgreSQL 16                Redis 7            Fournisseurs de cours
+   données persistantes      cache des cours    (Coinbase, Frankfurter,
+                                                  gold-api, FMP)
+```
+
+Les fournisseurs de cours ne sont jamais appelés depuis le navigateur. Chacun est encapsulé dans un adaptateur exposant une interface commune : la logique métier ignore lequel a répondu, et ajouter une classe d'actifs revient à écrire un adaptateur.
+
+Description détaillée : [architecture](docs/conception/architecture.md).
 
 ## Stack technique
 
-| Brique | Choix |
-|---|---|
-| Front-end | React 18 + Vite, react-router (SPA mobile-first) |
-| Back-end | Node.js + Express (API REST en couches) |
-| Base de données | PostgreSQL (montants en NUMERIC) |
-| Cache | Redis (cache court des cours externes) |
-| Authentification | JWT + bcrypt |
-| Déploiement | Docker + docker-compose |
-
-Les cours sont récupérés exclusivement côté serveur, via des adaptateurs interchangeables par fournisseur (Coinbase, Frankfurter, gold-api.com, FMP). Les clés d'API résident dans un fichier `.env` non versionné.
+| Brique | Choix | Version |
+|---|---|---|
+| Interface | React, Vite, React Router | React 18 |
+| Serveur | Node.js, Express | Node 20 |
+| Base de données | PostgreSQL | 16 |
+| Cache | Redis | 7 |
+| Authentification | jsonwebtoken, bcrypt | jeton HS256, validité 2 h |
+| Validation | Zod | schémas partagés serveur et interface |
+| Graphiques | Recharts | anneau et courbe d'aire |
+| Tests | Vitest | tests unitaires des services, adaptateurs et validations |
+| Conteneurisation | Docker, Docker Compose | services de développement |
 
 ## Structure du dépôt
 
 ```
-backend/    API Express, schéma SQL, services métier
-frontend/   application React (Vite + React 18)
-docs/       cadrage, cahier des charges, conception, planning, conventions
+backend/
+  db/            schéma SQL et jeu de données de démonstration
+  src/
+    adaptateurs/ fournisseurs de cours, derrière une interface commune
+    cache/       client Redis résilient
+    config/      chargement et contrôle de la configuration
+    controllers/ lecture de la requête, code de statut, forme de la réponse
+    db/          groupe de connexions et requêtes paramétrées
+    middlewares/ authentification, rôle, validation, gestion des erreurs
+    models/      accès aux données, requêtes paramétrées exclusivement
+    routes/      déclaration des points d'entrée
+    services/    logique métier : calcul, portefeuille, cours, alertes
+    utils/       arithmétique décimale exacte
+    validation/  schémas d'entrée
+frontend/        application React
+docs/            cadrage, cahier des charges, conception, planning, conventions
+docker-compose.yml
 ```
+
+## Démarrage rapide
+
+**Prérequis** : Node.js 20 ou supérieur, Docker et Docker Compose.
+
+```bash
+# 1. Configuration
+cp .env.example .env                  # variables des services conteneurisés
+cp backend/.env.example backend/.env  # variables de l'application
+# renseigner POSTGRES_PASSWORD dans .env et JWT_SECRET dans backend/.env
+
+# 2. Services de développement
+docker compose up -d                  # PostgreSQL et Redis
+docker compose ps                     # vérifier que les deux sont "healthy"
+
+# 3. Base de données
+psql -h localhost -p 5432 -U capitall -d capitall -f backend/db/schema.sql
+psql -h localhost -p 5432 -U capitall -d capitall -f backend/db/seed.sql
+
+# 4. Dépendances et lancement
+npm run install:all
+npm run dev                           # API et interface simultanément
+```
+
+L'API répond sur `http://localhost:5000`, route de santé `/api/sante`. L'interface est servie par Vite sur le port qu'il annonce au démarrage.
+
+Le port de PostgreSQL est paramétrable par `POSTGRES_PORT` dans le fichier `.env` de la racine. C'est utile en pratique : une installation locale de PostgreSQL occupe fréquemment le port par défaut. Si vous le changez, ajustez `DATABASE_URL` en conséquence.
+
+Le script de création exige un rôle propriétaire : il installe une extension et crée le rôle applicatif à moindre privilège utilisé ensuite par l'API.
+
+## Configuration
+
+Deux fichiers d'environnement distincts, aucun n'étant versionné. Chacun dispose d'un modèle commenté.
+
+**`.env`** à la racine, consommé par Docker Compose :
+
+| Variable | Rôle | Défaut |
+|---|---|---|
+| `POSTGRES_USER` | utilisateur de la base | aucun |
+| `POSTGRES_PASSWORD` | mot de passe | aucun |
+| `POSTGRES_DB` | nom de la base | aucun |
+| `POSTGRES_PORT` | port publié sur le poste | 5432 |
+| `REDIS_PORT` | port publié sur le poste | 6379 |
+
+**`backend/.env`**, consommé par l'API :
+
+| Variable | Rôle | Obligatoire |
+|---|---|---|
+| `DATABASE_URL` | chaîne de connexion PostgreSQL | oui |
+| `JWT_SECRET` | secret de signature des jetons, 32 caractères minimum | oui |
+| `JWT_EXPIRATION` | durée de validité des jetons | non, 2h |
+| `REDIS_URL` | adresse du cache | non |
+| `PORT` | port d'écoute de l'API | non, 5000 |
+| `NODE_ENV` | environnement d'exécution | non, development |
+
+Les variables obligatoires sont contrôlées au démarrage. Si l'une manque, le serveur s'arrête immédiatement en indiquant l'ensemble des variables manquantes, et non la première rencontrée. L'absence de `REDIS_URL` n'empêche pas le démarrage : le cache est une optimisation, pas une dépendance dure.
+
+## Jeu de données de démonstration
+
+Le script `backend/db/seed.sql` crée deux comptes, un portefeuille couvrant les quatre classes d'actifs, douze transactions, deux alertes, trois annonces et quatre-vingt-dix jours d'historique de valorisation.
+
+Il est idempotent : il vide les tables avant de réinsérer, et peut donc être rejoué autant que nécessaire pour repartir d'un état propre. Les identifiants de démonstration figurent en tête du fichier.
+
+## Tests
+
+```bash
+npm test --prefix backend        # exécution unique
+npm run test:watch --prefix backend
+```
+
+Les tests portent sur ce qui contient de la logique : validation des entrées, intergiciels, arithmétique décimale, moteur de calcul, adaptateurs de cours, stratégie de cache et évaluation des alertes. Les services métier reçoivent leurs dépendances en paramètre, ce qui permet de les tester sans base de données, sans réseau et sans cache.
+
+## Interface de programmation
+
+| Domaine | Routes |
+|---|---|
+| Authentification | `POST /api/auth/inscription`, `POST /api/auth/connexion`, `GET /api/auth/moi` |
+| Actifs | `GET POST /api/actifs`, `GET PATCH DELETE /api/actifs/:id` |
+| Transactions | `POST /api/actifs/:id/transactions`, `DELETE /api/actifs/:id/transactions/:idTransaction` |
+| Portefeuille | `GET /api/portefeuille`, `GET /api/portefeuille/historique` |
+| Alertes | `GET POST /api/alertes`, `PATCH /api/alertes/:id` |
+
+Toutes les routes privées attendent le jeton dans l'en-tête `Authorization: Bearer`. Une ressource inexistante et une ressource appartenant à un autre utilisateur renvoient toutes deux un code 404, afin de ne pas confirmer l'existence d'un identifiant.
+
+Tableau complet avec les codes de statut : [cahier des charges, section 8](docs/cahier-des-charges.md).
+
+## Quelques partis pris
+
+**Aucun calcul monétaire en virgule flottante.** Les montants sont conservés en base dans un type numérique à précision arbitraire et manipulés côté serveur en entiers à échelle fixe. Additionner deux dixièmes ne produit jamais une valeur approchée, ce qui serait inacceptable sur un prix de revient.
+
+**Le cloisonnement est porté par le SQL.** Aucune ressource n'est chargée puis comparée en JavaScript à l'utilisateur courant. Chaque requête filtre sur le propriétaire, et pour les transactions, dont la table ne porte pas d'identifiant d'utilisateur, le filtrage se fait par jointure à l'intérieur de la même requête. Une insertion sur un actif qui n'appartient pas au demandeur n'insère simplement rien.
+
+**Le prix de revient n'est jamais stocké.** C'est une valeur dérivée des transactions, recalculée à chaque demande. La conserver en base créerait un risque d'incohérence permanent, toute correction d'une transaction ancienne rendant la valeur stockée fausse sans que rien ne le signale.
+
+**L'historique de valorisation, en revanche, est stocké.** Il déroge volontairement à la règle précédente, parce qu'il n'est pas reconstituable après coup : retrouver la valeur du portefeuille à une date passée exigerait des cours qui ne sont pas conservés.
+
+**Le cache n'est jamais une dépendance dure.** Si Redis est arrêté, l'application démarre et fonctionne, les cours étant demandés directement aux fournisseurs. Si un fournisseur tombe, le dernier cours connu est renvoyé, explicitement signalé comme tel.
 
 ## Documentation
 
-- [Note de cadrage](docs/note-de-cadrage.md)
-- [Cahier des charges](docs/cahier-des-charges.md)
-- [Architecture](docs/conception/architecture.md)
-- [Modèle de données](docs/conception/modele-de-donnees.md)
-- [Cas d'utilisation](docs/conception/cas-utilisation.md)
-- [Direction artistique](docs/conception/direction-artistique.md)
-- [Planning](docs/planning.md)
-- [Convention de commits](docs/convention-commits.md)
+| Document | Contenu |
+|---|---|
+| [Note de cadrage](docs/note-de-cadrage.md) | contexte, objectifs, périmètre initial |
+| [Cahier des charges](docs/cahier-des-charges.md) | acteurs, exigences, règles de gestion, critères de recette |
+| [Architecture](docs/conception/architecture.md) | couches, flux, adaptateurs |
+| [Modèle de données](docs/conception/modele-de-donnees.md) | modèle conceptuel, logique et physique |
+| [Cas d'utilisation](docs/conception/cas-utilisation.md) | acteurs et cas d'utilisation |
+| [Direction artistique](docs/conception/direction-artistique.md) | palette, typographie, écrans |
+| [Jeu d'essai](docs/jeu-essai-calculs.md) | déroulé détaillé du calcul du prix de revient et des plus-values |
+| [Planning](docs/planning.md) | calendrier et jalons |
+| [Convention de commits](docs/convention-commits.md) | format des messages et flux de contribution |
 
-## Installation (développement local)
+## Statut
 
-Prérequis : Node.js 20+, PostgreSQL 15+, Redis. Copier `backend/.env.example` vers `backend/.env` et renseigner les variables.
-
-```
-npm run install:all                          # dépendances back-end et front-end
-psql -d capitall -f backend/db/schema.sql    # création du schéma
-psql -d capitall -f backend/db/seed.sql      # jeu de données de démonstration
-npm run dev                                  # lance l'API et le front simultanément
-```
-
-L'API répond sur `http://localhost:5000` (route de santé : `/api/sante`). Les comptes de démonstration sont créés par le seed (voir l'en-tête de `backend/db/seed.sql`).
-
-La procédure complète avec Docker Compose sera ajoutée à la mise en place du déploiement.
+Projet de formation, en cours de développement. Il n'est pas destiné à un usage réel : les cours proviennent de sources publiques gratuites sans engagement de disponibilité, et ne constituent pas une donnée contractuelle.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,3 +25,8 @@ JWT_EXPIRATION=2h
 
 # Chaîne de connexion Redis, utilisée par le cache des cours.
 REDIS_URL=redis://localhost:6379
+
+# Origine autorisée à appeler l'API depuis un navigateur. Optionnel en développement,
+# où le serveur de Vite écoute sur http://localhost:5173. À renseigner avec le domaine
+# de l'interface en production.
+ORIGINE_AUTORISEE=http://localhost:5173

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const cors = require('cors');
+const config = require('./config');
 
 const routeurAuthentification = require('./routes/authentification');
 const routeurActif = require('./routes/actif');
@@ -9,7 +10,16 @@ const gestionErreurs = require('./middlewares/gestionErreurs');
 
 const app = express();
 
-app.use(cors());
+// Seule l'origine de l'interface est autorisée (exigence du cahier des charges).
+// Ouvrir l'API à toutes les origines laisserait n'importe quelle page tierce appeler
+// le service depuis le navigateur d'un utilisateur connecté. L'en-tête d'autorisation
+// est explicitement admis, sans quoi le jeton ne pourrait pas être transmis.
+app.use(
+  cors({
+    origin: config.origineAutorisee,
+    allowedHeaders: ['Content-Type', 'Authorization'],
+  })
+);
 app.use(express.json());
 
 app.get('/api/sante', (req, res) => {

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -44,6 +44,10 @@ const config = Object.freeze({
   // joignable, l'application démarre et sert les cours en appelant directement les
   // fournisseurs. Une valeur par défaut suffit donc en développement.
   redisUrl: process.env.REDIS_URL || 'redis://localhost:6379',
+  // Origine autorisée à consommer l'API. En développement, c'est le serveur de Vite ;
+  // en production, le domaine qui sert l'interface. La valeur par défaut évite d'avoir
+  // à renseigner la variable sur un poste de développement.
+  origineAutorisee: process.env.ORIGINE_AUTORISEE || 'http://localhost:5173',
 });
 
 module.exports = config;

--- a/docs/cahier-des-charges.md
+++ b/docs/cahier-des-charges.md
@@ -289,7 +289,9 @@ Toutes les routes privées attendent le jeton dans l'en-tête d'autorisation. Un
 
 Les routes d'administration renvoient 403 et non 404 : contrairement au cloisonnement entre utilisateurs, il n'y a ici aucun intérêt à masquer l'existence de la ressource, et un refus explicite est plus clair.
 
-Les structures de données échangées par chaque point d'entrée sont documentées au fil du développement dans une collection d'appels rejouable, versionnée avec le projet.
+**Statut à la date de cette version.** Les routes d'authentification, d'actifs, de transactions, de portefeuille et d'alertes sont développées et vérifiées. Les six routes d'annonces et d'administration constituent des engagements du présent cahier des charges, non encore développés à la date de la version 2.0. Ce tableau décrit la cible contractuelle du produit, l'état d'avancement relevant du suivi de projet.
+
+Les structures de données échangées par chaque point d'entrée seront documentées dans une collection d'appels rejouable, constituée au fil du développement et versionnée avec le projet.
 
 ## 9. Interface utilisateur
 

--- a/docs/conception/direction-artistique.md
+++ b/docs/conception/direction-artistique.md
@@ -25,16 +25,34 @@ Contrastes vérifiés à respecter (RGAA) : texte principal et secondaire sur fo
 ## Principes de mise en page
 
 - mobile-first : une colonne, cartes empilées ; sur desktop, grille deux colonnes pour le tableau de bord
-- navigation par barre d'onglets en bas sur mobile (tableau de bord, actifs, ajout, compte), barre latérale sur desktop
+- navigation par barre d'onglets en bas sur mobile à cinq entrées (patrimoine, positions, ajout au centre, seuils, compte), rail latéral sur desktop
 - coins arrondis discrets (8 px), pas d'ombres marquées, hiérarchie par la couleur de fond
 - graphique de répartition en anneau, courbe d'évolution en aire dégradée
+
+## Grammaire visuelle
+
+Trois niveaux de contenant et pas davantage : à plat sur le fond pour les listes et les formulaires, carte bordée pour les blocs à frontière logique, carte au fond accentué pour le seul bloc de patrimoine.
+
+Rythme vertical à trois valeurs : 32 px avant un changement de section, 24 px entre blocs d'une même section, 12 px entre éléments liés. L'espace au-dessus d'un titre est toujours supérieur à l'espace en dessous.
+
+Chaque classe d'actif porte un jeton distinct **par la forme** et pas seulement par la couleur : cercle pour les cryptomonnaies, carré arrondi pour les métaux, losange pour les devises, hexagone pour les actions. La forme reste lisible en niveaux de gris.
+
+Sur tout graphe de cours d'une position, le prix de revient est tracé en ligne horizontale pointillée, l'aire entre la courbe et cette ligne étant teintée selon le signe. C'est le geste graphique propre à l'application : il donne à voir d'un regard l'information principale du produit.
 
 ## Écrans à maquetter (Figma)
 
 1. connexion / inscription
-2. tableau de bord (valeur totale, plus-value globale, anneau de répartition, courbe d'évolution, sélecteur de devise d'affichage euro/dollar)
-3. liste des actifs (carte par actif : symbole, quantité, PRU, cours, plus-value)
-4. détail d'un actif (historique des transactions, plus-value latente et réalisée)
-5. formulaire d'ajout de transaction
+2. patrimoine (tableau de bord)
+3. positions
+4. détail d'une position
+5. mouvement (achat ou vente)
+6. seuils
+7. compte
 
-Chaque écran en version mobile (375 px) et desktop (1440 px).
+Chaque écran en version mobile (375 px) et desktop (1440 px), accompagné d'une planche d'états couvrant le premier lancement, le portefeuille vide, le chargement, l'erreur d'API, l'erreur réseau, la session expirée et le repli sur le dernier cours connu.
+
+Direction retenue : une seule interface à deux points de rupture, dense et outillée en desktop, resserrée sur le geste en mobile. Les prototypes HTML ayant servi aux arbitrages ne sont pas versionnés.
+
+## Documents liés
+
+Le détail de chaque écran, ses états et ses règles d'interaction : `specification-fonctionnelle.md`. Le formatage de toute valeur numérique affichée : `formatage-nombres.md`.

--- a/docs/conception/formatage-nombres.md
+++ b/docs/conception/formatage-nombres.md
@@ -1,0 +1,146 @@
+# Politique de formatage des nombres
+
+Règles d'affichage des valeurs numériques dans l'interface de CapitAll. Ce document est la référence unique : toute valeur affichée passe par l'une des six catégories ci-dessous, sans exception locale.
+
+Le besoin est particulier à l'application : quatre classes d'actifs qui ne se mesurent pas de la même façon cohabitent sur un même écran. Une cryptomonnaie se compte en unités à huit décimales, un métal en grammes, une action en titres entiers, une devise en unités monétaires. Une règle unique produirait soit des colonnes illisibles, soit des arrondis faux.
+
+## Principe fondateur
+
+Les montants sont stockés en `NUMERIC` et transitent par l'API sous forme de **chaînes de caractères**, jamais de nombres flottants. Le formatage respecte cette contrainte : il opère par manipulation de la chaîne décimale, pas par conversion en `Number`.
+
+Concrètement, on découpe sur le séparateur décimal, on tronque ou on complète la partie décimale, on retire les zéros de fin, puis on insère les séparateurs de milliers. `parseFloat` n'est utilisé nulle part dans la chaîne d'affichage d'un montant.
+
+Ce choix a un coût, une trentaine de lignes de code, et deux bénéfices. Il rend impossible l'introduction d'une erreur de représentation en virgule flottante, y compris sur les quantités à huit décimales où `Number` finit par mentir. Et il tient la promesse posée à la conception : aucun montant n'est jamais converti en flottant, pas même pour être affiché.
+
+## Conventions communes
+
+- **Locale française** : virgule décimale, espace insécable fine comme séparateur de milliers (`12 480,65`), symbole après la valeur avec espace insécable (`12 480,65 €`).
+- **Chiffres tabulaires** (`font-variant-numeric: tabular-nums`) sur toute valeur numérique, pour que les colonnes s'alignent verticalement.
+- **Zéros de fin toujours supprimés**, dans les six catégories. `20,00 €` s'écrit `20 €`, `0,60000000 BTC` s'écrit `0,6 BTC`.
+- **Jamais de troncature silencieuse d'une valeur significative.** Si une valeur ne tient pas dans le format prévu, on élargit le format, on ne rogne pas le chiffre.
+
+## 1. Montants en devise fiduciaire
+
+Valorisations, coûts d'acquisition, montants d'opération, plus-values, totaux.
+
+**Deux décimales maximum, zéros de fin supprimés.**
+
+| Valeur reçue | Affichage |
+|---|---|
+| `20.00` | `20 €` |
+| `20.50` | `20,5 €` |
+| `20.25` | `20,25 €` |
+| `12480.6500` | `12 480,65 €` |
+| `0.004` | `0,01 €` (arrondi au centime supérieur en valeur absolue) |
+
+*Motivation.* Le centime est la plus petite unité qui ait un sens pour un patrimoine. Afficher `20,00 €` alourdit la lecture sans rien apporter ; les décimales portent de l'information seulement quand elles ne sont pas nulles.
+
+*Cas limite.* Une valeur non nulle inférieure à un centime ne s'affiche jamais `0 €`, ce qui laisserait croire à une absence de valeur. Elle s'affiche `0,01 €` avec une infobulle donnant la valeur exacte.
+
+## 2. Quantités d'actifs
+
+Le nombre d'unités détenues. Le format dépend de la classe.
+
+| Classe | Décimales maximum | Unité affichée | Exemple |
+|---|---|---|---|
+| Cryptomonnaie | 8 | symbole | `0,6 BTC`, `0,60000001 BTC` |
+| Métal précieux | 3 | `g` | `18 g`, `620,5 g` |
+| Devise | 2 | code ISO | `1 500 USD` |
+| Action | 6 | `titre` / `titres` | `12 titres`, `0,5 titre` |
+
+**Zéros de fin supprimés dans tous les cas.**
+
+| Valeur reçue | Affichage |
+|---|---|
+| `0.60000000` | `0,6` |
+| `15.00000000` | `15` |
+| `0.60000010` | `0,6000001` |
+| `0.60000001` | `0,60000001` |
+
+*Motivation.* La précision d'une quantité est une donnée, pas une décoration : elle résulte d'un achat réel et l'arrondir fausserait la vérification manuelle du calcul par l'utilisateur. Mais afficher huit décimales quand six sont nulles produit une colonne illisible. Supprimer les zéros de fin conserve l'exactitude et rend la lecture possible.
+
+*Sur l'unité affichée.* L'unité n'est jamais omise ni convertie. Un gramme d'or reste un gramme, il n'est pas ramené à une once ni à un pourcentage. Cette hétérogénéité assumée est un parti pris de l'application : elle donne à voir la nature réelle de chaque position.
+
+*Accord en nombre.* `1 titre`, `2 titres`. Le pluriel ne s'applique qu'aux unités nommées en français, jamais aux symboles ni aux codes ISO (`1 BTC` et non `1 BTCs`).
+
+## 3. Cours unitaires
+
+Le prix d'une unité d'actif, et le prix de revient unitaire.
+
+**Précision significative variable selon l'ordre de grandeur, zéros de fin supprimés.**
+
+| Ordre de grandeur | Décimales maximum | Exemple |
+|---|---|---|
+| ≥ 1 000 | 2 | `61 240 €`, `54 890,12 €` |
+| ≥ 10 et < 1 000 | 2 | `92,14 €`, `249,61 €` |
+| ≥ 0,01 et < 10 | 4 | `1,1523 €`, `0,9152 €` |
+| < 0,01 | 6 | `0,000842 €` |
+
+*Motivation.* C'est le point où une règle unique à deux décimales échoue. Le gramme d'argent vaut environ `1,1523 €` : arrondi à `1,15`, l'erreur atteint 0,2 % sur une valorisation, soit un écart visible entre le cours affiché et le total affiché. L'utilisateur qui refait le calcul à la main ne retrouve pas ses chiffres, et la confiance tombe. La règle par ordre de grandeur conserve toujours quatre chiffres significatifs au minimum.
+
+*Cohérence avec le total.* Le total affiché est toujours calculé à partir de la valeur exacte, jamais à partir de la valeur arrondie affichée. Le formatage est une couche de présentation, il n'entre jamais dans un calcul.
+
+## 4. Taux de change
+
+Le taux euro-dollar de la bascule d'affichage.
+
+**Quatre décimales, zéros de fin supprimés.** `1 € = 1,0926 $`.
+
+*Motivation.* Même raisonnement qu'au point 3, poussé plus loin : un taux de change s'exprime conventionnellement à quatre décimales dans tous les usages financiers, et deux décimales le rendraient inutilisable. La règle est fixe et ne dépend pas de l'ordre de grandeur, l'usage étant établi.
+
+*Affichage de la source.* Un taux est toujours accompagné de son horodatage lorsqu'il est utilisé pour convertir un affichage, jamais présenté comme une vérité intemporelle.
+
+## 5. Pourcentages
+
+Répartition du portefeuille, part d'une classe, progression vers un seuil.
+
+**Une décimale maximum, zéros de fin supprimés, symbole avec espace insécable.**
+
+| Valeur | Affichage |
+|---|---|
+| `46.0` | `46 %` |
+| `46.04` | `46 %` |
+| `46.15` | `46,2 %` |
+| `0.04` | `< 0,1 %` |
+
+*Motivation.* La deuxième décimale d'une répartition n'a aucune valeur décisionnelle et alourdit une légende qui compte déjà quatre à six lignes. Le seuil bas `< 0,1 %` évite d'afficher `0 %` pour une position qui existe.
+
+*Somme des parts.* Les parts arrondies peuvent ne pas totaliser exactement 100 %. On n'ajuste jamais artificiellement une part pour forcer le total : on n'affiche simplement pas de ligne de total dans la légende de répartition.
+
+## 6. Variations, absolues et relatives
+
+La performance d'une position ou du portefeuille.
+
+**Variation relative** : une décimale maximum, zéros de fin supprimés, signe explicite toujours présent. `+11,6 %`, `−6,5 %`, `0 %`.
+
+**Variation absolue** : règle des montants fiduciaires, signe explicite toujours présent. `+393,71 €`, `−135,51 €`.
+
+**Le signe est obligatoire**, y compris au positif. Le moins est le signe typographique `−` (U+2212) et non le trait d'union, pour l'alignement en chiffres tabulaires.
+
+*Traitement graduel selon l'amplitude.* Le poids visuel d'une variation suit son amplitude, ce qui évite qu'une page entière crie d'une seule voix.
+
+| Amplitude | Traitement |
+|---|---|
+| ≥ 10 % | pastille pleine colorée, flèche, signe |
+| ≥ 1 % et < 10 % | texte coloré, flèche, signe, sans pastille |
+| < 1 % | texte atténué, signe, sans couleur ni flèche |
+| exactement 0 | texte atténué, `0 %`, sans signe ni flèche |
+
+*Accessibilité, règle non négociable.* Une variation n'est **jamais** portée par la couleur seule. Le signe et la flèche (`▲` `▼`) sont toujours présents, ce qui rend l'information lisible en niveaux de gris et par un utilisateur daltonien. C'est une exigence du référentiel d'accessibilité, et c'est ce qui justifie que la troisième ligne du tableau ci-dessus conserve le signe alors qu'elle abandonne la couleur.
+
+## Mise en œuvre
+
+Module unique `frontend/src/utils/formatage.js`, sans dépendance externe :
+
+```
+formaterMontant(chaine)                  → catégorie 1
+formaterQuantite(chaine, typeActif)      → catégorie 2
+formaterCours(chaine)                    → catégorie 3
+formaterTaux(chaine)                     → catégorie 4
+formaterPourcentage(chaine)              → catégorie 5
+formaterVariation(chaine, mode)          → catégorie 6, mode 'absolue' ou 'relative'
+```
+
+Aucun composant ne formate un nombre par lui-même. Toute valeur numérique affichée dans l'interface provient de l'une de ces six fonctions, ce qui rend la politique vérifiable par une simple recherche dans le code.
+
+Les fonctions sont couvertes par des tests unitaires portant explicitement sur les cas limites listés dans ce document : zéros de fin, valeur nulle, valeur inférieure au seuil d'affichage, changement d'ordre de grandeur, signe des variations.

--- a/docs/conception/specification-fonctionnelle.md
+++ b/docs/conception/specification-fonctionnelle.md
@@ -1,0 +1,344 @@
+# Spécification fonctionnelle et UX/UI
+
+Référence unique pour la réalisation des maquettes et l'intégration de l'interface. Décrit ce que chaque écran affiche, comment il se comporte et dans quels états il peut se trouver.
+
+Ne décrit pas : la palette et la typographie (`direction-artistique.md`), le formatage des valeurs numériques (`formatage-nombres.md`), le modèle de données (`modele-de-donnees.md`), les règles de calcul (`cahier-des-charges.md`).
+
+---
+
+# Partie I — Principes transverses
+
+## 1. Lexique
+
+Un même objet porte le même nom partout : interface, code, documentation, routes.
+
+| Terme retenu | Désigne | À ne pas employer |
+|---|---|---|
+| **patrimoine** | la valeur totale consolidée | valorisation totale, capital |
+| **position** | ce que l'utilisateur détient d'un actif | ligne, holding |
+| **actif** | l'instrument lui-même (Bitcoin, l'or) | — |
+| **mouvement** | un achat ou une vente | transaction, opération |
+| **seuil** | une alerte de franchissement | alerte, notification |
+| **prix de revient** | le coût unitaire moyen pondéré | PRU en toutes lettres dans l'interface |
+| **cours** | le prix unitaire de marché | prix, valeur unitaire |
+
+Le terme *notification* est proscrit de l'interface : l'application n'envoie rien, elle constate un franchissement à la consultation.
+
+## 2. Système de navigation
+
+Une seule interface, **deux points de rupture**.
+
+**Sous 768 px** : barre de navigation basse fixe à cinq entrées, l'ajout d'un mouvement au centre en bouton circulaire proéminent. Les saisies s'ouvrent en feuille glissante depuis le bas, jamais en page. Le retour se fait par le geste de fermeture ou la flèche d'en-tête.
+
+**À partir de 768 px** : rail latéral fixe de 212 px à cinq entrées, pied de rail portant l'identité de session et la déconnexion. Les saisies s'ouvrent en boîte de dialogue centrée. L'ajout d'un mouvement est un bouton d'action principal dans la barre de titre.
+
+Entrées de navigation, dans cet ordre : Patrimoine, Positions, *(ajout)*, Seuils, Compte.
+
+L'écran Détail d'une position n'est pas dans la navigation : on y accède depuis Positions ou depuis le tableau de bord.
+
+## 3. Grammaire visuelle
+
+**Trois niveaux de contenant, pas davantage.** Niveau 0, à plat sur le fond : listes, tableaux, formulaires longs. Niveau 1, carte bordée : blocs à frontière logique, graphe, répartition. Niveau 2, carte au fond accentué : le seul bloc de patrimoine. Un écran ne mélange jamais plus de deux niveaux.
+
+**Rythme vertical à trois valeurs.** 32 px avant un changement de section, 24 px entre blocs d'une même section, 12 px entre éléments liés. L'espace au-dessus d'un titre est toujours supérieur à l'espace en dessous.
+
+**Jeton de classe, par la forme et pas seulement par la couleur.** Cercle pour les cryptomonnaies, carré à coins arrondis pour les métaux, losange pour les devises, hexagone pour les actions. La forme reste lisible en niveaux de gris, ce qui sert l'accessibilité et donne à la liste une texture propre à l'application.
+
+**Ligne de prix de revient.** Sur tout graphe de cours d'une position, le prix de revient est tracé en ligne horizontale pointillée, l'aire entre la courbe et cette ligne étant teintée en positif au-dessus et en négatif en dessous. C'est le geste graphique signature de l'application : il donne à voir en un regard l'information principale du produit.
+
+## 4. Bibliothèque de composants
+
+Existants dans le dépôt : `Bouton`, `Carte`, `Champ`, `Chargement`, `Alerte` (message), `RouteProtegee`, `Coquille`.
+
+À créer, par ordre de dépendance :
+
+| Composant | Rôle | Utilisé par |
+|---|---|---|
+| `Montant` | affiche une valeur selon la politique de formatage | tous |
+| `Variation` | pourcentage ou montant signé, avec traitement graduel | E2, E3, E4 |
+| `JetonClasse` | pastille de forme selon la classe d'actif | E2, E3, E4, E5 |
+| `EtatVide` | illustration, titre, explication, action | E2, E3, E6 |
+| `Squelette` | forme de chargement calquée sur le contenu attendu | E2, E3, E4 |
+| `MessageErreur` | erreur avec cause et action de reprise | tous |
+| `PastilleFraicheur` | ancienneté et source d'un cours | E2, E3, E4 |
+| `SelecteurPeriode` | plages avec performance affichée par plage | E2, E4 |
+| `Anneau` | répartition, légende chiffrée | E2 |
+| `Courbe` | évolution, avec ligne de prix de revient optionnelle | E2, E4 |
+| `TableauPositions` | liste responsive des positions | E2, E3 |
+| `FrisesMouvements` | chronologie des mouvements avec effet sur le prix de revient | E4 |
+| `Feuille` | conteneur glissant mobile, dialogue desktop | E5, E6 |
+| `BarreProgression` | avancement vers un seuil | E4, E6 |
+| `Confirmation` | dialogue de confirmation d'action destructrice | E4, E5, E7 |
+| `BasculeDevise` | euro ou dollar | E2, E7 |
+| `MasquageMontants` | bascule de confidentialité | E2, E7 |
+
+## 5. Grammaire des états
+
+Les sept états demandés sont définis **une fois ici** et ne sont rappelés dans chaque écran que par leurs particularités propres. Un état décrit sept fois à l'identique cesse d'être lu et diverge à la première évolution.
+
+| État | Déclencheur | Traitement générique |
+|---|---|---|
+| **Chargement** | requête en cours, premier affichage | Squelette calqué sur la forme du contenu attendu, jamais un rond tournant plein écran. Pas d'affichage avant 200 ms pour éviter le clignotement sur réseau rapide. |
+| **Données normales** | réponse reçue, contenu présent | — |
+| **Absence de données** | réponse reçue, collection vide après filtrage | Message dans le contenant, sans illustration, avec action de réinitialisation du filtre. À distinguer strictement du portefeuille vide. |
+| **Portefeuille vide** | compte sans aucune position | `EtatVide` avec action principale menant à la création de la première position. Voir 6. |
+| **Premier lancement** | première connexion après inscription | Cas particulier du portefeuille vide, avec un texte d'accueil différent. Voir 6. |
+| **Erreur API** | réponse 4xx ou 5xx | Cause en clair, jamais de code technique brut. 401 : redirection vers la connexion avec message de session expirée. 403, 404 : message dédié. 5xx : message générique et bouton de réessai. |
+| **Erreur réseau** | requête sans réponse, hors ligne | Message distinct de l'erreur API : « connexion indisponible », bouton de réessai, conservation des données déjà affichées, grisées, plutôt que page blanche. |
+
+**Deux états supplémentaires propres à l'application**, à ne pas oublier :
+
+| État | Déclencheur | Traitement |
+|---|---|---|
+| **Cours en repli** | `cours_indisponibles` non vide dans la réponse | Bandeau d'avertissement nommant les actifs concernés et la date du dernier cours connu. `PastilleFraicheur` en état tiède sur les positions concernées. Les valorisations restent affichées, jamais masquées. |
+| **Session expirée** | 401 sur une requête d'un écran déjà affiché | Le jeton vivant en mémoire, un rechargement ramène à la connexion. Message explicite plutôt que redirection silencieuse. |
+
+## 6. Premier lancement, le parcours qui décide de tout
+
+Un compte neuf n'a aucune position. Aujourd'hui, cela produirait un tableau de bord affichant zéro euro, quatre indicateurs vides et un anneau sans segment : le pire accueil possible pour une application patrimoniale.
+
+Parcours retenu : après inscription, l'utilisateur arrive sur le tableau de bord en état **premier lancement**. L'écran ne montre ni graphe ni répartition. Il montre un texte court expliquant ce que fait l'application, et une action principale unique, « Ajouter votre première position », qui ouvre directement le formulaire de mouvement pré-réglé sur un achat.
+
+Après le premier enregistrement, le tableau de bord bascule en état normal. Tant qu'une seule position existe, l'anneau de répartition reste masqué : un anneau à un seul segment n'informe pas.
+
+---
+
+# Partie II — Spécification des écrans
+
+## E1 — Connexion et inscription
+
+**Objectif.** Ouvrir une session et créer un compte. Écran déjà intégré, spécifié ici pour la cohérence et pour la couverture de la maquette.
+
+**Cas d'utilisation.** Première inscription ; connexion quotidienne ; retour après expiration de session.
+
+**Informations affichées.** Identité de l'application et une phrase de positionnement. Formulaire. Lien de bascule entre les deux modes. Aucune donnée patrimoniale.
+
+**Hiérarchie.** Le formulaire domine ; le positionnement est secondaire ; le lien de bascule est tertiaire.
+
+**Composants.** `Champ` (adresse, mot de passe, pseudonyme à l'inscription), `Bouton` principal, `MessageErreur`, indicateur de robustesse du mot de passe à l'inscription.
+
+**Interactions.** Validation à la soumission, pas à la frappe, sauf le mot de passe à l'inscription dont la robustesse s'évalue en direct. Entrée valide le formulaire. Après inscription réussie, connexion automatique et arrivée en premier lancement. Après connexion réussie, arrivée sur le tableau de bord.
+
+**États particuliers.** Erreur API 409 à l'inscription : « cette adresse est déjà utilisée », le champ concerné reçoit le focus. Erreur 401 à la connexion : message unique « adresse ou mot de passe incorrect », jamais un message distinguant les deux cas, ce qui révélerait l'existence d'un compte. Soumission en cours : bouton désactivé avec libellé d'attente, pour empêcher le double envoi.
+
+**Accessibilité.** Chaque champ porte un `label` visible, pas un simple `placeholder`. Les erreurs sont associées par `aria-describedby` et annoncées via une région `aria-live`. Le focus arrive sur le premier champ à l'ouverture, sur le premier champ en erreur après un échec. Contraste minimum 4,5:1, y compris sur les textes d'aide atténués.
+
+**Questions ouvertes.** Aucune.
+
+---
+
+## E2 — Patrimoine (tableau de bord)
+
+**Objectif.** Répondre en un regard à quatre questions, dans cet ordre : combien je possède, comment cela a évolué, comment c'est réparti, qu'est-ce qui demande mon attention. C'est l'écran d'arrivée et le plus consulté.
+
+**Cas d'utilisation.** Consultation quotidienne rapide ; vérification après un mouvement ; constat d'un seuil franchi.
+
+**Informations affichées et hiérarchie.**
+
+*Priorité 1, dominante visuelle.* Le patrimoine total, en très grand, avec sa variation absolue et relative depuis l'origine. Bloc de niveau 2, occupant environ les deux tiers de la largeur en desktop.
+
+*Priorité 2.* La courbe d'évolution et le sélecteur de période affichant la performance de chaque plage sans clic (jour, semaine, mois, année, origine). Cinq informations pour un regard.
+
+*Priorité 3, sans carte, en colonne latérale sur desktop.* Montant investi, plus-value latente, plus-value réalisée. Trois lignes de texte séparées par des filets, pas trois cartes : ce sont des chiffres de contexte, pas des indicateurs de tête.
+
+*Priorité 4.* Répartition en anneau avec légende chiffrée par classe, montant et part.
+
+*Priorité 5.* Seuils franchis, en liste courte, seulement s'il y en a. Le bloc disparaît entièrement s'il est vide.
+
+*Priorité 6.* Les cinq positions les plus importantes, avec un lien vers l'écran Positions. Le tableau complet n'a pas sa place ici.
+
+**Source.** `GET /api/portefeuille` fournit `valeur_totale`, `cout_total`, `plus_value_latente`, `plus_value_realisee`, `repartition`, `actifs`, `cours_indisponibles`, `taux_affichage`, `alertes_declenchees`. `GET /api/portefeuille/historique` fournit la courbe.
+
+**Composants.** `Montant`, `Variation`, `SelecteurPeriode`, `Courbe`, `Anneau`, `TableauPositions` en mode réduit, `PastilleFraicheur`, `BasculeDevise`, `MasquageMontants`, `EtatVide`, `Squelette`, `MessageErreur`.
+
+**Interactions.** La bascule euro-dollar convertit l'affichage sans nouvelle requête, le taux étant déjà dans la réponse ; le choix persiste dans la session. Le masquage remplace tout montant par une suite de points, y compris dans le graphe dont l'axe est masqué ; l'état persiste. Le sélecteur de période recharge la courbe. Un clic sur une classe de la légende filtre l'écran Positions et y navigue. Un clic sur une position ouvre son détail. Le bouton d'ajout ouvre E5.
+
+**États particuliers.**
+
+*Premier lancement et portefeuille vide.* Voir I.6. Ni courbe, ni anneau, ni indicateurs. Un texte, une action.
+
+*Une seule position.* Anneau masqué, la répartition n'a pas de sens.
+
+*Historique insuffisant.* Moins de deux points de mesure : la courbe est remplacée par un message « l'évolution s'affichera après quelques jours de suivi ». Ne jamais tracer une courbe à un point.
+
+*Cours en repli.* Bandeau nommant les actifs concernés. Le patrimoine reste affiché, avec la mention que la valorisation utilise le dernier cours connu.
+
+*Chargement.* Squelette respectant la composition : un grand bloc, une zone de graphe, trois lignes, un cercle.
+
+**Accessibilité.** La courbe et l'anneau portent un `role="img"` avec un `aria-label` décrivant la donnée en toutes lettres, et sont doublés par la légende chiffrée qui suffit à comprendre sans voir le graphique. Aucune information n'est portée par la couleur seule dans la légende : chaque entrée porte son libellé et sa valeur. Le sélecteur de période est un vrai groupe d'onglets navigable aux flèches. Le masquage des montants est annoncé par `aria-pressed`.
+
+**Questions ouvertes.**
+1. Le bloc des cinq principales positions fait-il doublon avec l'écran Positions ? Il évite un aller-retour mais ajoute de la hauteur. Recommandation : le conserver en desktop, le supprimer en mobile où le défilement est déjà long.
+2. La période par défaut : mois ou année ? Recommandation : mois, plus proche du rythme réel de consultation, l'année étant à un clic.
+
+---
+
+## E3 — Positions
+
+**Objectif.** Donner la vue exhaustive et comparable de ce qui est détenu, et permettre d'atteindre une position précise.
+
+**Cas d'utilisation.** Vérifier une ligne ; comparer les performances ; filtrer une classe ; accéder au détail.
+
+**Informations affichées et hiérarchie.** Une ligne par position. Par ordre de priorité de lecture : nom et jeton de classe, valorisation, variation, puis quantité et prix de revient en information secondaire de deuxième ligne.
+
+En desktop, tableau à colonnes : Actif, Quantité, Cours, Prix de revient, Valorisation, Plus-value, tendance 30 jours. En mobile, liste à deux niveaux : jeton, nom et sous-ligne à gauche, valorisation et variation à droite.
+
+**Contenant.** Niveau 0, à plat sur le fond, séparateurs entre les lignes. C'est une liste, pas un ensemble de cartes.
+
+**Composants.** `TableauPositions`, `JetonClasse`, `Montant`, `Variation`, `PastilleFraicheur`, filtres par classe avec compteur, `EtatVide`, `Squelette`.
+
+**Interactions.** Filtres par classe, cumulables, avec compteur ; le filtre est reflété dans l'URL pour être partageable et survivre à un rechargement. Tri par colonne en desktop, tri par menu en mobile ; tri par défaut sur la valorisation décroissante. Un clic ou un appui sur une ligne ouvre le détail. Le bouton d'ajout ouvre E5.
+
+**États particuliers.** *Absence de données après filtrage* : message dans la liste et action de réinitialisation, l'en-tête et les filtres restant affichés. *Portefeuille vide* : `EtatVide` avec action de création. *Cours en repli* : pastille tiède sur les lignes concernées et bandeau en tête de liste.
+
+**Accessibilité.** Table sémantique en desktop, avec `scope` sur les en-têtes ; le tri est annoncé par `aria-sort`. En mobile, liste et non tableau, chaque élément étant un lien dont le texte accessible reprend le nom de l'actif et sa valorisation, jamais « voir » seul. Les filtres sont des boutons à `aria-pressed`. Zone tactile minimale 44 px.
+
+**Questions ouvertes.**
+1. Faut-il permettre la suppression d'une position depuis la liste ? Elle est destructrice et la route existe. Recommandation : non, uniquement depuis le détail, avec confirmation. Une action destructrice ne se place pas dans une liste où l'appui est fréquent.
+
+---
+
+## E4 — Détail d'une position
+
+**Objectif.** Comprendre une position : ce qu'elle vaut, ce qu'elle a coûté, comment on y est arrivé, et ce qui la surveille.
+
+**Cas d'utilisation.** Vérifier un prix de revient ; relire l'historique d'achat ; ajouter un mouvement sur un actif connu ; poser un seuil.
+
+**Informations affichées et hiérarchie.**
+
+*En-tête.* Jeton, nom, symbole, classe, source du cours et sa fraîcheur.
+
+*Priorité 1.* Valorisation de la position et plus-value latente, absolue et relative.
+
+*Priorité 2.* Trio quantité détenue, cours actuel, prix de revient.
+
+*Priorité 3.* Graphe du cours **avec la ligne de prix de revient** (voir I.3) et sélecteur de période.
+
+*Priorité 4, en onglets.* Mouvements ; Seuils. L'onglet « Analyse » présent dans les maquettes est supprimé : il ne contenait rien de défini.
+
+*Onglet Mouvements.* Frise chronologique : type, date, quantité signée, montant, prix unitaire, frais, et **effet sur le prix de revient**. Une vente affiche en outre la plus-value réalisée.
+
+*Onglet Seuils.* Seuils posés sur cet actif, avec progression vers le franchissement.
+
+**Composants.** `Courbe` avec ligne de prix de revient, `SelecteurPeriode`, `FrisesMouvements`, `BarreProgression`, `Confirmation`, `Montant`, `Variation`, `JetonClasse`, `PastilleFraicheur`.
+
+**Interactions.** Ajout d'un mouvement pré-réglé sur cet actif. Création d'un seuil pré-réglée sur cet actif. Suppression d'un mouvement, avec confirmation nommant explicitement la conséquence : « la suppression de cet achat recalculera le prix de revient de la position ». Suppression de la position, avec confirmation mentionnant que les mouvements associés seront supprimés.
+
+**États particuliers.** *Position sans mouvement* : cas impossible dans le modèle, un actif naissant d'un premier achat ; à traiter tout de même en défensif par un message neutre. *Cours indisponible* : le graphe affiche la dernière valeur connue et une zone grisée pour la période manquante, jamais une interpolation. *Erreur 404* : la ressource d'un autre compte est traitée comme inexistante ; message « position introuvable » et retour à la liste.
+
+**Accessibilité.** La frise est une liste ordonnée sémantique. La ligne de prix de revient est décrite dans l'`aria-label` du graphe. Les onglets suivent le motif ARIA d'onglets, navigables aux flèches, avec `aria-controls`. La confirmation de suppression capture le focus, se ferme par Échap, et son bouton destructeur n'est jamais le premier dans l'ordre de tabulation.
+
+**Questions ouvertes.**
+1. La colonne « effet sur le prix de revient » suppose un calcul historique que l'API ne renvoie pas aujourd'hui. Deux options : la calculer côté client par reconstitution séquentielle, ou l'ajouter à la réponse de l'API. Recommandation : côté serveur, dans le détail d'actif, le moteur de calcul étant déjà là et le client ne devant pas refaire de calcul métier. **Impact API à valider.**
+
+---
+
+## E5 — Mouvement (achat ou vente)
+
+**Objectif.** Enregistrer une opération et en montrer l'effet avant validation. C'est l'écran le plus important après le tableau de bord : c'est là que se crée la donnée.
+
+**Forme.** Feuille glissante en mobile, dialogue centré en desktop. Jamais une page : le contexte doit rester visible.
+
+**Cas d'utilisation.** Premier ajout depuis l'état vide ; achat sur un actif déjà détenu ; vente partielle ou totale ; saisie rétroactive d'une opération passée.
+
+**Informations affichées et hiérarchie.** Bascule achat ou vente en tête, colorée et explicite. Sélection de l'actif, avec création d'un actif inexistant dans le même geste. Quantité et prix unitaire. Date. Frais, facultatif. Puis, en bas et mis en évidence, le **récapitulatif recalculé en direct** : montant de l'opération, quantité détenue après, nouveau prix de revient et son écart. Pour une vente : plus-value réalisée par l'opération.
+
+**Composants.** `Feuille`, `Champ`, `JetonClasse`, `Bouton`, `Montant`, `MessageErreur`, sélecteur d'actif avec recherche.
+
+**Interactions.** Le prix unitaire est pré-rempli au cours du jour et reste modifiable, avec une mention explicite. Une vente ne propose jamais une quantité supérieure à la quantité détenue : le champ est borné et un raccourci « tout vendre » est proposé. La date ne peut pas être future. La validation est bloquée tant que le récapitulatif ne peut pas être calculé. À l'enregistrement, la feuille se ferme et l'écran d'origine se rafraîchit, avec confirmation brève.
+
+**Validations.** Quantité strictement positive, dans la précision de la classe. Prix unitaire positif. Date passée ou du jour. Frais positifs ou nuls. Les messages nomment le champ et la règle, jamais un code.
+
+**États particuliers.** *Actif nouveau* : les champs de classe et de symbole apparaissent, le symbole étant vérifié auprès du service de cours avant validation. *Cours indisponible* : le prix unitaire n'est pas pré-rempli, un message l'explique, la saisie manuelle reste possible. *Erreur 422* : les messages du serveur sont replacés sur les champs concernés, jamais affichés en bloc. *Enregistrement en cours* : bouton désactivé, formulaire verrouillé.
+
+**Accessibilité.** La feuille est un dialogue modal : focus capturé, retour au déclencheur à la fermeture, fermeture par Échap. Le récapitulatif est une région `aria-live="polite"` : ses recalculs sont annoncés sans interrompre la saisie. Les champs numériques portent `inputmode="decimal"`. La bascule achat ou vente est un groupe de boutons radio, pas une paire de boutons.
+
+**Questions ouvertes.**
+1. Faut-il permettre la création d'un actif depuis ce formulaire, ou imposer un écran séparé ? Recommandation : dans le formulaire. Séparer impose deux parcours pour une même intention et double le nombre d'écrans.
+2. Le champ frais est-il utile au MVP ? Il entre dans le prix de revient et enrichit le calcul, mais allonge le formulaire. Recommandation : le conserver, replié derrière un lien « ajouter des frais », visible mais non imposé.
+
+---
+
+## E6 — Seuils
+
+**Objectif.** Surveiller sans consulter en permanence. Répondre à une seule question devant chaque ligne : suis-je proche ?
+
+**Cas d'utilisation.** Poser un seuil sur un actif ou sur le patrimoine total ; constater un franchissement ; retirer un seuil devenu inutile.
+
+**Informations affichées et hiérarchie.** Deux groupes : franchis, puis en cours. Chaque ligne porte la cible, le sens et la valeur du seuil, l'écart restant en pourcentage, et une barre de progression. Les franchis portent la date de franchissement.
+
+**Contenant.** Cartes de niveau 1, la progression justifiant une frontière visuelle.
+
+**Composants.** `BarreProgression`, `JetonClasse`, `Feuille` pour la création, `Confirmation`, `EtatVide`.
+
+**Interactions.** Création via une feuille présentant le cours actuel en grand, la bascule au-dessus ou en dessous, le champ de seuil, et des décalages rapides à −10, −5, +5 et +10 %. La cible peut être un actif ou le patrimoine total, conformément au modèle. Un texte en clair rappelle la règle : le seuil est inclusif et le franchissement ne se produit qu'une fois. Confirmation brève après création. Retrait d'un seuil avec confirmation simple.
+
+**États particuliers.** *Aucun seuil* : `EtatVide` expliquant l'intérêt et proposant la création. *Cours indisponible sur la cible* : la progression n'est pas calculable, la barre est remplacée par une mention explicite plutôt que par une barre à zéro, qui mentirait.
+
+**Accessibilité.** La barre de progression porte `role="progressbar"` avec ses valeurs. Le pourcentage restant est toujours écrit en toutes lettres à côté : la barre seule ne porte jamais l'information. Le groupe des seuils franchis est annoncé par un titre de section, pas seulement par une couleur.
+
+**Questions ouvertes.**
+1. Un seuil franchi doit-il pouvoir être réarmé ? Le modèle prévoit trois statuts dont `desactivee`, mais pas de retour à `active`. Recommandation : ne pas réarmer au MVP ; l'utilisateur recrée un seuil, ce qui est plus clair et ne demande aucune évolution.
+
+---
+
+## E7 — Compte
+
+**Objectif.** Donner à l'utilisateur la maîtrise de son compte et de ses données. Écran absent de toutes les maquettes, et son absence se verrait immédiatement en démonstration.
+
+**Cas d'utilisation.** Changer son mot de passe ; se déconnecter ; supprimer son compte ; régler l'affichage ; savoir d'où viennent les cours.
+
+**Structure.** Un seul écran, quatre sections, sans sous-navigation.
+
+*Compte.* Adresse électronique, pseudonyme, date d'inscription, rôle. Lecture seule au MVP.
+
+*Sécurité.* Changement du mot de passe : ancien mot de passe, nouveau, confirmation. Déconnexion. Suppression du compte.
+
+*Affichage.* Devise d'affichage euro ou dollar. Masquage des montants par défaut.
+
+*À propos.* Version de l'application, sources de cours utilisées et leur fréquence de rafraîchissement, mention explicite que l'application ne fournit aucun conseil en investissement.
+
+**Composants.** `Champ`, `Bouton`, `BasculeDevise`, `MasquageMontants`, `Confirmation`, `MessageErreur`.
+
+**Interactions.** Le changement de mot de passe exige l'ancien et n'invalide pas la session en cours. La suppression du compte demande une confirmation par saisie du mot de passe et énonce sans ambiguïté ce qui sera supprimé, positions, mouvements et seuils compris, et que l'opération est irréversible.
+
+**Impacts API, à créer.** `PATCH /api/compte/mot-de-passe` et `DELETE /api/compte`. Les données du compte proviennent de `GET /api/auth/moi`, déjà disponible.
+
+**États particuliers.** *Ancien mot de passe incorrect* : erreur sur le champ concerné, sans indication de tentatives restantes. *Suppression en cours* : formulaire verrouillé, puis déconnexion et retour à la connexion avec message de confirmation.
+
+**Accessibilité.** Les sections sont des `section` avec titre. Le dialogue de suppression capture le focus et ne présélectionne jamais le bouton destructeur. Les réglages d'affichage sont des interrupteurs à `aria-checked`, avec un libellé qui décrit l'état et non l'action.
+
+**Questions ouvertes.**
+1. Le pseudonyme doit-il être modifiable ? Le modèle le permet, une route `PATCH` de plus. Recommandation : non au MVP, l'information ayant peu d'usage dans l'application.
+
+---
+
+# Partie III — Cohérence et parcours
+
+## Parcours principaux
+
+*Découverte.* Inscription, premier lancement, création de la première position, retour au tableau de bord renseigné. Trois écrans, aucune impasse.
+
+*Quotidien.* Connexion, tableau de bord, éventuellement détail d'une position. Zéro saisie.
+
+*Enregistrement.* Depuis n'importe quel écran, bouton d'ajout, feuille, récapitulatif, validation, retour à l'écran d'origine rafraîchi.
+
+*Surveillance.* Tableau de bord, seuils franchis en évidence, détail de la position concernée.
+
+## Règles métier visibles dans l'interface
+
+Ces règles sont énoncées à l'écran, en français, pour que le comportement ne surprenne jamais.
+
+- Le prix de revient est une moyenne pondérée ; une vente ne le modifie pas.
+- Une vente ne peut pas excéder la quantité détenue.
+- Un seuil est inclusif et ne se déclenche qu'une fois.
+- Les seuils sont évalués à la consultation du portefeuille, aucun envoi n'est effectué.
+- Quand un cours est indisponible, la dernière valeur connue est utilisée et signalée.
+- La devise de référence des calculs est l'euro ; la bascule ne change que l'affichage.
+
+## Points de vigilance identifiés
+
+1. La colonne « effet sur le prix de revient » de E4 n'est pas fournie par l'API (question ouverte E4.1).
+2. Deux routes restent à créer pour E7.
+3. L'écran d'administration prévu au périmètre n'est pas spécifié ici : il relève d'un parcours distinct et d'un rôle distinct.
+4. Le formatage des valeurs doit passer sans exception par le module dédié, sous peine de divergence entre écrans.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -44,7 +44,6 @@ Front-end dynamique et accessibilité.
 - formulaire d'ajout de transaction, détail d'un actif, gestion des alertes
 - gestion du jeton JWT côté client, gestion des erreurs d'API
 - responsive mobile-first, vérifications RGAA (contrastes, labels, navigation clavier)
-- fil d'annonces en lecture
 
 CP visées : CP3, CP4.
 Captures : tableau de bord en desktop et en mobile, contrôle d'accessibilité.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,51 +9,304 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^6.0.3",
+        "jsdom": "^29.1.1",
         "oxlint": "^1.71.0",
-        "vite": "^8.1.1"
+        "vite": "^8.1.1",
+        "vitest": "^4.1.10"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -630,6 +883,40 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
@@ -671,6 +958,92 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -681,6 +1054,38 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -707,6 +1112,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -737,12 +1143,260 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -752,6 +1406,53 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -787,11 +1488,83 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
@@ -1066,6 +1839,53 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
@@ -1083,6 +1903,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/oxlint": {
@@ -1134,6 +1968,26 @@
         }
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1184,6 +2038,31 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1202,12 +2081,82 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-router": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -1244,6 +2193,19 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -1253,6 +2215,19 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1261,6 +2236,57 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1280,6 +2306,62 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1287,6 +2369,16 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/vite": {
       "version": "8.1.5",
@@ -1366,6 +2458,178 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.18.2"
+        "react-router-dom": "7.18.2"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^7.0.0",
@@ -88,6 +88,7 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -103,6 +104,7 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -218,7 +220,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -267,9 +268,33 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -279,6 +304,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1060,7 +1086,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1100,7 +1127,6 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1112,7 +1138,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1262,6 +1287,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1272,6 +1298,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1413,7 +1440,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -1530,7 +1558,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -1855,6 +1882,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -2001,7 +2029,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2044,6 +2071,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -2068,7 +2096,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2081,7 +2108,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2095,7 +2121,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.18.2",
@@ -2386,7 +2413,6 @@
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.18.2"
+    "react-router-dom": "7.18.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^7.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,17 +7,24 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "oxlint",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.18.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^6.0.3",
+    "jsdom": "^29.1.1",
     "oxlint": "^1.71.0",
-    "vite": "^8.1.1"
+    "vite": "^8.1.1",
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,35 @@
-function App() {
-  return (
-    <main>
-      <h1>CapitAll</h1>
-      <p>Suivi de patrimoine multi-actifs — environnement en cours d'initialisation.</p>
-    </main>
-  )
-}
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { FournisseurAuthentification } from './contexte/Authentification';
+import RouteProtegee from './composants/RouteProtegee';
+import Coquille from './mise-en-page/Coquille';
+import Connexion from './pages/Connexion';
+import Inscription from './pages/Inscription';
+import TableauDeBord from './pages/TableauDeBord';
+import Introuvable from './pages/Introuvable';
 
-export default App
+export default function App() {
+  return (
+    <BrowserRouter>
+      <FournisseurAuthentification>
+        <Routes>
+          <Route path="/connexion" element={<Connexion />} />
+          <Route path="/inscription" element={<Inscription />} />
+
+          {/* Les écrans authentifiés partagent la même coquille de navigation. */}
+          <Route
+            element={
+              <RouteProtegee>
+                <Coquille />
+              </RouteProtegee>
+            }
+          >
+            <Route path="/tableau-de-bord" element={<TableauDeBord />} />
+          </Route>
+
+          <Route path="/" element={<Navigate to="/tableau-de-bord" replace />} />
+          <Route path="*" element={<Introuvable />} />
+        </Routes>
+      </FournisseurAuthentification>
+    </BrowserRouter>
+  );
+}

--- a/frontend/src/composants/Alerte.css
+++ b/frontend/src/composants/Alerte.css
@@ -1,0 +1,27 @@
+.alerte {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--espace-2);
+  font-size: var(--taille-corps);
+  padding: var(--espace-3);
+  border: 1px solid;
+  border-radius: var(--rayon-carte);
+  margin-bottom: var(--espace-4);
+}
+
+.alerte__symbole {
+  flex-shrink: 0;
+  font-weight: var(--graisse-forte);
+}
+
+.alerte--erreur {
+  color: var(--couleur-negatif);
+  border-color: var(--couleur-negatif);
+  background: rgba(240, 86, 79, 0.08);
+}
+
+.alerte--information {
+  color: var(--couleur-texte-attenue);
+  border-color: var(--couleur-bordure);
+  background: rgba(76, 154, 255, 0.06);
+}

--- a/frontend/src/composants/Alerte.jsx
+++ b/frontend/src/composants/Alerte.jsx
@@ -1,0 +1,26 @@
+import './Alerte.css';
+
+// Bandeau de message. Le symbole placé devant le texte double l'information portée
+// par la couleur : un daltonien, ou un écran en niveaux de gris, distingue toujours
+// une erreur d'une information.
+//
+// role="alert" pour une erreur : le message est annoncé dès son apparition, sans
+// attendre que l'utilisateur l'atteigne. Une simple information n'interrompt pas.
+const SYMBOLES = {
+  erreur: '⚠',
+  information: 'ℹ',
+};
+
+export default function Alerte({ variante = 'information', children }) {
+  return (
+    <p
+      className={`alerte alerte--${variante}`}
+      role={variante === 'erreur' ? 'alert' : 'status'}
+    >
+      <span className="alerte__symbole" aria-hidden="true">
+        {SYMBOLES[variante]}
+      </span>
+      <span>{children}</span>
+    </p>
+  );
+}

--- a/frontend/src/composants/Bouton.css
+++ b/frontend/src/composants/Bouton.css
@@ -1,0 +1,34 @@
+.bouton {
+  font-family: var(--police);
+  font-size: var(--taille-corps);
+  font-weight: var(--graisse-forte);
+  padding: var(--espace-3) var(--espace-4);
+  border-radius: var(--rayon-carte);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.bouton:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.bouton--primaire {
+  background: var(--couleur-accent);
+  color: #0b1015;
+}
+
+.bouton--primaire:hover:not(:disabled) {
+  background: #6aabff;
+}
+
+.bouton--secondaire {
+  background: transparent;
+  color: var(--couleur-texte);
+  border-color: var(--couleur-bordure);
+}
+
+.bouton--secondaire:hover:not(:disabled) {
+  border-color: var(--couleur-accent);
+}

--- a/frontend/src/composants/Bouton.jsx
+++ b/frontend/src/composants/Bouton.jsx
@@ -1,0 +1,26 @@
+import './Bouton.css';
+
+// Bouton de l'application. L'état d'envoi désactive le bouton et remplace son libellé,
+// ce qui empêche une double soumission et rend l'attente visible.
+export default function Bouton({
+  children,
+  variante = 'primaire',
+  type = 'button',
+  enCours = false,
+  desactive = false,
+  ...proprietes
+}) {
+  return (
+    <button
+      type={type}
+      className={`bouton bouton--${variante}`}
+      disabled={desactive || enCours}
+      // Annonce l'attente aux technologies d'assistance, que le libellé visuel
+      // change ou non.
+      aria-busy={enCours || undefined}
+      {...proprietes}
+    >
+      {enCours ? 'Envoi en cours…' : children}
+    </button>
+  );
+}

--- a/frontend/src/composants/Carte.css
+++ b/frontend/src/composants/Carte.css
@@ -1,0 +1,19 @@
+.carte {
+  background: var(--couleur-carte);
+  border: 1px solid var(--couleur-bordure);
+  border-radius: var(--rayon-carte);
+  padding: var(--espace-6);
+}
+
+.carte__entete {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--espace-3);
+  margin-bottom: var(--espace-4);
+}
+
+.carte__titre {
+  font-size: var(--taille-titre);
+  font-weight: var(--graisse-forte);
+}

--- a/frontend/src/composants/Carte.jsx
+++ b/frontend/src/composants/Carte.jsx
@@ -1,0 +1,18 @@
+import './Carte.css';
+
+// Conteneur standard de l'interface. Le titre est optionnel : lorsqu'il est fourni,
+// il est rendu comme un véritable en-tête et non comme un simple texte en gras, afin
+// que la structure du document reste navigable.
+export default function Carte({ titre, action, children, ...proprietes }) {
+  return (
+    <section className="carte" {...proprietes}>
+      {(titre || action) && (
+        <header className="carte__entete">
+          {titre && <h2 className="carte__titre">{titre}</h2>}
+          {action}
+        </header>
+      )}
+      {children}
+    </section>
+  );
+}

--- a/frontend/src/composants/Champ.css
+++ b/frontend/src/composants/Champ.css
@@ -1,0 +1,50 @@
+.champ {
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-1);
+  margin-bottom: var(--espace-4);
+}
+
+.champ__label {
+  font-size: var(--taille-legende);
+  font-weight: var(--graisse-forte);
+  color: var(--couleur-texte-attenue);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.champ__obligatoire {
+  color: var(--couleur-accent);
+}
+
+.champ__saisie {
+  font-family: var(--police);
+  font-size: var(--taille-corps);
+  color: var(--couleur-texte);
+  background: var(--couleur-fond);
+  border: 1px solid var(--couleur-bordure);
+  border-radius: var(--rayon-carte);
+  padding: var(--espace-3);
+}
+
+.champ__saisie::placeholder {
+  color: var(--couleur-texte-attenue);
+}
+
+.champ__saisie--erreur {
+  border-color: var(--couleur-negatif);
+}
+
+.champ__aide,
+.champ__erreur {
+  font-size: var(--taille-legende);
+  margin: 0;
+}
+
+.champ__aide {
+  color: var(--couleur-texte-attenue);
+}
+
+.champ__erreur {
+  color: var(--couleur-negatif);
+}

--- a/frontend/src/composants/Champ.jsx
+++ b/frontend/src/composants/Champ.jsx
@@ -1,0 +1,69 @@
+import { useId } from 'react';
+import './Champ.css';
+
+// Champ de formulaire accessible.
+//
+// Trois liens sont établis explicitement, sans quoi un lecteur d'écran n'annoncerait
+// ni le libellé, ni l'erreur, ni le caractère obligatoire :
+//   - le label pointe sur le champ par son identifiant ;
+//   - le message d'erreur est rattaché au champ par aria-describedby ;
+//   - aria-invalid signale l'erreur, en plus de la bordure rouge, la couleur ne
+//     devant jamais porter seule une information.
+export default function Champ({
+  label,
+  type = 'text',
+  valeur,
+  onChange,
+  erreur,
+  obligatoire = false,
+  aide,
+  ...proprietes
+}) {
+  const identifiant = useId();
+  const idErreur = `${identifiant}-erreur`;
+  const idAide = `${identifiant}-aide`;
+
+  const decritPar = [erreur ? idErreur : null, aide ? idAide : null].filter(Boolean).join(' ');
+
+  return (
+    <div className="champ">
+      <label className="champ__label" htmlFor={identifiant}>
+        {label}
+        {obligatoire && (
+          <span className="champ__obligatoire" aria-hidden="true">
+            {' '}
+            *
+          </span>
+        )}
+        {obligatoire && <span className="lecteur-ecran-seulement"> (obligatoire)</span>}
+      </label>
+
+      <input
+        id={identifiant}
+        type={type}
+        className={`champ__saisie${erreur ? ' champ__saisie--erreur' : ''}`}
+        value={valeur}
+        onChange={onChange}
+        required={obligatoire}
+        aria-invalid={erreur ? 'true' : undefined}
+        aria-describedby={decritPar || undefined}
+        {...proprietes}
+      />
+
+      {aide && (
+        <p className="champ__aide" id={idAide}>
+          {aide}
+        </p>
+      )}
+
+      {erreur && (
+        // role="alert" fait annoncer le message dès son apparition, sans attendre que
+        // l'utilisateur atteigne le champ.
+        <p className="champ__erreur" id={idErreur} role="alert">
+          <span aria-hidden="true">⚠ </span>
+          {erreur}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/composants/Chargement.css
+++ b/frontend/src/composants/Chargement.css
@@ -1,0 +1,18 @@
+.chargement {
+  display: flex;
+  justify-content: center;
+  padding: var(--espace-6);
+}
+
+.chargement__point {
+  width: 10px;
+  height: 10px;
+  border-radius: var(--rayon-pilule);
+  background: var(--couleur-accent);
+  animation: pulsation 1s ease-in-out infinite;
+}
+
+@keyframes pulsation {
+  0%, 100% { opacity: 0.3; transform: scale(0.85); }
+  50%      { opacity: 1;   transform: scale(1); }
+}

--- a/frontend/src/composants/Chargement.jsx
+++ b/frontend/src/composants/Chargement.jsx
@@ -1,0 +1,12 @@
+import './Chargement.css';
+
+// Indicateur d'attente. Le libellé est réservé aux lecteurs d'écran : à l'œil, le
+// mouvement suffit ; à la voix, un point animé ne dit rien.
+export default function Chargement({ libelle = 'Chargement en cours' }) {
+  return (
+    <div className="chargement" role="status">
+      <span className="chargement__point" aria-hidden="true" />
+      <span className="lecteur-ecran-seulement">{libelle}</span>
+    </div>
+  );
+}

--- a/frontend/src/composants/RouteProtegee.jsx
+++ b/frontend/src/composants/RouteProtegee.jsx
@@ -1,0 +1,19 @@
+// Garde de routes : sans jeton, l'accès est renvoyé vers la connexion.
+//
+// La route demandée est mémorisée dans l'état de navigation, ce qui permet d'y
+// revenir une fois connecté plutôt que d'atterrir systématiquement sur le tableau de
+// bord. C'est aussi ce qui se produit lorsqu'un jeton expire en cours de session.
+
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuthentification } from '../contexte/Authentification';
+
+export default function RouteProtegee({ children }) {
+  const { estConnecte } = useAuthentification();
+  const emplacement = useLocation();
+
+  if (!estConnecte) {
+    return <Navigate to="/connexion" replace state={{ depuis: emplacement.pathname }} />;
+  }
+
+  return children;
+}

--- a/frontend/src/composants/RouteProtegee.jsx
+++ b/frontend/src/composants/RouteProtegee.jsx
@@ -5,7 +5,7 @@
 // bord. C'est aussi ce qui se produit lorsqu'un jeton expire en cours de session.
 
 import { Navigate, useLocation } from 'react-router-dom';
-import { useAuthentification } from '../contexte/Authentification';
+import { useAuthentification } from '../contexte/contexteAuthentification';
 
 export default function RouteProtegee({ children }) {
   const { estConnecte } = useAuthentification();

--- a/frontend/src/composants/__tests__/RouteProtegee.test.jsx
+++ b/frontend/src/composants/__tests__/RouteProtegee.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import RouteProtegee from '../RouteProtegee';
+import * as contexte from '../../contexte/Authentification';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function rendreAvecSession(estConnecte) {
+  vi.spyOn(contexte, 'useAuthentification').mockReturnValue({
+    estConnecte,
+    jeton: estConnecte ? 'jeton' : null,
+    utilisateur: estConnecte ? { pseudo: 'Camille' } : null,
+  });
+
+  return render(
+    <MemoryRouter initialEntries={['/tableau-de-bord']}>
+      <Routes>
+        <Route path="/connexion" element={<p>Écran de connexion</p>} />
+        <Route
+          path="/tableau-de-bord"
+          element={
+            <RouteProtegee>
+              <p>Contenu protégé</p>
+            </RouteProtegee>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('garde de routes', () => {
+  it('redirige vers la connexion en l\'absence de jeton', () => {
+    rendreAvecSession(false);
+
+    expect(screen.getByText('Écran de connexion')).toBeInTheDocument();
+    expect(screen.queryByText('Contenu protégé')).not.toBeInTheDocument();
+  });
+
+  it('rend le contenu protégé lorsque la session existe', () => {
+    rendreAvecSession(true);
+
+    expect(screen.getByText('Contenu protégé')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/composants/__tests__/RouteProtegee.test.jsx
+++ b/frontend/src/composants/__tests__/RouteProtegee.test.jsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import RouteProtegee from '../RouteProtegee';
-import * as contexte from '../../contexte/Authentification';
+import * as contexte from '../../contexte/contexteAuthentification';
 
 afterEach(() => {
   cleanup();

--- a/frontend/src/contexte/Authentification.jsx
+++ b/frontend/src/contexte/Authentification.jsx
@@ -1,0 +1,68 @@
+// Contexte d'authentification. Le jeton vit uniquement dans l'état React (D57) :
+// il n'est écrit ni dans le stockage local, ni dans le stockage de session, ni dans
+// un cookie. Un rafraîchissement de page déconnecte donc l'utilisateur.
+//
+// Ce comportement est assumé : un jeton conservé par le navigateur reste lisible par
+// tout script injecté dans la page, ce qui est le principal scénario d'attaque sur une
+// application manipulant des données patrimoniales. La contrepartie, se reconnecter
+// après un rafraîchissement, est acceptable pour un usage de consultation.
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { api, definirRappelSessionPerdue } from '../services/api';
+
+const ContexteAuthentification = createContext(null);
+
+export function FournisseurAuthentification({ children }) {
+  const [jeton, setJeton] = useState(null);
+  const [utilisateur, setUtilisateur] = useState(null);
+
+  const deconnecter = useCallback(() => {
+    setJeton(null);
+    setUtilisateur(null);
+  }, []);
+
+  // Le client d'API prévient d'un 401 : la session est perdue, l'état est vidé et la
+  // garde de routes renvoie vers la connexion au rendu suivant.
+  useEffect(() => {
+    definirRappelSessionPerdue(deconnecter);
+    return () => definirRappelSessionPerdue(null);
+  }, [deconnecter]);
+
+  const connecter = useCallback(async (identifiants) => {
+    const reponse = await api.connexion(identifiants);
+    setJeton(reponse.token);
+    setUtilisateur(reponse.utilisateur);
+    return reponse.utilisateur;
+  }, []);
+
+  // L'inscription enchaîne sur une connexion : l'utilisateur qui vient de créer son
+  // compte n'a pas à saisir deux fois les mêmes identifiants.
+  const inscrire = useCallback(
+    async (donnees) => {
+      await api.inscription(donnees);
+      return connecter({ email: donnees.email, motDePasse: donnees.motDePasse });
+    },
+    [connecter]
+  );
+
+  const valeur = useMemo(
+    () => ({ jeton, utilisateur, estConnecte: Boolean(jeton), connecter, inscrire, deconnecter }),
+    [jeton, utilisateur, connecter, inscrire, deconnecter]
+  );
+
+  return (
+    <ContexteAuthentification.Provider value={valeur}>{children}</ContexteAuthentification.Provider>
+  );
+}
+
+export function useAuthentification() {
+  const contexte = useContext(ContexteAuthentification);
+
+  if (!contexte) {
+    throw new Error(
+      "useAuthentification doit être utilisé à l'intérieur de FournisseurAuthentification."
+    );
+  }
+
+  return contexte;
+}

--- a/frontend/src/contexte/Authentification.jsx
+++ b/frontend/src/contexte/Authentification.jsx
@@ -1,4 +1,4 @@
-// Contexte d'authentification. Le jeton vit uniquement dans l'état React (D57) :
+// Fournisseur d'authentification. Le jeton vit uniquement dans l'état React (D57) :
 // il n'est écrit ni dans le stockage local, ni dans le stockage de session, ni dans
 // un cookie. Un rafraîchissement de page déconnecte donc l'utilisateur.
 //
@@ -6,11 +6,13 @@
 // tout script injecté dans la page, ce qui est le principal scénario d'attaque sur une
 // application manipulant des données patrimoniales. La contrepartie, se reconnecter
 // après un rafraîchissement, est acceptable pour un usage de consultation.
+//
+// Le contexte et son hook d'accès vivent dans contexteAuthentification.js : ce fichier
+// n'exporte qu'un composant, condition du rechargement à chaud.
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { api, definirRappelSessionPerdue } from '../services/api';
-
-const ContexteAuthentification = createContext(null);
+import { ContexteAuthentification } from './contexteAuthentification';
 
 export function FournisseurAuthentification({ children }) {
   const [jeton, setJeton] = useState(null);
@@ -53,16 +55,4 @@ export function FournisseurAuthentification({ children }) {
   return (
     <ContexteAuthentification.Provider value={valeur}>{children}</ContexteAuthentification.Provider>
   );
-}
-
-export function useAuthentification() {
-  const contexte = useContext(ContexteAuthentification);
-
-  if (!contexte) {
-    throw new Error(
-      "useAuthentification doit être utilisé à l'intérieur de FournisseurAuthentification."
-    );
-  }
-
-  return contexte;
 }

--- a/frontend/src/contexte/contexteAuthentification.js
+++ b/frontend/src/contexte/contexteAuthentification.js
@@ -1,0 +1,21 @@
+// Contexte d'authentification et hook d'accès.
+//
+// Séparés du fournisseur, qui est un composant : un module qui exporte à la fois des
+// composants et des valeurs empêche le rechargement à chaud de fonctionner
+// correctement pendant le développement.
+
+import { createContext, useContext } from 'react';
+
+export const ContexteAuthentification = createContext(null);
+
+export function useAuthentification() {
+  const contexte = useContext(ContexteAuthentification);
+
+  if (!contexte) {
+    throw new Error(
+      "useAuthentification doit être utilisé à l'intérieur de FournisseurAuthentification."
+    );
+  }
+
+  return contexte;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,8 +1,0 @@
-:root {
-  color-scheme: light dark;
-  font: 16px/1.5 system-ui, 'Segoe UI', Roboto, sans-serif;
-}
-
-body {
-  margin: 0;
-}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './styles/base.css';
+import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />
-  </StrictMode>,
-)
+  </StrictMode>
+);

--- a/frontend/src/mise-en-page/Coquille.css
+++ b/frontend/src/mise-en-page/Coquille.css
@@ -1,0 +1,134 @@
+/*
+  Mobile d'abord : la navigation est une barre d'onglets fixée en bas de l'écran,
+  là où le pouce l'atteint. À partir de 900 pixels, elle devient une colonne latérale.
+*/
+
+.coquille {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.coquille__navigation {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  display: flex;
+  background: var(--couleur-carte);
+  border-top: 1px solid var(--couleur-bordure);
+}
+
+.coquille__marque,
+.coquille__pied {
+  display: none;
+}
+
+.coquille__liste {
+  display: flex;
+  flex: 1;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.coquille__liste > li {
+  flex: 1;
+}
+
+.coquille__lien {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--espace-1);
+  padding: var(--espace-2) var(--espace-1);
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+  text-decoration: none;
+}
+
+.coquille__lien--actif {
+  color: var(--couleur-accent);
+}
+
+/* L'indisponibilité se lit aussi au trait barré, pas seulement à l'opacité. */
+.coquille__lien--indisponible {
+  opacity: 0.45;
+  cursor: not-allowed;
+  text-decoration: line-through;
+}
+
+.coquille__symbole {
+  font-size: var(--taille-titre);
+  line-height: 1;
+}
+
+.coquille__contenu {
+  flex: 1;
+  padding: var(--espace-4);
+  padding-bottom: 88px;
+  max-width: 1440px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+@media (min-width: 900px) {
+  .coquille {
+    flex-direction: row;
+  }
+
+  .coquille__navigation {
+    position: sticky;
+    top: 0;
+    bottom: auto;
+    height: 100vh;
+    width: 220px;
+    flex-direction: column;
+    border-top: none;
+    border-right: 1px solid var(--couleur-bordure);
+    padding: var(--espace-6) var(--espace-4);
+    gap: var(--espace-6);
+  }
+
+  .coquille__marque {
+    display: block;
+    font-size: var(--taille-titre);
+    font-weight: var(--graisse-forte);
+  }
+
+  .coquille__liste {
+    flex-direction: column;
+    gap: var(--espace-1);
+  }
+
+  .coquille__lien {
+    flex-direction: row;
+    justify-content: flex-start;
+    gap: var(--espace-3);
+    padding: var(--espace-3);
+    font-size: var(--taille-corps);
+    border-radius: var(--rayon-carte);
+  }
+
+  .coquille__lien--actif {
+    background: rgba(76, 154, 255, 0.1);
+  }
+
+  .coquille__pied {
+    display: flex;
+    flex-direction: column;
+    gap: var(--espace-2);
+    margin-top: auto;
+  }
+
+  .coquille__pseudo {
+    font-size: var(--taille-legende);
+    color: var(--couleur-texte-attenue);
+  }
+
+  .coquille__contenu {
+    padding: var(--espace-8);
+    padding-bottom: var(--espace-8);
+  }
+}

--- a/frontend/src/mise-en-page/Coquille.jsx
+++ b/frontend/src/mise-en-page/Coquille.jsx
@@ -1,0 +1,67 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import { useAuthentification } from '../contexte/Authentification';
+import Bouton from '../composants/Bouton';
+import './Coquille.css';
+
+// Navigation principale. Les écrans non encore développés figurent déjà dans la
+// barre, désactivés : l'utilisateur voit où il ira, sans pouvoir atteindre une page
+// vide. Leur indisponibilité est portée par l'attribut aria-disabled et par une
+// mention textuelle, jamais par la seule couleur atténuée.
+const ENTREES = [
+  { chemin: '/tableau-de-bord', libelle: 'Tableau de bord', symbole: '◫', disponible: true },
+  { chemin: '/actifs', libelle: 'Actifs', symbole: '◈', disponible: false },
+  { chemin: '/alertes', libelle: 'Alertes', symbole: '△', disponible: false },
+  { chemin: '/annonces', libelle: 'Annonces', symbole: '✉', disponible: false },
+  { chemin: '/compte', libelle: 'Compte', symbole: '◉', disponible: false },
+];
+
+export default function Coquille() {
+  const { utilisateur, deconnecter } = useAuthentification();
+
+  return (
+    <div className="coquille">
+      <nav className="coquille__navigation" aria-label="Navigation principale">
+        <p className="coquille__marque">CapitAll</p>
+
+        <ul className="coquille__liste">
+          {ENTREES.map((entree) => (
+            <li key={entree.chemin}>
+              {entree.disponible ? (
+                <NavLink
+                  to={entree.chemin}
+                  className={({ isActive }) =>
+                    `coquille__lien${isActive ? ' coquille__lien--actif' : ''}`
+                  }
+                >
+                  <span className="coquille__symbole" aria-hidden="true">
+                    {entree.symbole}
+                  </span>
+                  <span className="coquille__libelle">{entree.libelle}</span>
+                </NavLink>
+              ) : (
+                <span className="coquille__lien coquille__lien--indisponible" aria-disabled="true">
+                  <span className="coquille__symbole" aria-hidden="true">
+                    {entree.symbole}
+                  </span>
+                  <span className="coquille__libelle">{entree.libelle}</span>
+                  <span className="lecteur-ecran-seulement"> (bientôt disponible)</span>
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+
+        <div className="coquille__pied">
+          {utilisateur && <p className="coquille__pseudo">{utilisateur.pseudo}</p>}
+          <Bouton variante="secondaire" onClick={deconnecter}>
+            Se déconnecter
+          </Bouton>
+        </div>
+      </nav>
+
+      <main className="coquille__contenu">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/mise-en-page/Coquille.jsx
+++ b/frontend/src/mise-en-page/Coquille.jsx
@@ -1,5 +1,5 @@
 import { NavLink, Outlet } from 'react-router-dom';
-import { useAuthentification } from '../contexte/Authentification';
+import { useAuthentification } from '../contexte/contexteAuthentification';
 import Bouton from '../composants/Bouton';
 import './Coquille.css';
 

--- a/frontend/src/pages/Authentification.css
+++ b/frontend/src/pages/Authentification.css
@@ -1,0 +1,35 @@
+.authentification {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--espace-4);
+}
+
+.authentification__carte {
+  width: 100%;
+  max-width: 400px;
+  background: var(--couleur-carte);
+  border: 1px solid var(--couleur-bordure);
+  border-radius: var(--rayon-carte);
+  padding: var(--espace-8) var(--espace-6);
+}
+
+.authentification__titre {
+  font-size: var(--taille-montant);
+  font-weight: var(--graisse-forte);
+  margin-bottom: var(--espace-2);
+}
+
+.authentification__intro {
+  font-size: var(--taille-corps);
+  color: var(--couleur-texte-attenue);
+  margin-bottom: var(--espace-6);
+}
+
+.authentification__bascule {
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+  text-align: center;
+  margin-top: var(--espace-6);
+}

--- a/frontend/src/pages/Connexion.jsx
+++ b/frontend/src/pages/Connexion.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom';
-import { useAuthentification } from '../contexte/Authentification';
+import { useAuthentification } from '../contexte/contexteAuthentification';
 import Bouton from '../composants/Bouton';
 import Champ from '../composants/Champ';
 import Alerte from '../composants/Alerte';

--- a/frontend/src/pages/Connexion.jsx
+++ b/frontend/src/pages/Connexion.jsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { useAuthentification } from '../contexte/Authentification';
+import Bouton from '../composants/Bouton';
+import Champ from '../composants/Champ';
+import Alerte from '../composants/Alerte';
+import './Authentification.css';
+
+export default function Connexion() {
+  const { connecter, estConnecte } = useAuthentification();
+  const naviguer = useNavigate();
+  const emplacement = useLocation();
+
+  const [email, setEmail] = useState('');
+  const [motDePasse, setMotDePasse] = useState('');
+  const [erreur, setErreur] = useState(null);
+  const [enCours, setEnCours] = useState(false);
+
+  // Route demandée avant la redirection vers la connexion, le cas échéant.
+  const destination = emplacement.state?.depuis ?? '/tableau-de-bord';
+
+  if (estConnecte) {
+    return <Navigate to={destination} replace />;
+  }
+
+  async function soumettre(evenement) {
+    evenement.preventDefault();
+    setErreur(null);
+    setEnCours(true);
+
+    try {
+      await connecter({ email, motDePasse });
+      naviguer(destination, { replace: true });
+    } catch (echec) {
+      // Le message du serveur est repris tel quel. Il est volontairement générique et
+      // ne distingue jamais l'adresse du mot de passe : le reformuler ici, ou tenter
+      // de préciser la cause, annulerait cette protection.
+      setErreur(echec.message);
+    } finally {
+      setEnCours(false);
+    }
+  }
+
+  return (
+    <main className="authentification">
+      <div className="authentification__carte">
+        <h1 className="authentification__titre">Connexion</h1>
+        <p className="authentification__intro">Accédez au suivi de votre patrimoine.</p>
+
+        {erreur && <Alerte variante="erreur">{erreur}</Alerte>}
+
+        <form onSubmit={soumettre} noValidate>
+          <Champ
+            label="Adresse électronique"
+            type="email"
+            autoComplete="email"
+            valeur={email}
+            onChange={(e) => setEmail(e.target.value)}
+            obligatoire
+          />
+
+          <Champ
+            label="Mot de passe"
+            type="password"
+            autoComplete="current-password"
+            valeur={motDePasse}
+            onChange={(e) => setMotDePasse(e.target.value)}
+            obligatoire
+          />
+
+          <Bouton type="submit" enCours={enCours}>
+            Se connecter
+          </Bouton>
+        </form>
+
+        <p className="authentification__bascule">
+          Pas encore de compte ? <Link to="/inscription">Créer un compte</Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/pages/Inscription.jsx
+++ b/frontend/src/pages/Inscription.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link, Navigate, useNavigate } from 'react-router-dom';
-import { useAuthentification } from '../contexte/Authentification';
+import { useAuthentification } from '../contexte/contexteAuthentification';
 import Bouton from '../composants/Bouton';
 import Champ from '../composants/Champ';
 import Alerte from '../composants/Alerte';

--- a/frontend/src/pages/Inscription.jsx
+++ b/frontend/src/pages/Inscription.jsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { Link, Navigate, useNavigate } from 'react-router-dom';
+import { useAuthentification } from '../contexte/Authentification';
+import Bouton from '../composants/Bouton';
+import Champ from '../composants/Champ';
+import Alerte from '../composants/Alerte';
+import './Authentification.css';
+
+// Contrôles repris de ceux du serveur, qui reste l'autorité : cette validation n'est
+// qu'un confort, elle évite un aller-retour réseau pour une erreur évidente.
+const LONGUEUR_MINIMALE_MOT_DE_PASSE = 10;
+
+function validerLocalement({ email, motDePasse }) {
+  const erreurs = {};
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    erreurs.email = "Le format de l'adresse est invalide.";
+  }
+  if (motDePasse.length < LONGUEUR_MINIMALE_MOT_DE_PASSE) {
+    erreurs.motDePasse = `Le mot de passe doit contenir au moins ${LONGUEUR_MINIMALE_MOT_DE_PASSE} caractères.`;
+  }
+
+  return erreurs;
+}
+
+export default function Inscription() {
+  const { inscrire, estConnecte } = useAuthentification();
+  const naviguer = useNavigate();
+
+  const [email, setEmail] = useState('');
+  const [motDePasse, setMotDePasse] = useState('');
+  const [pseudo, setPseudo] = useState('');
+  const [erreursChamps, setErreursChamps] = useState({});
+  const [erreur, setErreur] = useState(null);
+  const [enCours, setEnCours] = useState(false);
+
+  if (estConnecte) {
+    return <Navigate to="/tableau-de-bord" replace />;
+  }
+
+  async function soumettre(evenement) {
+    evenement.preventDefault();
+    setErreur(null);
+
+    const erreursLocales = validerLocalement({ email, motDePasse });
+    setErreursChamps(erreursLocales);
+    if (Object.keys(erreursLocales).length > 0) {
+      return;
+    }
+
+    setEnCours(true);
+    try {
+      // L'inscription enchaîne sur la connexion : inutile de ressaisir les mêmes
+      // identifiants immédiatement après avoir créé le compte.
+      await inscrire({ email, motDePasse, ...(pseudo ? { pseudo } : {}) });
+      naviguer('/tableau-de-bord', { replace: true });
+    } catch (echec) {
+      // Le serveur renvoie une erreur par champ sur une validation, et un message
+      // global sur un conflit d'adresse déjà utilisée.
+      if (echec.champs) {
+        setErreursChamps(
+          Object.fromEntries(echec.champs.map((entree) => [entree.champ, entree.message]))
+        );
+      }
+      setErreur(echec.message);
+    } finally {
+      setEnCours(false);
+    }
+  }
+
+  return (
+    <main className="authentification">
+      <div className="authentification__carte">
+        <h1 className="authentification__titre">Créer un compte</h1>
+        <p className="authentification__intro">
+          Réunissez vos cryptomonnaies, devises, métaux et actions sur un seul tableau de bord.
+        </p>
+
+        {erreur && <Alerte variante="erreur">{erreur}</Alerte>}
+
+        <form onSubmit={soumettre} noValidate>
+          <Champ
+            label="Adresse électronique"
+            type="email"
+            autoComplete="email"
+            valeur={email}
+            onChange={(e) => setEmail(e.target.value)}
+            erreur={erreursChamps.email}
+            obligatoire
+          />
+
+          <Champ
+            label="Mot de passe"
+            type="password"
+            autoComplete="new-password"
+            valeur={motDePasse}
+            onChange={(e) => setMotDePasse(e.target.value)}
+            erreur={erreursChamps.motDePasse}
+            aide={`${LONGUEUR_MINIMALE_MOT_DE_PASSE} caractères minimum.`}
+            obligatoire
+          />
+
+          <Champ
+            label="Pseudonyme"
+            valeur={pseudo}
+            onChange={(e) => setPseudo(e.target.value)}
+            erreur={erreursChamps.pseudo}
+            aide="Facultatif. À défaut, votre adresse servira de nom d'affichage."
+          />
+
+          <Bouton type="submit" enCours={enCours}>
+            Créer mon compte
+          </Bouton>
+        </form>
+
+        <p className="authentification__bascule">
+          Déjà inscrit ? <Link to="/connexion">Se connecter</Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/pages/Introuvable.jsx
+++ b/frontend/src/pages/Introuvable.jsx
@@ -1,0 +1,13 @@
+import { Link } from 'react-router-dom';
+
+export default function Introuvable() {
+  return (
+    <main style={{ padding: 'var(--espace-8)', textAlign: 'center' }}>
+      <h1 style={{ fontSize: 'var(--taille-montant)' }}>Page introuvable</h1>
+      <p style={{ color: 'var(--couleur-texte-attenue)', margin: 'var(--espace-4) 0' }}>
+        Cette adresse ne correspond à aucun écran de l'application.
+      </p>
+      <Link to="/tableau-de-bord">Retour au tableau de bord</Link>
+    </main>
+  );
+}

--- a/frontend/src/pages/TableauDeBord.jsx
+++ b/frontend/src/pages/TableauDeBord.jsx
@@ -1,0 +1,25 @@
+import { useAuthentification } from '../contexte/Authentification';
+import Carte from '../composants/Carte';
+
+// Écran provisoire. Le tableau de bord réel, avec ses indicateurs, son anneau de
+// répartition et sa courbe d'évolution, est développé au lot suivant.
+export default function TableauDeBord() {
+  const { utilisateur } = useAuthentification();
+
+  return (
+    <>
+      <h1>Tableau de bord</h1>
+      <p style={{ color: 'var(--couleur-texte-attenue)', marginBottom: 'var(--espace-6)' }}>
+        Bonjour {utilisateur?.pseudo ?? 'et bienvenue'}.
+      </p>
+
+      <Carte titre="Interface en cours de construction">
+        <p>
+          Le socle est en place : authentification, navigation et composants de base. Les
+          indicateurs, la répartition par classe d'actif et la courbe d'évolution arrivent
+          au prochain lot.
+        </p>
+      </Carte>
+    </>
+  );
+}

--- a/frontend/src/pages/TableauDeBord.jsx
+++ b/frontend/src/pages/TableauDeBord.jsx
@@ -1,4 +1,4 @@
-import { useAuthentification } from '../contexte/Authentification';
+import { useAuthentification } from '../contexte/contexteAuthentification';
 import Carte from '../composants/Carte';
 
 // Écran provisoire. Le tableau de bord réel, avec ses indicateurs, son anneau de

--- a/frontend/src/pages/__tests__/Connexion.test.jsx
+++ b/frontend/src/pages/__tests__/Connexion.test.jsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Connexion from '../Connexion';
-import * as contexte from '../../contexte/Authentification';
+import * as contexte from '../../contexte/contexteAuthentification';
 
 afterEach(() => {
   cleanup();

--- a/frontend/src/pages/__tests__/Connexion.test.jsx
+++ b/frontend/src/pages/__tests__/Connexion.test.jsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Connexion from '../Connexion';
+import * as contexte from '../../contexte/Authentification';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('écran de connexion', () => {
+  it("affiche le message du serveur sans le reformuler", async () => {
+    const messageServeur = 'Email ou mot de passe incorrect.';
+    const connecter = vi.fn().mockRejectedValue(new Error(messageServeur));
+
+    vi.spyOn(contexte, 'useAuthentification').mockReturnValue({
+      estConnecte: false,
+      connecter,
+    });
+
+    render(
+      <MemoryRouter>
+        <Connexion />
+      </MemoryRouter>
+    );
+
+    // La soumission passe par le formulaire : c'est le chemin réel de l'utilisateur.
+    screen.getByRole('button', { name: /se connecter/i }).click();
+
+    await waitFor(() => {
+      // Le message doit apparaître à l'identique, sans mention de l'adresse ou du
+      // mot de passe : c'est ce qui empêche de savoir si un compte existe.
+      expect(screen.getByRole('alert')).toHaveTextContent(messageServeur);
+    });
+  });
+
+  it('associe un libellé à chaque champ de saisie', () => {
+    vi.spyOn(contexte, 'useAuthentification').mockReturnValue({
+      estConnecte: false,
+      connecter: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <Connexion />
+      </MemoryRouter>
+    );
+
+    // getByLabelText échoue si le label n'est pas relié au champ : le test vaut
+    // vérification d'accessibilité.
+    expect(screen.getByLabelText(/adresse électronique/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/mot de passe/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/services/__tests__/api.test.js
+++ b/frontend/src/services/__tests__/api.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { requete, definirRappelSessionPerdue, ErreurApi } from '../api';
+
+function reponseFactice({ statut = 200, corps = {} } = {}) {
+  return {
+    ok: statut >= 200 && statut < 300,
+    status: statut,
+    json: async () => corps,
+  };
+}
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  definirRappelSessionPerdue(null);
+  vi.restoreAllMocks();
+});
+
+describe("client d'API", () => {
+  it("ajoute l'en-tête d'autorisation quand un jeton est fourni", async () => {
+    global.fetch.mockResolvedValue(reponseFactice({ corps: { ok: true } }));
+
+    await requete('/portefeuille', { jeton: 'jeton-de-test' });
+
+    const [, options] = global.fetch.mock.calls[0];
+    expect(options.headers.Authorization).toBe('Bearer jeton-de-test');
+  });
+
+  it("omet l'en-tête d'autorisation en l'absence de jeton", async () => {
+    global.fetch.mockResolvedValue(reponseFactice({ corps: { ok: true } }));
+
+    await requete('/auth/connexion', { methode: 'POST', corps: { email: 'a@b.fr' } });
+
+    const [, options] = global.fetch.mock.calls[0];
+    expect(options.headers.Authorization).toBeUndefined();
+    expect(options.headers['Content-Type']).toBe('application/json');
+  });
+
+  // Le jeton expire au bout de deux heures : ce cas se produit en usage réel, et
+  // l'interface doit alors renvoyer l'utilisateur vers la connexion.
+  it('déclenche la perte de session sur une réponse 401', async () => {
+    const surSessionPerdue = vi.fn();
+    definirRappelSessionPerdue(surSessionPerdue);
+    global.fetch.mockResolvedValue(
+      reponseFactice({ statut: 401, corps: { erreur: "Jeton d'authentification invalide ou expiré." } })
+    );
+
+    await expect(requete('/portefeuille', { jeton: 'perime' })).rejects.toThrow(ErreurApi);
+    expect(surSessionPerdue).toHaveBeenCalledTimes(1);
+  });
+
+  it('ne déclenche pas la perte de session sur une autre erreur', async () => {
+    const surSessionPerdue = vi.fn();
+    definirRappelSessionPerdue(surSessionPerdue);
+    global.fetch.mockResolvedValue(reponseFactice({ statut: 409, corps: { erreur: 'Déjà utilisé.' } }));
+
+    await expect(requete('/auth/inscription', { methode: 'POST', corps: {} })).rejects.toThrow(
+      'Déjà utilisé.'
+    );
+    expect(surSessionPerdue).not.toHaveBeenCalled();
+  });
+
+  it("expose le message du serveur sans le reformuler", async () => {
+    global.fetch.mockResolvedValue(
+      reponseFactice({ statut: 401, corps: { erreur: 'Email ou mot de passe incorrect.' } })
+    );
+
+    await expect(requete('/auth/connexion', { methode: 'POST', corps: {} })).rejects.toThrow(
+      'Email ou mot de passe incorrect.'
+    );
+  });
+
+  it('traduit une panne réseau en message lisible', async () => {
+    global.fetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    await expect(requete('/portefeuille')).rejects.toThrow(/injoignable/);
+  });
+});

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,91 @@
+// Point de passage unique vers le serveur. Aucun composant n'appelle fetch
+// directement : l'en-tête d'autorisation, le traitement des erreurs et la perte de
+// session sont donc traités à un seul endroit.
+//
+// Les appels partent en chemin relatif : en développement, le serveur de Vite les
+// redirige vers l'API (voir vite.config.js) ; en production, l'interface et l'API
+// sont servies sous la même origine. Aucune adresse d'API n'a donc à figurer ici.
+
+const BASE = '/api';
+
+// Rappel posé par le contexte d'authentification. Il est appelé lorsque le serveur
+// répond 401, c'est-à-dire quand le jeton a expiré ou n'est plus valable. Le jeton
+// ayant une durée de vie de deux heures, ce cas se produit réellement en usage.
+let surSessionPerdue = null;
+
+export function definirRappelSessionPerdue(rappel) {
+  surSessionPerdue = rappel;
+}
+
+export class ErreurApi extends Error {
+  constructor(message, statut, champs) {
+    super(message);
+    this.name = 'ErreurApi';
+    this.statut = statut;
+    // Erreurs de validation, champ par champ, telles que le serveur les renvoie.
+    this.champs = champs ?? null;
+  }
+}
+
+async function lireCorps(reponse) {
+  // Un 204 n'a pas de corps, et une erreur d'infrastructure peut ne pas être du JSON.
+  if (reponse.status === 204) {
+    return null;
+  }
+  try {
+    return await reponse.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function requete(chemin, { methode = 'GET', corps, jeton } = {}) {
+  const entetes = {};
+
+  if (corps !== undefined) {
+    entetes['Content-Type'] = 'application/json';
+  }
+  if (jeton) {
+    entetes.Authorization = `Bearer ${jeton}`;
+  }
+
+  let reponse;
+  try {
+    reponse = await fetch(`${BASE}${chemin}`, {
+      method: methode,
+      headers: entetes,
+      body: corps !== undefined ? JSON.stringify(corps) : undefined,
+    });
+  } catch {
+    // Coupure réseau ou serveur injoignable : l'appelant reçoit un message lisible
+    // plutôt qu'une exception technique.
+    throw new ErreurApi('Le serveur est injoignable. Vérifiez votre connexion.', 0);
+  }
+
+  const donnees = await lireCorps(reponse);
+
+  if (reponse.ok) {
+    return donnees;
+  }
+
+  if (reponse.status === 401) {
+    // La session n'est plus valable : le contexte vide le jeton, la garde de routes
+    // renvoie alors vers la connexion.
+    surSessionPerdue?.();
+  }
+
+  // Le serveur normalise déjà ses erreurs : on expose son message plutôt qu'un objet
+  // brut, sans jamais le reformuler. Un message d'échec de connexion volontairement
+  // générique doit arriver tel quel à l'utilisateur.
+  throw new ErreurApi(
+    donnees?.erreur ?? 'Une erreur est survenue.',
+    reponse.status,
+    donnees?.champs
+  );
+}
+
+export const api = {
+  inscription: (donnees) => requete('/auth/inscription', { methode: 'POST', corps: donnees }),
+  connexion: (donnees) => requete('/auth/connexion', { methode: 'POST', corps: donnees }),
+  profil: (jeton) => requete('/auth/moi', { jeton }),
+};

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -1,0 +1,89 @@
+/* Socle visuel : remise à zéro minimale et application des jetons. */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+@import './tokens.css';
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body,
+h1,
+h2,
+h3,
+p,
+figure {
+  margin: 0;
+}
+
+body {
+  background: var(--couleur-fond);
+  color: var(--couleur-texte);
+  font-family: var(--police);
+  font-size: var(--taille-corps);
+  font-weight: var(--graisse-normale);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1 {
+  font-size: var(--taille-titre);
+  font-weight: var(--graisse-forte);
+}
+
+h2 {
+  font-size: var(--taille-corps);
+  font-weight: var(--graisse-forte);
+}
+
+a {
+  color: var(--couleur-accent);
+}
+
+/*
+  Indicateur de focus défini une seule fois pour tout le document. Il reste visible
+  au clavier, condition d'une navigation sans souris : le supprimer rendrait
+  l'application inutilisable pour qui n'emploie pas de pointeur.
+*/
+:focus-visible {
+  outline: 2px solid var(--couleur-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/*
+  Chiffres à chasse fixe : sans cela, les montants d'une colonne ne s'alignent pas
+  verticalement, chaque chiffre ayant sa propre largeur.
+*/
+.montant {
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--graisse-forte);
+}
+
+.montant-principal {
+  font-size: var(--taille-montant);
+}
+
+/* Réservé aux lecteurs d'écran : invisible à l'œil, restitué à la voix. */
+.lecteur-ecran-seulement {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,0 +1,43 @@
+/*
+  Jetons de la direction artistique (D10) : interface sombre, sobre, pensée pour la
+  lecture de chiffres. Les valeurs sont reprises telles quelles dans le dépôt plutôt
+  qu'importées d'ailleurs, afin que le projet reste autonome.
+
+  Les contrastes du texte sur les fonds sombres respectent le seuil de 4,5:1 exigé par
+  le référentiel d'accessibilité. Le vert et le rouge ne portent jamais seuls une
+  information : un signe ou un symbole les accompagne systématiquement.
+*/
+
+:root {
+  /* Couleurs */
+  --couleur-fond: #101418;
+  --couleur-carte: #1a2027;
+  --couleur-bordure: #2d3640;
+  --couleur-texte: #e8ecf1;
+  --couleur-texte-attenue: #9aa7b4;
+  --couleur-accent: #4c9aff;
+  --couleur-positif: #34c77b;
+  --couleur-negatif: #f0564f;
+
+  /* Espacements */
+  --espace-1: 4px;
+  --espace-2: 8px;
+  --espace-3: 12px;
+  --espace-4: 16px;
+  --espace-6: 24px;
+  --espace-8: 32px;
+
+  /* Rayons */
+  --rayon-carte: 10px;
+  --rayon-pilule: 999px;
+
+  /* Typographie */
+  --police: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --graisse-normale: 400;
+  --graisse-forte: 600;
+
+  --taille-legende: 12px;
+  --taille-corps: 14px;
+  --taille-titre: 18px;
+  --taille-montant: 26px;
+}

--- a/frontend/src/test/preparation.js
+++ b/frontend/src/test/preparation.js
@@ -1,0 +1,3 @@
+// Mise en place commune des tests d'interface : ajoute les assertions de jest-dom
+// (toBeInTheDocument, toHaveAttribute...) au vocabulaire d'expect.
+import '@testing-library/jest-dom/vitest';

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,22 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+
+  server: {
+    // Les appels à l'API partent en chemin relatif (/api/...) et sont redirigés ici
+    // vers le serveur de développement. Le navigateur ne voit donc qu'une seule
+    // origine : aucune question de partage entre origines en développement, et aucune
+    // adresse d'API à porter dans le code ni dans une variable d'environnement.
+    proxy: {
+      '/api': 'http://localhost:5000',
+    },
+  },
+
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/preparation.js',
+  },
+});


### PR DESCRIPTION
Closes #30, closes #31, closes #33, closes #89, closes #90, closes #91, closes #92, closes #94

Socle de l'interface et parcours d'authentification, premier lot front.

## Contenu

- **Structure et outillage** : routage `react-router-dom`, tests d'interface sous Vitest en environnement jsdom, et proxy de développement redirigeant `/api` vers le serveur. Les appels partent en chemin relatif : le navigateur ne voit qu'une seule origine, et aucune adresse d'API ne figure dans le code.
- **Jetons de style et composants de base** : les valeurs de la direction artistique sont recopiées dans le dépôt plutôt qu'importées d'ailleurs. Cinq composants réutilisables : bouton, champ, carte, message, indicateur de chargement.
- **Client d'API unique** : aucun composant n'appelle `fetch` directement. L'en-tête d'autorisation, la traduction des erreurs et la perte de session sont traités à un seul endroit. Une réponse 401 déclenche la fin de session et le retour vers la connexion, cas qui se produit réellement puisque le jeton expire au bout de deux heures.
- **Contexte d'authentification** : le jeton vit uniquement dans l'état React (D57), jamais dans le stockage du navigateur. Un rafraîchissement de page déconnecte, comportement assumé et à signaler pendant la démonstration.
- **Garde de routes** : une route privée atteinte sans jeton redirige vers la connexion en mémorisant la destination demandée.
- **Écrans de connexion et d'inscription** : formulaires contrôlés, validation locale alignée sur celle du serveur qui reste l'autorité, bouton verrouillé pendant l'appel réseau. Le message d'échec de connexion est repris tel que le serveur le renvoie, sans jamais être reformulé : il ne distingue pas l'adresse du mot de passe.
- **Restriction des origines côté serveur** : l'API n'accepte plus que l'origine de l'interface, avec l'en-tête d'autorisation explicitement admis.

## Épinglage de `react-router-dom` en 7.18.2

D62 prévoyait un épinglage en 7.11.0, version antérieure à l'intervalle affecté par l'avis connu. L'audit rejoué au moment d'appliquer a contredit cette hypothèse : la 7.11.0 cumule douze avis de sécurité contre un seul pour la 7.18.2, dont une redirection ouverte via `<Link>` et `useNavigate`, composants effectivement employés par l'interface. L'outil d'audit désigne d'ailleurs la 7.18.2 comme le correctif.

La cible a donc été révisée : l'épinglage est conservé, en 7.18.2 exacte, sans intervalle. L'objectif de reproductibilité est atteint sans régression de sécurité. La vulnérabilité résiduelle, propre au mode React Server Components qui n'est pas utilisé ici, est documentée dans la veille du dossier avec sa justification de non-exposition.

## Documents de conception versionnés

- `docs/conception/specification-fonctionnelle.md` : principes transverses (lexique, navigation, grammaire visuelle, bibliothèque de composants, grammaire des états, premier lancement) puis spécification écran par écran.
- `docs/conception/formatage-nombres.md` : politique de formatage de toute valeur numérique affichée.

Ces deux documents servent de référence aux lots d'interface suivants.

## Vérifications

167 tests au vert côté serveur et 10 côté interface. Le décompte serveur intègre les huit tests d'authentification arrivés avec D60, rapatriée dans cette branche par une fusion de `dev`.

Construction sans avertissement, `oxlint` sans avertissement. Le hook d'authentification a été séparé de son fournisseur pour satisfaire cette dernière condition : un module exportant à la fois un composant et une valeur empêche le rechargement à chaud de fonctionner.

Aucun appel à `localStorage` ni `sessionStorage` dans l'ensemble de l'interface, conformément à D57.

## Liste de contrôle

- [x] Jeton en memoire uniquement, aucune persistance
- [x] Aucun composant n'appelle fetch directement
- [x] Champs, libelles et messages d'erreur relies pour l'accessibilite
- [x] Aucun calcul monetaire cote interface
- [x] Tests, construction et lint sans avertissement
- [x] Messages de commit conformes a docs/convention-commits.md
