### PR TITLE
Socle d'affichage : formatage des valeurs et composants associés

### DIFF
--- a/frontend/src/composants/JetonClasse.css
+++ b/frontend/src/composants/JetonClasse.css
@@ -1,0 +1,39 @@
+.jeton-classe {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--espace-2);
+  font-size: var(--taille-legende);
+}
+
+.jeton-classe__forme {
+  flex: none;
+  width: 12px;
+  height: 12px;
+  /*
+    La direction artistique fixe une forme par classe mais aucune couleur par classe :
+    le jeton reprend donc l'accent de l'interface, la distinction restant portée par la
+    géométrie. Le jour où des couleurs de classe seront arbitrées, elles s'ajouteront
+    ici sans toucher au composant.
+  */
+  background-color: var(--couleur-accent);
+}
+
+.jeton-classe__forme--crypto {
+  border-radius: 50%;
+}
+
+.jeton-classe__forme--metal {
+  border-radius: 3px;
+}
+
+.jeton-classe__forme--devise {
+  transform: rotate(45deg);
+}
+
+.jeton-classe__forme--action {
+  clip-path: polygon(50% 0%, 93% 25%, 93% 75%, 50% 100%, 7% 75%, 7% 25%);
+}
+
+.jeton-classe__libelle {
+  color: var(--couleur-texte-attenue);
+}

--- a/frontend/src/composants/JetonClasse.jsx
+++ b/frontend/src/composants/JetonClasse.jsx
@@ -1,0 +1,35 @@
+import './JetonClasse.css';
+import { CLASSES_QUANTITE } from '../utils/formatage';
+
+// Marqueur visuel de la classe d'un actif.
+//
+// La classe se distingue d'abord par la forme, cercle, carré arrondi, losange ou
+// hexagone, et non par la couleur : le repère survit ainsi à un affichage en niveaux de
+// gris comme à un daltonisme. C'est la règle posée par la direction artistique.
+//
+// La forme seule ne se prononce pas : le nom de la classe accompagne toujours le jeton,
+// visible lorsque l'appelant le demande, restitué à la voix dans tous les cas.
+
+const LIBELLES = {
+  crypto: 'Cryptomonnaie',
+  metal: 'Métal précieux',
+  devise: 'Devise',
+  action: 'Action',
+};
+
+export default function JetonClasse({ classe, avecLibelle = false, ...proprietes }) {
+  if (!CLASSES_QUANTITE.includes(classe)) {
+    return null;
+  }
+
+  const libelle = LIBELLES[classe];
+
+  return (
+    <span className="jeton-classe" {...proprietes}>
+      <span className={`jeton-classe__forme jeton-classe__forme--${classe}`} aria-hidden="true" />
+      <span className={avecLibelle ? 'jeton-classe__libelle' : 'lecteur-ecran-seulement'}>
+        {libelle}
+      </span>
+    </span>
+  );
+}

--- a/frontend/src/composants/Message.css
+++ b/frontend/src/composants/Message.css
@@ -1,4 +1,4 @@
-.alerte {
+.message {
   display: flex;
   align-items: flex-start;
   gap: var(--espace-2);
@@ -9,18 +9,18 @@
   margin-bottom: var(--espace-4);
 }
 
-.alerte__symbole {
+.message__symbole {
   flex-shrink: 0;
   font-weight: var(--graisse-forte);
 }
 
-.alerte--erreur {
+.message--erreur {
   color: var(--couleur-negatif);
   border-color: var(--couleur-negatif);
   background: rgba(240, 86, 79, 0.08);
 }
 
-.alerte--information {
+.message--information {
   color: var(--couleur-texte-attenue);
   border-color: var(--couleur-bordure);
   background: rgba(76, 154, 255, 0.06);

--- a/frontend/src/composants/Message.jsx
+++ b/frontend/src/composants/Message.jsx
@@ -1,6 +1,9 @@
-import './Alerte.css';
+import './Message.css';
 
-// Bandeau de message. Le symbole placé devant le texte double l'information portée
+// Bandeau de message. Le terme « alerte » est réservé aux seuils de franchissement du
+// portefeuille : l'employer ici aussi installerait une ambiguïté durable.
+//
+// Le symbole placé devant le texte double l'information portée
 // par la couleur : un daltonien, ou un écran en niveaux de gris, distingue toujours
 // une erreur d'une information.
 //
@@ -11,13 +14,13 @@ const SYMBOLES = {
   information: 'ℹ',
 };
 
-export default function Alerte({ variante = 'information', children }) {
+export default function Message({ variante = 'information', children }) {
   return (
     <p
-      className={`alerte alerte--${variante}`}
+      className={`message message--${variante}`}
       role={variante === 'erreur' ? 'alert' : 'status'}
     >
-      <span className="alerte__symbole" aria-hidden="true">
+      <span className="message__symbole" aria-hidden="true">
         {SYMBOLES[variante]}
       </span>
       <span>{children}</span>

--- a/frontend/src/composants/Montant.css
+++ b/frontend/src/composants/Montant.css
@@ -1,0 +1,29 @@
+.montant {
+  /* Chiffres de largeur fixe : sans cela, les colonnes de montants se décalent d'une
+     ligne à l'autre selon les chiffres présents. */
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.montant--corps {
+  font-size: var(--taille-corps);
+}
+
+.montant--legende {
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+}
+
+.montant--titre {
+  font-size: var(--taille-titre);
+  font-weight: var(--graisse-forte);
+}
+
+.montant--principal {
+  font-size: var(--taille-montant);
+  font-weight: var(--graisse-forte);
+}
+
+.montant--indisponible {
+  color: var(--couleur-texte-attenue);
+}

--- a/frontend/src/composants/Montant.jsx
+++ b/frontend/src/composants/Montant.jsx
@@ -1,0 +1,53 @@
+import './Montant.css';
+import {
+  formaterMontant,
+  formaterQuantite,
+  formaterCours,
+  formaterTaux,
+  formaterPourcentage,
+} from '../utils/formatage';
+
+// Affiche une valeur numérique. C'est le seul point d'entrée de l'interface vers la
+// politique de formatage : aucun écran ne met en forme un nombre par lui-même, ce qui
+// rend la conformité vérifiable par une simple recherche des appels à ce composant.
+//
+// La valeur arrive toujours sous forme de chaîne, telle que l'API la renvoie. Lui faire
+// traverser un nombre, même le temps d'un passage de propriété, suffirait à altérer une
+// quantité à huit décimales.
+
+const FORMATEURS = {
+  montant: (valeur) => formaterMontant(valeur),
+  quantite: (valeur, classe, symbole) => formaterQuantite(valeur, classe, symbole),
+  cours: (valeur) => formaterCours(valeur),
+  taux: (valeur) => formaterTaux(valeur),
+  pourcentage: (valeur) => formaterPourcentage(valeur),
+};
+
+export default function Montant({
+  valeur,
+  type = 'montant',
+  classe,
+  symbole,
+  taille = 'corps',
+  ...proprietes
+}) {
+  const formateur = FORMATEURS[type];
+  const texte = formateur ? formateur(valeur, classe, symbole) : null;
+
+  // Une valeur absente ou invalide s'affiche par un tiret cadratin plutôt que par un
+  // zéro : « pas de donnée » et « zéro » ne se confondent pas sur un patrimoine.
+  if (texte === null) {
+    return (
+      <span className={`montant montant--${taille} montant--indisponible`} {...proprietes}>
+        <span aria-hidden="true">—</span>
+        <span className="lecteur-ecran-seulement">valeur indisponible</span>
+      </span>
+    );
+  }
+
+  return (
+    <span className={`montant montant--${taille}`} {...proprietes}>
+      {texte}
+    </span>
+  );
+}

--- a/frontend/src/composants/PastilleFraicheur.css
+++ b/frontend/src/composants/PastilleFraicheur.css
@@ -1,0 +1,25 @@
+.pastille-fraicheur {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--espace-1);
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+}
+
+.pastille-fraicheur__marque {
+  flex: none;
+  line-height: 1;
+}
+
+.pastille-fraicheur--actuel .pastille-fraicheur__marque {
+  color: var(--couleur-positif);
+}
+
+/*
+  Repli sur le dernier cours connu. La marque passe au demi-cercle en plus de changer de
+  teinte : l'état reste identifiable sans la couleur, et la valorisation continue d'être
+  affichée plutôt que masquée, comme le veut la spécification.
+*/
+.pastille-fraicheur--tiede .pastille-fraicheur__marque {
+  color: var(--couleur-accent);
+}

--- a/frontend/src/composants/PastilleFraicheur.jsx
+++ b/frontend/src/composants/PastilleFraicheur.jsx
@@ -1,0 +1,39 @@
+import './PastilleFraicheur.css';
+import { formaterAnciennete } from '../utils/duree';
+
+// Ancienneté et provenance d'un cours.
+//
+// Deux états seulement, et ils ne se déduisent pas d'une horloge : un cours est à jour,
+// ou bien il provient du dernier cours connu parce que le fournisseur n'a pas répondu.
+// C'est le repli signalé par la réponse de l'API, la seule distinction que la
+// spécification nomme. Aucun seuil de durée n'est inventé ici : la pastille rend compte
+// d'un fait transmis par le serveur, elle ne le décide pas.
+//
+// La couleur ne porte rien seule : l'état tiède ajoute un symbole et l'ancienneté est
+// écrite en toutes lettres.
+
+export default function PastilleFraicheur({ source, horodatage, enRepli = false, ...proprietes }) {
+  const anciennete = formaterAnciennete(horodatage);
+  const etat = enRepli ? 'tiede' : 'actuel';
+
+  const description = enRepli
+    ? `Dernier cours connu${source ? `, source ${source}` : ''}${anciennete ? `, ${anciennete}` : ''}`
+    : `Cours à jour${source ? `, source ${source}` : ''}${anciennete ? `, ${anciennete}` : ''}`;
+
+  return (
+    <span
+      className={`pastille-fraicheur pastille-fraicheur--${etat}`}
+      aria-label={description}
+      {...proprietes}
+    >
+      <span className="pastille-fraicheur__marque" aria-hidden="true">
+        {enRepli ? '◐' : '●'}
+      </span>
+      <span aria-hidden="true">
+        {source}
+        {source && anciennete ? ' · ' : ''}
+        {anciennete}
+      </span>
+    </span>
+  );
+}

--- a/frontend/src/composants/PastilleFraicheur.jsx
+++ b/frontend/src/composants/PastilleFraicheur.jsx
@@ -3,11 +3,18 @@ import { formaterAnciennete } from '../utils/duree';
 
 // Ancienneté et provenance d'un cours.
 //
-// Deux états seulement, et ils ne se déduisent pas d'une horloge : un cours est à jour,
-// ou bien il provient du dernier cours connu parce que le fournisseur n'a pas répondu.
-// C'est le repli signalé par la réponse de l'API, la seule distinction que la
-// spécification nomme. Aucun seuil de durée n'est inventé ici : la pastille rend compte
-// d'un fait transmis par le serveur, elle ne le décide pas.
+// Deux états seulement, et ils ne se déduisent jamais d'un seuil d'ancienneté calculé
+// ici. La raison tient à la durée de vie du cache, qui est différenciée par classe côté
+// serveur : deux minutes pour une cryptomonnaie, cinq pour une action, dix pour un
+// métal, une heure pour une devise. Un cours de métal vieux de quatre minutes est donc
+// parfaitement frais là où un cours de crypto du même âge ne l'est plus. Un seuil unique
+// appliqué côté client se tromperait sur trois classes sur quatre, et reproduire les
+// quatre durées ici les dédoublerait, avec la certitude qu'elles divergent un jour.
+//
+// Le serveur est seul à pouvoir trancher, et il le fait déjà : la réponse du
+// portefeuille énumère dans cours_indisponibles les actifs servis depuis le dernier
+// cours connu. La pastille rend compte de ce fait, elle ne le décide pas. Deux états,
+// jamais trois.
 //
 // La couleur ne porte rien seule : l'état tiède ajoute un symbole et l'ancienneté est
 // écrite en toutes lettres.

--- a/frontend/src/composants/Variation.css
+++ b/frontend/src/composants/Variation.css
@@ -1,0 +1,52 @@
+.variation {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--espace-1);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  font-size: var(--taille-corps);
+}
+
+.variation__fleche {
+  font-size: var(--taille-legende);
+}
+
+/*
+  Trois poids visuels, selon le tableau des amplitudes de la politique de formatage.
+  Au-delà de dix pour cent, la pastille pleine ; entre un et dix, le texte coloré seul ;
+  en deçà, le texte atténué. La couleur n'ajoute jamais d'information : elle appuie un
+  signe et une flèche déjà présents.
+*/
+.variation--forte {
+  padding: var(--espace-1) var(--espace-2);
+  border-radius: var(--rayon-pilule);
+  font-weight: var(--graisse-forte);
+}
+
+.variation--forte.variation--hausse {
+  color: var(--couleur-fond);
+  background-color: var(--couleur-positif);
+}
+
+.variation--forte.variation--baisse {
+  color: var(--couleur-fond);
+  background-color: var(--couleur-negatif);
+}
+
+.variation--moyenne {
+  font-weight: var(--graisse-forte);
+}
+
+.variation--moyenne.variation--hausse {
+  color: var(--couleur-positif);
+}
+
+.variation--moyenne.variation--baisse {
+  color: var(--couleur-negatif);
+}
+
+.variation--faible,
+.variation--nulle,
+.variation--indisponible {
+  color: var(--couleur-texte-attenue);
+}

--- a/frontend/src/composants/Variation.jsx
+++ b/frontend/src/composants/Variation.jsx
@@ -1,0 +1,69 @@
+import './Variation.css';
+import { formaterVariation, amplitudeVariation, sensVariation } from '../utils/formatage';
+
+// Variation d'une position ou du portefeuille, en pourcentage ou en euros.
+//
+// Accessibilité, règle non négociable de la politique de formatage : l'information
+// n'est jamais portée par la couleur seule. Le signe est toujours écrit, la flèche
+// accompagne toute variation d'au moins un pour cent, et la valeur reste donc lisible
+// en niveaux de gris comme par un utilisateur daltonien.
+//
+// Le poids visuel suit l'amplitude, pour qu'une page entière ne crie pas d'une seule
+// voix : pastille pleine au-delà de dix pour cent, texte coloré entre un et dix,
+// texte atténué en deçà.
+
+const FLECHES = {
+  hausse: '▲',
+  baisse: '▼',
+};
+
+// Le libellé vocal ne peut pas se contenter du signe et de la flèche, qui ne se
+// prononcent pas : il énonce le sens en toutes lettres.
+const SENS_PARLE = {
+  hausse: 'en hausse de',
+  baisse: 'en baisse de',
+  stable: 'stable,',
+};
+
+export default function Variation({ valeur, mode = 'relative', amplitude, ...proprietes }) {
+  const texte = formaterVariation(valeur, mode);
+
+  if (texte === null) {
+    return (
+      <span className="variation variation--indisponible" {...proprietes}>
+        <span aria-hidden="true">—</span>
+        <span className="lecteur-ecran-seulement">variation indisponible</span>
+      </span>
+    );
+  }
+
+  const sens = sensVariation(valeur);
+
+  // Le tableau des amplitudes s'exprime en pourcentage. En mode absolu, la valeur
+  // affichée est un montant : l'amplitude relative correspondante doit alors être
+  // fournie par l'appelant, qui dispose des deux chiffres. À défaut, la variation
+  // reste lisible mais adopte le traitement discret, jamais la pastille pleine.
+  const reference = mode === 'absolue' ? amplitude : valeur;
+  const niveau = amplitudeVariation(reference) ?? (sens === 'stable' ? 'nulle' : 'faible');
+
+  const fleche = niveau === 'forte' || niveau === 'moyenne' ? FLECHES[sens] : null;
+
+  // Le signe typographique et la flèche ne se prononcent pas : le libellé vocal reprend
+  // le sens en toutes lettres puis la valeur nue, sans son signe.
+  const libelle = `${SENS_PARLE[sens]} ${texte.replace(/^[+−]/, '')}`;
+
+  return (
+    <span
+      className={`variation variation--${niveau} variation--${sens}`}
+      aria-label={libelle}
+      {...proprietes}
+    >
+      {fleche && (
+        <span className="variation__fleche" aria-hidden="true">
+          {fleche}
+        </span>
+      )}
+      <span aria-hidden="true">{texte}</span>
+    </span>
+  );
+}

--- a/frontend/src/composants/__tests__/affichage.test.jsx
+++ b/frontend/src/composants/__tests__/affichage.test.jsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import Montant from '../Montant';
+import Variation from '../Variation';
+import JetonClasse from '../JetonClasse';
+import PastilleFraicheur from '../PastilleFraicheur';
+
+afterEach(cleanup);
+
+const NBSP = ' '; // espace insécable, devant le symbole
+const FINE = ' '; // espace fine insécable, séparateur de milliers
+
+describe('Montant', () => {
+  it('délègue la mise en forme au module de formatage', () => {
+    const { container } = render(<Montant valeur="12480.6500" />);
+    expect(container.textContent).toBe(`12${FINE}480,65${NBSP}€`);
+  });
+
+  it('applique le format propre à chaque type', () => {
+    const { container } = render(
+      <>
+        <Montant valeur="0.60000000" type="quantite" classe="crypto" symbole="BTC" />
+        <Montant valeur="1.1523" type="cours" />
+        <Montant valeur="1.0926" type="taux" />
+        <Montant valeur="46.04" type="pourcentage" />
+      </>
+    );
+    expect(container.textContent).toBe(`0,6${NBSP}BTC1,1523${NBSP}€1,092646${NBSP}%`);
+  });
+
+  // Une donnée absente et une valeur nulle ne se confondent pas : sur un patrimoine,
+  // afficher « 0 € » pour un cours manquant serait une information fausse.
+  it("distingue l'absence de donnée d'un zéro", () => {
+    const { container } = render(<Montant valeur={null} />);
+    expect(container.textContent).toContain('—');
+    expect(screen.getByText('valeur indisponible')).toBeTruthy();
+  });
+});
+
+describe('Variation', () => {
+  it('impose le signe, y compris au positif', () => {
+    const { container } = render(<Variation valeur="11.6" />);
+    expect(container.textContent).toContain(`+11,6${NBSP}%`);
+  });
+
+  // Règle non négociable de la politique de formatage : jamais la couleur seule.
+  it('accompagne toute variation notable d\'une flèche, en plus du signe', () => {
+    const { container } = render(<Variation valeur="-11.6" />);
+    expect(container.textContent).toContain('▼');
+    expect(container.textContent).toContain(`−11,6${NBSP}%`);
+  });
+
+  it('gradue le poids visuel selon les trois seuils d\'amplitude', () => {
+    const { container } = render(
+      <>
+        <Variation valeur="11.6" data-cas="forte" />
+        <Variation valeur="6.5" data-cas="moyenne" />
+        <Variation valeur="0.4" data-cas="faible" />
+        <Variation valeur="0" data-cas="nulle" />
+      </>
+    );
+    const niveau = (cas) => container.querySelector(`[data-cas="${cas}"]`).className;
+    expect(niveau('forte')).toContain('variation--forte');
+    expect(niveau('moyenne')).toContain('variation--moyenne');
+    expect(niveau('faible')).toContain('variation--faible');
+    expect(niveau('nulle')).toContain('variation--nulle');
+  });
+
+  it('abandonne la flèche sous un pour cent, mais jamais le signe', () => {
+    const { container } = render(<Variation valeur="0.4" />);
+    expect(container.textContent).not.toContain('▲');
+    expect(container.textContent).toContain(`+0,4${NBSP}%`);
+  });
+
+  it('n\'affiche aucun signe pour une variation exactement nulle', () => {
+    const { container } = render(<Variation valeur="0" />);
+    expect(container.textContent).toBe(`0${NBSP}%`);
+  });
+
+  // En mode absolu la valeur affichée est un montant : l'amplitude relative, que
+  // l'appelant possède, sert à choisir le niveau. Sans elle, pas de pastille pleine.
+  it('gradue le mode absolu sur l\'amplitude relative fournie', () => {
+    const { container } = render(
+      <>
+        <Variation valeur="393.71" mode="absolue" amplitude="11.6" data-cas="fournie" />
+        <Variation valeur="393.71" mode="absolue" data-cas="absente" />
+      </>
+    );
+    expect(container.querySelector('[data-cas="fournie"]').className).toContain('variation--forte');
+    expect(container.querySelector('[data-cas="absente"]').className).toContain('variation--faible');
+    expect(container.querySelector('[data-cas="absente"]').textContent).toContain(
+      `+393,71${NBSP}€`
+    );
+  });
+
+  // La recherche par libellé normalise les espaces : l'insécable du libellé réel y est
+  // ramenée à une espace ordinaire, l'attente s'écrit donc sans NBSP.
+  it('énonce le sens en toutes lettres pour les lecteurs d\'écran', () => {
+    render(<Variation valeur="-6.5" />);
+    expect(screen.getByLabelText('en baisse de 6,5 %')).toBeTruthy();
+  });
+});
+
+describe('JetonClasse', () => {
+  it('porte une forme distincte par classe', () => {
+    const { container } = render(
+      <>
+        <JetonClasse classe="crypto" />
+        <JetonClasse classe="metal" />
+        <JetonClasse classe="devise" />
+        <JetonClasse classe="action" />
+      </>
+    );
+    const formes = [...container.querySelectorAll('.jeton-classe__forme')].map((n) => n.className);
+    expect(new Set(formes).size).toBe(4);
+  });
+
+  // La forme ne se prononce pas : le nom de la classe est toujours restitué.
+  it('nomme la classe même lorsque le libellé n\'est pas visible', () => {
+    render(<JetonClasse classe="metal" />);
+    expect(screen.getByText('Métal précieux')).toBeTruthy();
+  });
+
+  it('ignore une classe inconnue plutôt que d\'afficher une forme muette', () => {
+    const { container } = render(<JetonClasse classe="obligation" />);
+    expect(container.innerHTML).toBe('');
+  });
+});
+
+describe('PastilleFraicheur', () => {
+  const ilYaDixMinutes = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+
+  it('annonce la source et l\'ancienneté du cours', () => {
+    render(<PastilleFraicheur source="CoinGecko" horodatage={ilYaDixMinutes} />);
+    expect(screen.getByLabelText('Cours à jour, source CoinGecko, il y a 10 min')).toBeTruthy();
+  });
+
+  // L'état de repli change de marque en plus de changer de teinte : il reste
+  // identifiable en niveaux de gris.
+  it('distingue le repli autrement que par la couleur', () => {
+    const { container } = render(
+      <PastilleFraicheur source="CoinGecko" horodatage={ilYaDixMinutes} enRepli />
+    );
+    expect(container.querySelector('.pastille-fraicheur--tiede')).toBeTruthy();
+    expect(container.textContent).toContain('◐');
+    expect(screen.getByLabelText(/Dernier cours connu/)).toBeTruthy();
+  });
+});

--- a/frontend/src/composants/__tests__/affichage.test.jsx
+++ b/frontend/src/composants/__tests__/affichage.test.jsx
@@ -66,6 +66,33 @@ describe('Variation', () => {
     expect(niveau('nulle')).toContain('variation--nulle');
   });
 
+  // Décalque du tableau de la catégorie 6 : quatre niveaux d'amplitude, croisés avec le
+  // sens là où la couleur intervient, soit six traitements et pas un de plus. Chaque
+  // ligne du tableau ci-dessous se lit directement dans le document de référence.
+  it('couvre exactement les six traitements du tableau des amplitudes', () => {
+    const CAS = [
+      { valeur: '11.6', niveau: 'forte', sens: 'hausse', fleche: '▲' },
+      { valeur: '-11.6', niveau: 'forte', sens: 'baisse', fleche: '▼' },
+      { valeur: '6.5', niveau: 'moyenne', sens: 'hausse', fleche: '▲' },
+      { valeur: '-6.5', niveau: 'moyenne', sens: 'baisse', fleche: '▼' },
+      { valeur: '0.4', niveau: 'faible', sens: 'hausse', fleche: null },
+      { valeur: '0', niveau: 'nulle', sens: 'stable', fleche: null },
+    ];
+
+    CAS.forEach(({ valeur, niveau, sens, fleche }) => {
+      const { container, unmount } = render(<Variation valeur={valeur} />);
+      const rendu = container.firstChild;
+      expect(rendu.className).toContain(`variation--${niveau}`);
+      expect(rendu.className).toContain(`variation--${sens}`);
+      if (fleche) {
+        expect(rendu.textContent).toContain(fleche);
+      } else {
+        expect(rendu.textContent).not.toMatch(/[▲▼]/);
+      }
+      unmount();
+    });
+  });
+
   it('abandonne la flèche sous un pour cent, mais jamais le signe', () => {
     const { container } = render(<Variation valeur="0.4" />);
     expect(container.textContent).not.toContain('▲');

--- a/frontend/src/pages/Connexion.jsx
+++ b/frontend/src/pages/Connexion.jsx
@@ -3,7 +3,7 @@ import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { useAuthentification } from '../contexte/contexteAuthentification';
 import Bouton from '../composants/Bouton';
 import Champ from '../composants/Champ';
-import Alerte from '../composants/Alerte';
+import Message from '../composants/Message';
 import './Authentification.css';
 
 export default function Connexion() {
@@ -47,7 +47,7 @@ export default function Connexion() {
         <h1 className="authentification__titre">Connexion</h1>
         <p className="authentification__intro">Accédez au suivi de votre patrimoine.</p>
 
-        {erreur && <Alerte variante="erreur">{erreur}</Alerte>}
+        {erreur && <Message variante="erreur">{erreur}</Message>}
 
         <form onSubmit={soumettre} noValidate>
           <Champ

--- a/frontend/src/pages/Inscription.jsx
+++ b/frontend/src/pages/Inscription.jsx
@@ -3,7 +3,7 @@ import { Link, Navigate, useNavigate } from 'react-router-dom';
 import { useAuthentification } from '../contexte/contexteAuthentification';
 import Bouton from '../composants/Bouton';
 import Champ from '../composants/Champ';
-import Alerte from '../composants/Alerte';
+import Message from '../composants/Message';
 import './Authentification.css';
 
 // Contrôles repris de ceux du serveur, qui reste l'autorité : cette validation n'est
@@ -76,7 +76,7 @@ export default function Inscription() {
           Réunissez vos cryptomonnaies, devises, métaux et actions sur un seul tableau de bord.
         </p>
 
-        {erreur && <Alerte variante="erreur">{erreur}</Alerte>}
+        {erreur && <Message variante="erreur">{erreur}</Message>}
 
         <form onSubmit={soumettre} noValidate>
           <Champ

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -54,17 +54,11 @@ a {
 }
 
 /*
-  Chiffres à chasse fixe : sans cela, les montants d'une colonne ne s'alignent pas
-  verticalement, chaque chiffre ayant sa propre largeur.
+  Les règles d'affichage des valeurs numériques appartiennent désormais au composant
+  Montant et à sa feuille de style : les conserver ici en double exposait à ce qu'une
+  règle globale l'emporte sur celle du composant, le gras s'appliquant alors à toute
+  valeur, y compris aux légendes qui doivent rester discrètes.
 */
-.montant {
-  font-variant-numeric: tabular-nums;
-  font-weight: var(--graisse-forte);
-}
-
-.montant-principal {
-  font-size: var(--taille-montant);
-}
 
 /* Réservé aux lecteurs d'écran : invisible à l'œil, restitué à la voix. */
 .lecteur-ecran-seulement {

--- a/frontend/src/utils/__tests__/duree.test.js
+++ b/frontend/src/utils/__tests__/duree.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { formaterAnciennete } from '../duree';
+
+// L'instant courant est fixé explicitement : un test qui dépend de l'horloge réelle
+// échoue tôt ou tard, et toujours au mauvais moment.
+const MAINTENANT = new Date('2026-08-11T12:00:00.000Z');
+
+function ilYa(millisecondes) {
+  return new Date(MAINTENANT.getTime() - millisecondes).toISOString();
+}
+
+const MINUTE = 60 * 1000;
+const HEURE = 60 * MINUTE;
+const JOUR = 24 * HEURE;
+
+describe('ancienneté d\'un horodatage', () => {
+  it('reste implicite sous la minute', () => {
+    expect(formaterAnciennete(ilYa(0), MAINTENANT)).toBe("à l'instant");
+    expect(formaterAnciennete(ilYa(59 * 1000), MAINTENANT)).toBe("à l'instant");
+  });
+
+  it('compte en minutes jusqu\'à une heure', () => {
+    expect(formaterAnciennete(ilYa(MINUTE), MAINTENANT)).toBe('il y a 1 min');
+    expect(formaterAnciennete(ilYa(59 * MINUTE), MAINTENANT)).toBe('il y a 59 min');
+  });
+
+  it('compte en heures jusqu\'à un jour', () => {
+    expect(formaterAnciennete(ilYa(HEURE), MAINTENANT)).toBe('il y a 1 h');
+    expect(formaterAnciennete(ilYa(23 * HEURE), MAINTENANT)).toBe('il y a 23 h');
+  });
+
+  it('compte en jours au-delà', () => {
+    expect(formaterAnciennete(ilYa(JOUR), MAINTENANT)).toBe('il y a 1 j');
+    expect(formaterAnciennete(ilYa(9 * JOUR), MAINTENANT)).toBe('il y a 9 j');
+  });
+
+  // Une horloge client en avance sur le serveur donnerait un écart négatif : mieux vaut
+  // annoncer un cours frais qu'une durée absurde.
+  it('absorbe un horodatage dans le futur', () => {
+    expect(formaterAnciennete(ilYa(-5 * MINUTE), MAINTENANT)).toBe("à l'instant");
+  });
+
+  it('refuse un horodatage absent ou illisible', () => {
+    expect(formaterAnciennete(null, MAINTENANT)).toBeNull();
+    expect(formaterAnciennete(undefined, MAINTENANT)).toBeNull();
+    expect(formaterAnciennete('pas une date', MAINTENANT)).toBeNull();
+  });
+});

--- a/frontend/src/utils/__tests__/formatage.test.js
+++ b/frontend/src/utils/__tests__/formatage.test.js
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formaterMontant,
+  formaterQuantite,
+  formaterCours,
+  formaterTaux,
+  formaterPourcentage,
+  formaterVariation,
+  amplitudeVariation,
+  sensVariation,
+} from '../formatage';
+
+// Les séparateurs sont des caractères invisibles : les nommer rend les attentes
+// lisibles et évite qu'un espace ordinaire passe pour un espace insécable.
+const FINE = ' '; // espace fine insécable, séparateur de milliers
+const NBSP = ' '; // espace insécable, devant le symbole
+const MOINS = '−'; // signe moins typographique
+
+describe('catégorie 1 — montants', () => {
+  it("supprime les zéros de fin : 20,00 s'écrit 20", () => {
+    expect(formaterMontant('20.00')).toBe(`20${NBSP}€`);
+  });
+
+  it('conserve une seule décimale utile', () => {
+    expect(formaterMontant('20.50')).toBe(`20,5${NBSP}€`);
+  });
+
+  it('conserve deux décimales utiles', () => {
+    expect(formaterMontant('20.25')).toBe(`20,25${NBSP}€`);
+  });
+
+  it('groupe les milliers et coupe au centime', () => {
+    expect(formaterMontant('12480.6500')).toBe(`12${FINE}480,65${NBSP}€`);
+  });
+
+  it('affiche zéro sans décimale', () => {
+    expect(formaterMontant('0')).toBe(`0${NBSP}€`);
+    expect(formaterMontant('0.00')).toBe(`0${NBSP}€`);
+  });
+
+  // Régression identifiée à la conception : une position qui existe ne doit jamais
+  // paraître vide. Afficher « 0 € » pour 0,004 € ferait croire à une absence de valeur.
+  it("remonte au centime une valeur non nulle inférieure au seuil, jamais 0 €", () => {
+    expect(formaterMontant('0.004')).toBe(`0,01${NBSP}€`);
+    expect(formaterMontant('0.0001')).toBe(`0,01${NBSP}€`);
+    expect(formaterMontant('-0.004')).toBe(`${MOINS}0,01${NBSP}€`);
+  });
+
+  it('emploie le signe moins typographique et non le trait d\'union', () => {
+    expect(formaterMontant('-135.51')).toBe(`${MOINS}135,51${NBSP}€`);
+    expect(formaterMontant('-135.51').startsWith('-')).toBe(false);
+  });
+
+  it('arrondit au plus proche, les demis s\'éloignant de zéro', () => {
+    expect(formaterMontant('20.255')).toBe(`20,26${NBSP}€`);
+    expect(formaterMontant('20.254')).toBe(`20,25${NBSP}€`);
+  });
+
+  it('traite les très grands montants sans perte de précision', () => {
+    expect(formaterMontant('9876543210.99')).toBe(`9${FINE}876${FINE}543${FINE}210,99${NBSP}€`);
+    // Au-delà de ce qu'un flottant représente exactement : la manipulation en chaîne
+    // rend le dernier chiffre fidèle, là où Number l'aurait altéré.
+    expect(formaterMontant('9007199254740993.01')).toBe(
+      `9${FINE}007${FINE}199${FINE}254${FINE}740${FINE}993,01${NBSP}€`
+    );
+  });
+
+  it('propage la retenue sur un arrondi en cascade', () => {
+    expect(formaterMontant('9.999')).toBe(`10${NBSP}€`);
+    expect(formaterMontant('999.999')).toBe(`1${FINE}000${NBSP}€`);
+  });
+
+  it('refuse une entrée non numérique', () => {
+    expect(formaterMontant('abc')).toBeNull();
+    expect(formaterMontant('')).toBeNull();
+    expect(formaterMontant(null)).toBeNull();
+    expect(formaterMontant(undefined)).toBeNull();
+  });
+});
+
+describe('catégorie 2 — quantités', () => {
+  it('affiche une cryptomonnaie à huit décimales avec son symbole', () => {
+    expect(formaterQuantite('0.60000001', 'crypto', 'BTC')).toBe(`0,60000001${NBSP}BTC`);
+  });
+
+  it('supprime les zéros de fin d\'une quantité', () => {
+    expect(formaterQuantite('0.60000000', 'crypto', 'BTC')).toBe(`0,6${NBSP}BTC`);
+    expect(formaterQuantite('15.00000000', 'crypto', 'BTC')).toBe(`15${NBSP}BTC`);
+    expect(formaterQuantite('0.60000010', 'crypto', 'BTC')).toBe(`0,6000001${NBSP}BTC`);
+  });
+
+  it('affiche un métal en grammes, à trois décimales', () => {
+    expect(formaterQuantite('18', 'metal')).toBe(`18${NBSP}g`);
+    expect(formaterQuantite('620.500', 'metal')).toBe(`620,5${NBSP}g`);
+  });
+
+  it('affiche une devise avec son code, à deux décimales', () => {
+    expect(formaterQuantite('1500.00', 'devise', 'USD')).toBe(`1${FINE}500${NBSP}USD`);
+  });
+
+  // Le pluriel ne vaut que pour les unités nommées en français, jamais pour un symbole
+  // ni un code : on écrit 1 BTC, pas 1 BTCs.
+  it('accorde en nombre l\'unité des actions', () => {
+    expect(formaterQuantite('12', 'action')).toBe(`12${NBSP}titres`);
+    expect(formaterQuantite('1', 'action')).toBe(`1${NBSP}titre`);
+    expect(formaterQuantite('1.000000', 'action')).toBe(`1${NBSP}titre`);
+    expect(formaterQuantite('0.5', 'action')).toBe(`0,5${NBSP}titre`);
+    // Le pluriel commence à deux, pas à un : 1,5 reste au singulier.
+    expect(formaterQuantite('1.5', 'action')).toBe(`1,5${NBSP}titre`);
+    expect(formaterQuantite('2', 'action')).toBe(`2${NBSP}titres`);
+  });
+
+  it('refuse une classe d\'actif inconnue', () => {
+    expect(formaterQuantite('1', 'obligation')).toBeNull();
+    expect(formaterQuantite('1', undefined)).toBeNull();
+  });
+});
+
+describe('catégorie 3 — cours unitaires, quatre plages', () => {
+  it('au moins mille : deux décimales', () => {
+    expect(formaterCours('61240')).toBe(`61${FINE}240${NBSP}€`);
+    expect(formaterCours('54890.12')).toBe(`54${FINE}890,12${NBSP}€`);
+  });
+
+  it('de dix à mille : deux décimales', () => {
+    expect(formaterCours('92.14')).toBe(`92,14${NBSP}€`);
+    expect(formaterCours('249.6149')).toBe(`249,61${NBSP}€`);
+  });
+
+  // C'est ici qu'une règle unique à deux décimales échouerait : le gramme d'argent
+  // arrondi à 1,15 introduirait un écart visible entre le cours et le total.
+  it('de un centime à dix : quatre décimales', () => {
+    expect(formaterCours('1.1523')).toBe(`1,1523${NBSP}€`);
+    expect(formaterCours('0.9152')).toBe(`0,9152${NBSP}€`);
+    expect(formaterCours('9.99999')).toBe(`10${NBSP}€`);
+  });
+
+  it('sous le centime : six décimales', () => {
+    expect(formaterCours('0.000842')).toBe(`0,000842${NBSP}€`);
+    expect(formaterCours('0.00000012')).toBe(`0${NBSP}€`);
+  });
+
+  it('bascule de plage exactement aux bornes', () => {
+    expect(formaterCours('10.12345')).toBe(`10,12${NBSP}€`);
+    expect(formaterCours('9.12345')).toBe(`9,1235${NBSP}€`);
+    expect(formaterCours('0.01234')).toBe(`0,0123${NBSP}€`);
+    expect(formaterCours('0.00934')).toBe(`0,00934${NBSP}€`);
+  });
+});
+
+describe('catégorie 4 — taux de change', () => {
+  it('affiche quatre décimales', () => {
+    expect(formaterTaux('1.0926')).toBe('1,0926');
+  });
+
+  it('supprime les zéros de fin', () => {
+    expect(formaterTaux('1.1000')).toBe('1,1');
+    expect(formaterTaux('1.0000')).toBe('1');
+  });
+
+  it('arrondit au-delà de quatre décimales', () => {
+    expect(formaterTaux('1.09265')).toBe('1,0927');
+  });
+});
+
+describe('catégorie 5 — pourcentages', () => {
+  it('supprime la décimale nulle', () => {
+    expect(formaterPourcentage('46.0')).toBe(`46${NBSP}%`);
+  });
+
+  it('arrondit à une décimale', () => {
+    expect(formaterPourcentage('46.04')).toBe(`46${NBSP}%`);
+    expect(formaterPourcentage('46.15')).toBe(`46,2${NBSP}%`);
+  });
+
+  // Une part qui existe ne s'affiche pas « 0 % » : le seuil bas la rend visible.
+  it('affiche un seuil bas pour une part non nulle très faible', () => {
+    expect(formaterPourcentage('0.04')).toBe(`<${NBSP}0,1${NBSP}%`);
+  });
+
+  it('affiche zéro pour une part réellement nulle', () => {
+    expect(formaterPourcentage('0')).toBe(`0${NBSP}%`);
+  });
+});
+
+describe('catégorie 6 — variations', () => {
+  it('impose le signe, y compris au positif', () => {
+    expect(formaterVariation('11.6')).toBe(`+11,6${NBSP}%`);
+    expect(formaterVariation('6.5')).toBe(`+6,5${NBSP}%`);
+  });
+
+  it('emploie le moins typographique au négatif', () => {
+    expect(formaterVariation('-6.5')).toBe(`${MOINS}6,5${NBSP}%`);
+  });
+
+  // Une variation nulle ne va nulle part : elle ne porte donc pas de signe.
+  it('n\'ajoute aucun signe à une variation nulle', () => {
+    expect(formaterVariation('0')).toBe(`0${NBSP}%`);
+    expect(formaterVariation('0.00')).toBe(`0${NBSP}%`);
+  });
+
+  it('applique la règle des montants en mode absolu', () => {
+    expect(formaterVariation('393.71', 'absolue')).toBe(`+393,71${NBSP}€`);
+    expect(formaterVariation('-135.51', 'absolue')).toBe(`${MOINS}135,51${NBSP}€`);
+    expect(formaterVariation('0', 'absolue')).toBe(`0${NBSP}€`);
+  });
+});
+
+describe('traitement graduel selon l\'amplitude', () => {
+  it('classe une amplitude forte à partir de dix pour cent', () => {
+    expect(amplitudeVariation('10')).toBe('forte');
+    expect(amplitudeVariation('11.6')).toBe('forte');
+    expect(amplitudeVariation('-42.8')).toBe('forte');
+    expect(amplitudeVariation('250')).toBe('forte');
+  });
+
+  it('classe une amplitude moyenne entre un et dix pour cent', () => {
+    expect(amplitudeVariation('1')).toBe('moyenne');
+    expect(amplitudeVariation('6.5')).toBe('moyenne');
+    expect(amplitudeVariation('-9.99')).toBe('moyenne');
+  });
+
+  it('classe une amplitude faible sous un pour cent', () => {
+    expect(amplitudeVariation('0.9')).toBe('faible');
+    expect(amplitudeVariation('-0.01')).toBe('faible');
+  });
+
+  it('distingue le cas exactement nul', () => {
+    expect(amplitudeVariation('0')).toBe('nulle');
+    expect(amplitudeVariation('0.000')).toBe('nulle');
+  });
+
+  it('ignore le signe pour déterminer l\'amplitude', () => {
+    expect(amplitudeVariation('-11.6')).toBe(amplitudeVariation('11.6'));
+  });
+});
+
+describe('sens d\'une variation', () => {
+  it('distingue hausse, baisse et stabilité', () => {
+    expect(sensVariation('11.6')).toBe('hausse');
+    expect(sensVariation('-6.5')).toBe('baisse');
+    expect(sensVariation('0')).toBe('stable');
+    expect(sensVariation('0.00')).toBe('stable');
+  });
+});
+
+describe('garantie de non-conversion en virgule flottante', () => {
+  // Le cœur de la politique : ces valeurs sont exactement celles que Number altère.
+  // Si une conversion se glissait dans la chaîne d'affichage, ces tests tomberaient.
+  it('rend fidèlement des valeurs qu\'un flottant ne représente pas', () => {
+    expect(formaterQuantite('0.10000000', 'crypto', 'BTC')).toBe(`0,1${NBSP}BTC`);
+    expect(formaterQuantite('0.30000000', 'crypto', 'BTC')).toBe(`0,3${NBSP}BTC`);
+    expect(formaterMontant('0.145')).toBe(`0,15${NBSP}€`);
+  });
+
+  it('conserve la précision de quantités que Number arrondirait', () => {
+    expect(formaterQuantite('0.00000001', 'crypto', 'BTC')).toBe(`0,00000001${NBSP}BTC`);
+    expect(formaterQuantite('123456789.12345678', 'crypto', 'BTC')).toBe(
+      `123${FINE}456${FINE}789,12345678${NBSP}BTC`
+    );
+  });
+});

--- a/frontend/src/utils/duree.js
+++ b/frontend/src/utils/duree.js
@@ -1,0 +1,45 @@
+// Mise en forme des durées.
+//
+// Volontairement séparé de utils/formatage.js : celui-ci met en œuvre les six catégories
+// de la politique de formatage des nombres, qui portent toutes sur des valeurs
+// financières transmises en chaîne. Une ancienneté n'en est pas une, et l'y ajouter
+// affaiblirait la règle « toute valeur affichée provient de l'une des six fonctions ».
+
+const MINUTE = 60 * 1000;
+const HEURE = 60 * MINUTE;
+const JOUR = 24 * HEURE;
+
+// Ancienneté d'un horodatage, en formulation relative.
+//
+// L'instant courant est un paramètre et non un appel à Date.now() enfoui dans la
+// fonction : c'est ce qui rend le résultat testable sans figer l'horloge.
+export function formaterAnciennete(horodatage, maintenant = new Date()) {
+  if (!horodatage) {
+    return null;
+  }
+
+  const instant = new Date(horodatage);
+
+  if (Number.isNaN(instant.getTime())) {
+    return null;
+  }
+
+  const ecart = maintenant.getTime() - instant.getTime();
+
+  // Une horloge client en avance sur le serveur produirait un écart négatif : plutôt
+  // qu'une durée absurde, on considère la valeur comme fraîche.
+  if (ecart < MINUTE) {
+    return "à l'instant";
+  }
+
+  if (ecart < HEURE) {
+    return `il y a ${Math.floor(ecart / MINUTE)} min`;
+  }
+
+  if (ecart < JOUR) {
+    return `il y a ${Math.floor(ecart / HEURE)} h`;
+  }
+
+  const jours = Math.floor(ecart / JOUR);
+  return `il y a ${jours} j`;
+}

--- a/frontend/src/utils/formatage.js
+++ b/frontend/src/utils/formatage.js
@@ -1,0 +1,320 @@
+// Formatage des valeurs numériques affichées, selon docs/conception/formatage-nombres.md.
+// Ce module est la seule source de vérité : aucun composant ne formate un nombre par
+// lui-même, ce qui rend la politique vérifiable par une simple recherche dans le code.
+//
+// Règle fondatrice : les valeurs arrivent de l'interface de programmation sous forme de
+// chaînes, parce qu'elles sont stockées en NUMERIC. Elles sont manipulées comme telles
+// de bout en bout. Ni Number ni parseFloat n'apparaissent ici, pas même pour choisir un
+// format : convertir en virgule flottante, y compris pour un simple affichage, rouvrirait
+// la porte aux erreurs de représentation que le projet écarte partout ailleurs.
+
+// Espace fine insécable, séparateur de milliers en typographie française.
+const ESPACE_MILLIERS = ' ';
+// Espace insécable, entre la valeur et son symbole.
+const ESPACE_SYMBOLE = ' ';
+// Signe moins typographique (U+2212), et non le trait d'union : il a la même chasse que
+// les chiffres, ce qui préserve l'alignement des colonnes.
+const MOINS = '−';
+
+// Précisions par classe d'actif (catégorie 2 de la politique).
+const FORMATS_QUANTITE = {
+  crypto: { decimales: 8, unite: (symbole) => symbole },
+  metal: { decimales: 3, unite: () => 'g' },
+  devise: { decimales: 2, unite: (symbole) => symbole },
+  action: { decimales: 6, unite: (_, valeur) => (estSingulier(valeur) ? 'titre' : 'titres') },
+};
+
+// ---------------------------------------------------------------------------
+// Manipulation de chaînes décimales
+// ---------------------------------------------------------------------------
+
+// Découpe une chaîne décimale en ses trois composants, sans jamais l'évaluer.
+function decomposer(chaine) {
+  const texte = String(chaine ?? '').trim();
+  const negatif = texte.startsWith('-') || texte.startsWith(MOINS);
+  const absolu = negatif ? texte.slice(1) : texte;
+  const [entiere = '', decimale = ''] = absolu.split('.');
+
+  return { negatif, entiere: entiere || '0', decimale };
+}
+
+// Une chaîne est exploitable si elle ne contient que des chiffres, un signe et au plus
+// un séparateur décimal. Toute autre entrée est refusée plutôt que devinée.
+function estDecimaleValide(chaine) {
+  return /^[-−]?\d*(\.\d*)?$/.test(String(chaine ?? '').trim()) && /\d/.test(String(chaine ?? ''));
+}
+
+// En français, le pluriel commence à deux : on écrit « 0,5 titre » et « 1,5 titre »,
+// mais « 2 titres ». La règle porte sur la valeur, pas sur la présence de décimales.
+function estSingulier(composants) {
+  return !estSuperieureOuEgale(composants, '2');
+}
+
+// La valeur est-elle exactement zéro ? Se lit sur les chiffres, sans conversion.
+function estNul({ entiere, decimale }) {
+  return !/[1-9]/.test(entiere) && !/[1-9]/.test(decimale);
+}
+
+// Arrondi au plus proche, à n décimales, entièrement en manipulation de chaînes.
+// Les demis s'éloignent de zéro, règle usuelle en comptabilité qui traite gains et
+// pertes de façon symétrique.
+function arrondir({ negatif, entiere, decimale }, decimales) {
+  const conservees = decimale.slice(0, decimales);
+  const premiereRejetee = decimale.charAt(decimales);
+  const arrondiVersLeHaut = premiereRejetee !== '' && premiereRejetee >= '5';
+
+  let chiffres = (entiere + conservees.padEnd(decimales, '0')).replace(/^0+(?=\d)/, '');
+
+  if (arrondiVersLeHaut) {
+    chiffres = incrementer(chiffres);
+  }
+
+  const coupure = chiffres.length - decimales;
+  const nouvelleEntiere = (coupure > 0 ? chiffres.slice(0, coupure) : '0').replace(/^0+(?=\d)/, '');
+  const nouvelleDecimale = decimales > 0 ? chiffres.slice(-decimales).padStart(decimales, '0') : '';
+
+  return { negatif, entiere: nouvelleEntiere || '0', decimale: nouvelleDecimale };
+}
+
+// Chiffre suivant, par simple table : aucune arithmétique, donc aucune conversion.
+// Une recherche de « Number » ou « parseFloat » dans ce fichier ne doit rien remonter,
+// c'est ce qui rend la politique vérifiable d'un coup d'œil.
+const CHIFFRE_SUIVANT = { 0: '1', 1: '2', 2: '3', 3: '4', 4: '5', 5: '6', 6: '7', 7: '8', 8: '9' };
+
+// Ajoute 1 à un entier représenté en chaîne, en propageant la retenue.
+function incrementer(chiffres) {
+  const resultat = chiffres.split('');
+  let position = resultat.length - 1;
+
+  while (position >= 0) {
+    if (resultat[position] === '9') {
+      resultat[position] = '0';
+      position -= 1;
+    } else {
+      resultat[position] = CHIFFRE_SUIVANT[resultat[position]];
+      return resultat.join('');
+    }
+  }
+
+  return `1${resultat.join('')}`;
+}
+
+// Insère le séparateur de milliers par groupes de trois, en partant de la droite.
+function grouperMilliers(entiere) {
+  return entiere.replace(/\B(?=(\d{3})+(?!\d))/g, ESPACE_MILLIERS);
+}
+
+// Assemble les composants en chaîne affichable : zéros de fin toujours supprimés
+// (convention commune aux six catégories).
+function composer({ negatif, entiere, decimale }) {
+  const decimaleUtile = decimale.replace(/0+$/, '');
+  const corps = grouperMilliers(entiere) + (decimaleUtile ? `,${decimaleUtile}` : '');
+
+  return (negatif ? MOINS : '') + corps;
+}
+
+// Formate une chaîne décimale à n décimales maximum. Rend null si l'entrée n'est pas
+// exploitable, à charge pour l'appelant de décider quoi afficher.
+function formaterDecimale(chaine, decimales) {
+  if (!estDecimaleValide(chaine)) {
+    return null;
+  }
+  return composer(arrondir(decomposer(chaine), decimales));
+}
+
+// ---------------------------------------------------------------------------
+// Catégorie 1 : montants en devise fiduciaire
+// ---------------------------------------------------------------------------
+
+const DECIMALES_MONTANT = 2;
+
+export function formaterMontant(chaine, { symbole = '€' } = {}) {
+  if (!estDecimaleValide(chaine)) {
+    return null;
+  }
+
+  const composants = decomposer(chaine);
+  const arrondi = arrondir(composants, DECIMALES_MONTANT);
+
+  // Une valeur non nulle qui s'arrondit à zéro ne s'affiche jamais « 0 € » : cela
+  // laisserait croire à une position vide. On remonte au centime, plus petite unité
+  // qui ait un sens pour un patrimoine.
+  if (estNul(arrondi) && !estNul(composants)) {
+    return `${composants.negatif ? MOINS : ''}0,01${ESPACE_SYMBOLE}${symbole}`;
+  }
+
+  return `${composer(arrondi)}${ESPACE_SYMBOLE}${symbole}`;
+}
+
+// ---------------------------------------------------------------------------
+// Catégorie 2 : quantités d'actifs
+// ---------------------------------------------------------------------------
+
+export function formaterQuantite(chaine, classeActif, symbole = '') {
+  const format = FORMATS_QUANTITE[classeActif];
+
+  if (!format || !estDecimaleValide(chaine)) {
+    return null;
+  }
+
+  const arrondi = arrondir(decomposer(chaine), format.decimales);
+  const unite = format.unite(symbole, arrondi);
+
+  return unite ? `${composer(arrondi)}${ESPACE_SYMBOLE}${unite}` : composer(arrondi);
+}
+
+// ---------------------------------------------------------------------------
+// Catégorie 3 : cours unitaires
+// ---------------------------------------------------------------------------
+
+// La précision suit l'ordre de grandeur. Celui-ci se lit sur la longueur de la partie
+// entière et sur la position du premier chiffre significatif : aucune conversion n'est
+// nécessaire pour le déterminer.
+function decimalesSelonOrdreDeGrandeur({ entiere, decimale }) {
+  const entiereUtile = entiere.replace(/^0+(?=\d)/, '');
+
+  // Au moins une unité : deux décimales suffisent, l'information est dans la partie
+  // entière (règles « ≥ 1 000 » et « ≥ 10 et < 1 000 » de la politique).
+  if (/[1-9]/.test(entiereUtile)) {
+    return entiereUtile.length >= 2 ? 2 : 4;
+  }
+
+  // Sous l'unité : la valeur est ≥ 0,01 si l'un des deux premiers chiffres décimaux
+  // est significatif, sinon elle est inférieure et demande six décimales.
+  return /[1-9]/.test(decimale.slice(0, 2)) ? 4 : 6;
+}
+
+export function formaterCours(chaine, { symbole = '€' } = {}) {
+  if (!estDecimaleValide(chaine)) {
+    return null;
+  }
+
+  const composants = decomposer(chaine);
+  const decimales = decimalesSelonOrdreDeGrandeur(composants);
+
+  return `${composer(arrondir(composants, decimales))}${ESPACE_SYMBOLE}${symbole}`;
+}
+
+// ---------------------------------------------------------------------------
+// Catégorie 4 : taux de change
+// ---------------------------------------------------------------------------
+
+const DECIMALES_TAUX = 4;
+
+export function formaterTaux(chaine) {
+  return formaterDecimale(chaine, DECIMALES_TAUX);
+}
+
+// ---------------------------------------------------------------------------
+// Catégorie 5 : pourcentages
+// ---------------------------------------------------------------------------
+
+const DECIMALES_POURCENTAGE = 1;
+
+export function formaterPourcentage(chaine) {
+  if (!estDecimaleValide(chaine)) {
+    return null;
+  }
+
+  const composants = decomposer(chaine);
+  const arrondi = arrondir(composants, DECIMALES_POURCENTAGE);
+
+  // Même raison qu'au centime : une part qui existe ne s'affiche pas « 0 % ».
+  if (estNul(arrondi) && !estNul(composants)) {
+    return `<${ESPACE_SYMBOLE}0,1${ESPACE_SYMBOLE}%`;
+  }
+
+  return `${composer(arrondi)}${ESPACE_SYMBOLE}%`;
+}
+
+// ---------------------------------------------------------------------------
+// Catégorie 6 : variations
+// ---------------------------------------------------------------------------
+
+// Seuils du traitement graduel, exprimés en points de pourcentage.
+const AMPLITUDE_FORTE = '10';
+const AMPLITUDE_MOYENNE = '1';
+
+export function formaterVariation(chaine, mode = 'relative') {
+  if (!estDecimaleValide(chaine)) {
+    return null;
+  }
+
+  const composants = decomposer(chaine);
+  const formatee =
+    mode === 'absolue'
+      ? formaterMontant(chaine)
+      : formaterPourcentage(chaine);
+
+  if (formatee === null) {
+    return null;
+  }
+
+  // Une variation nulle ne porte pas de signe : elle ne va nulle part.
+  if (estNul(composants)) {
+    return formatee;
+  }
+
+  // Le signe est obligatoire, y compris au positif : il double l'information portée
+  // par la couleur, condition d'accessibilité. Le moins est déjà posé par composer().
+  return composants.negatif ? formatee : `+${formatee}`;
+}
+
+// Compare deux valeurs décimales en valeur absolue, sans jamais les convertir : d'abord
+// la longueur de la partie entière, qui donne l'ordre de grandeur, puis l'ordre
+// lexicographique une fois les parties alignées sur la même longueur.
+function estSuperieureOuEgale(composants, reference) {
+  const b = decomposer(reference);
+
+  const entiereA = composants.entiere.replace(/^0+(?=\d)/, '');
+  const entiereB = b.entiere.replace(/^0+(?=\d)/, '');
+
+  if (entiereA.length !== entiereB.length) {
+    return entiereA.length > entiereB.length;
+  }
+  if (entiereA !== entiereB) {
+    return entiereA > entiereB;
+  }
+
+  const longueur = Math.max(composants.decimale.length, b.decimale.length);
+  return composants.decimale.padEnd(longueur, '0') >= b.decimale.padEnd(longueur, '0');
+}
+
+// Niveau de traitement visuel d'une variation, selon son amplitude en pourcentage.
+// Rend 'forte', 'moyenne', 'faible' ou 'nulle'.
+export function amplitudeVariation(chainePourcentage) {
+  if (!estDecimaleValide(chainePourcentage)) {
+    return null;
+  }
+
+  const composants = decomposer(chainePourcentage);
+
+  if (estNul(composants)) {
+    return 'nulle';
+  }
+
+  // Le signe ne joue pas sur l'amplitude : une baisse de 12 % pèse autant qu'une hausse.
+  if (estSuperieureOuEgale(composants, AMPLITUDE_FORTE)) {
+    return 'forte';
+  }
+  if (estSuperieureOuEgale(composants, AMPLITUDE_MOYENNE)) {
+    return 'moyenne';
+  }
+  return 'faible';
+}
+
+// Sens d'une variation, pour choisir la flèche et la couleur.
+export function sensVariation(chaine) {
+  if (!estDecimaleValide(chaine)) {
+    return null;
+  }
+
+  const composants = decomposer(chaine);
+
+  if (estNul(composants)) {
+    return 'stable';
+  }
+  return composants.negatif ? 'baisse' : 'hausse';
+}
+
+export const CLASSES_QUANTITE = Object.keys(FORMATS_QUANTITE);


### PR DESCRIPTION
Socle d'affichage des valeurs numériques : le module de formatage, le renommage du bandeau de message, et les quatre composants qui les consomment.

Ferme #97, #98 et #99.

## Ce que le diff ne montre pas

**La découpe de `Montant` suit la politique de formatage, pas une commodité d'appel.** Ses cinq types — `montant`, `quantite`, `cours`, `taux`, `pourcentage` — sont exactement les catégories 1 à 5 de `docs/conception/formatage-nombres.md`, dans le même ordre. Un sixième type n'aurait pas de sens : la catégorie 6 est la variation, et elle demande un traitement graduel et une sémantique d'accessibilité que `Montant` n'a pas à porter. C'est `Variation` qui la couvre, seul.

**`utils/duree.js` est séparé volontairement.** `PastilleFraicheur` doit afficher une ancienneté, et aucun composant ne formate un nombre par lui-même. Mais ajouter cette mise en forme à `utils/formatage.js` en aurait fait une septième catégorie et affaibli la règle qui rend la politique vérifiable : toute valeur affichée provient de l'une des six fonctions. Une durée n'est pas une valeur financière transmise en chaîne ; elle a donc son module, et `formatage.js` garde exactement six catégories.

**La règle de non-conversion est vérifiable par recherche.** Ni `Number(` ni `parseFloat` n'apparaissent dans `formatage.js`, y compris pour choisir un format : l'ordre de grandeur d'un cours se détermine sur la longueur de la partie entière de la chaîne, et l'incrémentation de retenue passe par une table de chiffres plutôt que par une addition. Un bloc de tests dédié le prouve sur les valeurs que le flottant altère, dont `9007199254740993.01` et `0.30000000` BTC.

## Deux points transférés au serveur plutôt qu'inventés

**Les états de fraîcheur.** Les durées de vie du cache sont différenciées par classe (D21) : un cours de métal vieux de quatre minutes est frais, un cours de crypto du même âge ne l'est plus. Un seuil client unique se tromperait sur trois classes sur quatre, et recopier les quatre durées les ferait diverger tôt ou tard. La pastille rend donc compte de `cours_indisponibles`, que le serveur émet déjà. Deux états, jamais trois. Le commentaire du composant consigne le raisonnement.

**La graduation en mode absolu.** Le tableau des amplitudes s'exprime en pourcentage alors que le mode absolu affiche un montant. `Variation` accepte une propriété `amplitude` que l'appelant renseigne avec le pourcentage correspondant, dont il dispose toujours. Sans elle, la variation reste signée et lisible mais adopte le traitement discret, jamais la pastille pleine.

## Conformité au tableau de la catégorie 6

Quatre niveaux d'amplitude, croisés avec le sens là où la couleur intervient, soit six traitements : forte hausse et forte baisse en pastille pleine au-delà de 10 %, hausse et baisse en texte coloré de 1 à 10 %, faible en texte atténué avec signe sous 1 %, nulle sans signe ni flèche. Un test tableau reprend les six lignes une à une, et les bornes exactes (10 et 1) sont couvertes côté module.

Règle d'accessibilité tenue à la lettre : aucune variation n'est portée par la couleur seule. Le signe est toujours écrit, la flèche accompagne toute variation d'au moins un pour cent, et le libellé vocal énonce le sens en toutes lettres, le signe typographique et la flèche ne se prononçant pas.

## Vérifications

- 73 tests front sur 6 fichiers, 167 tests back, tous verts
- `oxlint` muet, `vite build` propre
- une règle globale `.montant` morte, qui serait entrée en collision avec le composant en imposant le gras à toute valeur y compris aux légendes, a été transférée au composant
