### PR TITLE
E4 - Détail d'une position, historique de cours par position et tendance sur trente jours

### DIFF
--- a/backend/db/README.md
+++ b/backend/db/README.md
@@ -45,8 +45,11 @@ Les migrations n'ont pas à être rejouées dans ce cas : `schema.sql` les intè
 
 ## Sur une base existante
 
+Les migrations s'appliquent dans l'ordre chronologique de leur nom :
+
 ```bash
 psql -d capitall -f backend/db/migrations/2026-08-06_activation-compte.sql
+psql -d capitall -f backend/db/migrations/2026-08-23_historique-cours-par-position.sql
 ```
 
 Un rôle propriétaire est nécessaire : le rôle applicatif `capitall_app` est volontairement

--- a/backend/db/migrations/2026-08-23_historique-cours-par-position.sql
+++ b/backend/db/migrations/2026-08-23_historique-cours-par-position.sql
@@ -1,0 +1,53 @@
+-- Migration : historique de cours par position
+-- Date : 23/08/2026
+--
+-- Le modèle ne conservait qu'une seule série temporelle, la valeur totale du
+-- portefeuille dans snapshot_valorisation. Aucune série par position n'existait, alors
+-- que l'interface en a besoin en deux endroits : le graphe de cours avec ligne de prix
+-- de revient de l'écran de détail, et la colonne de tendance sur trente jours du
+-- tableau des positions.
+--
+-- Comme snapshot_valorisation, cette table déroge sciemment à la règle « aucune valeur
+-- dérivée n'est stockée » : le cours du bitcoin au 12 mars ne se recalcule pas après
+-- coup, les fournisseurs ne conservant pas leur historique gratuitement et de la même
+-- façon selon la classe d'actif. C'est un fait daté, pas une redondance.
+--
+-- Le cloisonnement reste porté par le SQL, par jointure sur actif, exactement comme
+-- pour transaction. Dénormaliser utilisateur_id ici créerait une seconde vérité sur le
+-- propriétaire d'une ligne, avec la certitude qu'elles divergent un jour.
+--
+-- À exécuter sur une base existante, avec un rôle propriétaire :
+--   psql -d capitall -f backend/db/migrations/2026-08-23_historique-cours-par-position.sql
+--
+-- Les bases créées après cette date à partir de schema.sql comportent déjà la table :
+-- IF NOT EXISTS rend cette migration sans effet dans ce cas, et rejouable sans risque.
+
+CREATE TABLE IF NOT EXISTS snapshot_cours (
+    id             SERIAL PRIMARY KEY,
+    actif_id       INTEGER NOT NULL REFERENCES actif(id) ON DELETE CASCADE,
+    date_snapshot  DATE NOT NULL,
+    cours_eur      NUMERIC(18, 2) NOT NULL CHECK (cours_eur >= 0),
+    -- Quantité détenue ce jour-là. Elle rend l'historique lisible seul : sans elle,
+    -- reconstituer la valeur passée d'une position obligerait à rejouer toutes les
+    -- transactions antérieures à chaque point de la courbe.
+    quantite       NUMERIC(24, 8) NOT NULL CHECK (quantite >= 0),
+    UNIQUE (actif_id, date_snapshot)
+);
+
+-- Aucun index supplémentaire n'est créé : la contrainte d'unicité en produit déjà un
+-- sur (actif_id, date_snapshot), dans cet ordre, et c'est exactement la lecture faite
+-- par l'application, un actif filtré puis trié par date.
+
+COMMENT ON TABLE snapshot_cours IS
+    'Cours unitaire et quantité détenue, par position et par jour. Le propriétaire se lit par jointure sur actif.';
+
+-- Le rôle applicatif est créé avec ses droits par schema.sql, avant l'existence de
+-- cette table : sur une base déjà en service, la table nouvelle ne les hérite pas.
+DO $$
+BEGIN
+    IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'capitall_app') THEN
+        GRANT SELECT, INSERT, UPDATE, DELETE ON snapshot_cours TO capitall_app;
+        GRANT USAGE, SELECT ON SEQUENCE snapshot_cours_id_seq TO capitall_app;
+    END IF;
+END
+$$;

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -4,6 +4,7 @@
 
 -- Nettoyage pour ré-exécution en environnement de développement
 DROP TABLE IF EXISTS annonce CASCADE;
+DROP TABLE IF EXISTS snapshot_cours CASCADE;
 DROP TABLE IF EXISTS snapshot_valorisation CASCADE;
 DROP TABLE IF EXISTS alerte CASCADE;
 DROP TABLE IF EXISTS transaction CASCADE;
@@ -65,6 +66,25 @@ CREATE TABLE snapshot_valorisation (
     date_snapshot       DATE NOT NULL,
     valeur_totale_eur   NUMERIC(18, 2) NOT NULL CHECK (valeur_totale_eur >= 0),
     UNIQUE (utilisateur_id, date_snapshot)
+);
+
+-- Historique du cours de chaque position, jour par jour.
+--
+-- Même dérogation assumée que snapshot_valorisation : un cours passé ne se recalcule
+-- pas, les fournisseurs ne conservant pas leur historique de la même façon selon la
+-- classe d'actif. C'est un fait daté, pas une valeur dérivée.
+--
+-- Aucun utilisateur_id ici : le propriétaire se lit par jointure sur actif, comme pour
+-- transaction. Le dupliquer créerait une seconde vérité sur le cloisonnement.
+CREATE TABLE snapshot_cours (
+    id             SERIAL PRIMARY KEY,
+    actif_id       INTEGER NOT NULL REFERENCES actif(id) ON DELETE CASCADE,
+    date_snapshot  DATE NOT NULL,
+    cours_eur      NUMERIC(18, 2) NOT NULL CHECK (cours_eur >= 0),
+    -- Quantité détenue ce jour-là : elle rend l'historique lisible sans avoir à rejouer
+    -- les transactions antérieures à chaque point de la courbe.
+    quantite       NUMERIC(24, 8) NOT NULL CHECK (quantite >= 0),
+    UNIQUE (actif_id, date_snapshot)
 );
 
 CREATE TABLE annonce (

--- a/backend/db/seed.sql
+++ b/backend/db/seed.sql
@@ -17,7 +17,7 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 -- Remise à zéro. RESTART IDENTITY réinitialise les séquences, CASCADE couvre les
 -- tables filles ; l'ordre importe peu grâce à CASCADE.
-TRUNCATE TABLE annonce, snapshot_valorisation, alerte, transaction, actif, utilisateur
+TRUNCATE TABLE annonce, snapshot_cours, snapshot_valorisation, alerte, transaction, actif, utilisateur
     RESTART IDENTITY CASCADE;
 
 -- Utilisateurs. Le rôle est fixé ici (jamais via une entrée applicative, D23).
@@ -112,3 +112,48 @@ SELECT (SELECT id FROM utilisateur WHERE email = 'user@capitall.fr'),
            + (random() - 0.5) * 900
        )::numeric, 2)
 FROM generate_series(CURRENT_DATE - 89, CURRENT_DATE, INTERVAL '1 day') AS jour;
+
+-- Historique de cours par position : les mêmes quatre-vingt-dix jours, déclinés actif
+-- par actif, pour alimenter le graphe de cours de l'écran de détail et la colonne de
+-- tendance sur trente jours du tableau des positions.
+--
+-- Deux différences assumées avec le bloc précédent.
+--
+-- La série est déterministe : aucune fonction aléatoire n'y intervient, l'ondulation
+-- venant d'un sinus décalé par l'identifiant de l'actif. Deux exécutions du seed
+-- produisent donc exactement les mêmes courbes, ce qui permet de s'y appuyer dans une
+-- vérification. Le bloc de valorisation totale, antérieur, conserve son bruit
+-- aléatoire : le rendre déterministe ne relève pas de ce lot.
+--
+-- Le cours part du prix du premier achat réel de l'actif et progresse d'environ
+-- dix-huit pour cent sur la période. Il reste ainsi cohérent avec le prix de revient
+-- calculé depuis les transactions du même jeu de données, sans quoi le graphe montrerait
+-- une ligne de prix de revient sans rapport avec la courbe qu'elle traverse.
+--
+-- La quantité est celle réellement détenue ce jour-là, reconstituée depuis les
+-- transactions. Elle vaut zéro avant le premier achat, ce qui est exact : la position
+-- n'existait pas encore.
+INSERT INTO snapshot_cours (actif_id, date_snapshot, cours_eur, quantite)
+SELECT a.id,
+       jour::date,
+       ROUND((premier.prix * (
+           1
+           + (jour::date - (CURRENT_DATE - 89)) * 0.0020
+           + SIN(((jour::date - (CURRENT_DATE - 89)) + a.id * 7) / 9.0) * 0.055
+       ))::numeric, 2),
+       COALESCE((
+           SELECT SUM(CASE WHEN t.sens = 'achat' THEN t.quantite ELSE -t.quantite END)
+           FROM transaction t
+           WHERE t.actif_id = a.id
+             AND t.date_transaction::date <= jour::date
+       ), 0)
+FROM actif a
+JOIN LATERAL (
+    SELECT t.prix_unitaire AS prix
+    FROM transaction t
+    WHERE t.actif_id = a.id
+    ORDER BY t.date_transaction, t.id
+    LIMIT 1
+) AS premier ON true
+CROSS JOIN generate_series(CURRENT_DATE - 89, CURRENT_DATE, INTERVAL '1 day') AS jour
+WHERE a.utilisateur_id = (SELECT id FROM utilisateur WHERE email = 'user@capitall.fr');

--- a/backend/src/models/snapshotCours.js
+++ b/backend/src/models/snapshotCours.js
@@ -1,0 +1,98 @@
+// Accès à la table snapshot_cours : l'historique du cours de chaque position.
+//
+// Même dérogation assumée que pour snapshot_valorisation (D8, D16, D81) : un cours
+// passé ne se recalcule pas. Les fournisseurs ne conservent pas leur historique de la
+// même façon selon la classe d'actif, et l'un d'eux n'en expose aucun. Ce que
+// l'application n'a pas relevé le jour même est définitivement perdu, ce qui fait de
+// chaque ligne un fait daté et non une valeur redondante.
+//
+// Aucune requête de ce module ne prend un identifiant d'utilisateur pour le comparer
+// après coup : le propriétaire entre dans le SQL, par jointure sur actif, exactement
+// comme pour les transactions. Une lecture portant sur l'actif d'un autre compte ne
+// rend rien, et rien n'est indiscernable d'un actif inexistant (D52).
+
+const { query } = require('../db');
+
+// Écriture des cours du jour pour toutes les positions à la fois.
+//
+// Une seule instruction plutôt qu'une par position : le tableau de bord charge six
+// actifs chez un utilisateur ordinaire, et autant d'allers-retours pour un effet de
+// bord d'historisation coûterait plus cher que le calcul lui-même.
+//
+// ON CONFLICT DO NOTHING s'appuie sur l'unicité (actif_id, date_snapshot). Deux onglets
+// ouverts en même temps passeraient tous deux un contrôle d'existence préalable ; ici,
+// c'est la base qui arbitre, comme pour la valorisation totale.
+async function enregistrerSiAbsent(utilisateurId, positions) {
+  const aHistoriser = positions.filter(
+    (position) => position.cours_eur !== null && position.cours_eur !== undefined
+  );
+
+  if (aHistoriser.length === 0) {
+    return [];
+  }
+
+  const { rows } = await query(
+    `INSERT INTO snapshot_cours (actif_id, date_snapshot, cours_eur, quantite)
+     SELECT a.id, CURRENT_DATE, entree.cours_eur, entree.quantite
+     FROM unnest($2::integer[], $3::numeric[], $4::numeric[])
+          AS entree(actif_id, cours_eur, quantite)
+     JOIN actif a ON a.id = entree.actif_id AND a.utilisateur_id = $1
+     ON CONFLICT (actif_id, date_snapshot) DO NOTHING
+     RETURNING actif_id`,
+    [
+      utilisateurId,
+      aHistoriser.map((position) => position.id),
+      aHistoriser.map((position) => position.cours_eur),
+      aHistoriser.map((position) => position.quantite_detenue ?? '0'),
+    ]
+  );
+
+  // Aucune ligne rendue signifie que l'historique du jour existait déjà : c'est le cas
+  // courant dès la seconde consultation, pas une erreur.
+  return rows;
+}
+
+// Historique d'une position, du plus ancien au plus récent, prêt à être tracé.
+//
+// La date est formatée en chaîne par PostgreSQL plutôt que rendue comme colonne DATE :
+// le pilote la convertirait sinon en instant interprété dans le fuseau du serveur, et
+// la sérialisation JSON afficherait la veille à l'est de Greenwich. Une date de
+// snapshot est un jour calendaire, pas un instant.
+async function listerParActif(actifId, utilisateurId, nombreDeJours) {
+  const conditionDeDate = nombreDeJours ? 'AND sc.date_snapshot >= CURRENT_DATE - $3::integer' : '';
+  const parametres = nombreDeJours ? [actifId, utilisateurId, nombreDeJours] : [actifId, utilisateurId];
+
+  const { rows } = await query(
+    `SELECT to_char(sc.date_snapshot, 'YYYY-MM-DD') AS date_snapshot,
+            sc.cours_eur,
+            sc.quantite
+     FROM snapshot_cours sc
+     JOIN actif a ON a.id = sc.actif_id
+     WHERE sc.actif_id = $1 AND a.utilisateur_id = $2 ${conditionDeDate}
+     ORDER BY sc.date_snapshot`,
+    parametres
+  );
+  return rows;
+}
+
+// Historique récent de toutes les positions d'un utilisateur, en une seule requête.
+//
+// C'est ce qui alimente la colonne de tendance du tableau des positions. Interroger
+// chaque actif séparément multiplierait les allers-retours par le nombre de lignes du
+// tableau, pour une information secondaire.
+async function listerRecentsParUtilisateur(utilisateurId, nombreDeJours) {
+  const { rows } = await query(
+    `SELECT sc.actif_id,
+            to_char(sc.date_snapshot, 'YYYY-MM-DD') AS date_snapshot,
+            sc.cours_eur
+     FROM snapshot_cours sc
+     JOIN actif a ON a.id = sc.actif_id
+     WHERE a.utilisateur_id = $1
+       AND sc.date_snapshot >= CURRENT_DATE - $2::integer
+     ORDER BY sc.actif_id, sc.date_snapshot`,
+    [utilisateurId, nombreDeJours]
+  );
+  return rows;
+}
+
+module.exports = { enregistrerSiAbsent, listerParActif, listerRecentsParUtilisateur };

--- a/backend/src/services/__tests__/calculPortefeuille.test.js
+++ b/backend/src/services/__tests__/calculPortefeuille.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  derouler,
   calculerPosition,
   valoriser,
   consolider,
@@ -310,5 +311,108 @@ describe('performance par plage du sélecteur de période', () => {
       { type: 'crypto', valeur: null, cout_total: '0.00', plus_value_latente: null, plus_value_realisee: '300.00' },
     ]);
     expect(totaux.plus_value_realisee).toBe('300.00');
+  });
+});
+
+// Déroulé des mouvements : l'effet de chacun sur le prix de revient.
+//
+// C'est la colonne la plus difficile à défendre à l'oral, et celle que l'interface ne
+// doit surtout pas reconstituer de son côté. Les cas ci-dessous sont les mêmes que ceux
+// du calcul de position, relus mouvement par mouvement.
+describe('déroulé des mouvements', () => {
+  it('rend une liste vide sans transaction', () => {
+    expect(derouler([]).mouvements).toEqual([]);
+  });
+
+  // Premier achat : le prix de revient part de zéro, l'effet vaut donc le PRU entier.
+  it('porte le prix de revient de zéro à sa valeur au premier achat', () => {
+    const [mouvement] = derouler([achat('10', '100.00', '5.00')]).mouvements;
+
+    expect(mouvement.pru_avant).toBe('0');
+    expect(mouvement.pru_apres).toBe('100.5');
+    expect(mouvement.effet_pru).toBe('100.5');
+    expect(mouvement.quantite_apres).toBe('10');
+    expect(mouvement.montant).toBe('1000.00');
+    expect(mouvement.plus_value_realisee).toBeNull();
+  });
+
+  // Second achat : 110,50 − 100,50 = 10, vérifiable de tête.
+  it('chiffre le déplacement du prix de revient provoqué par un achat', () => {
+    const { mouvements } = derouler([
+      achat('10', '100.00', '5.00', '2026-01-10', 1),
+      achat('10', '120.00', '5.00', '2026-02-10', 2),
+    ]);
+
+    expect(mouvements[1].pru_avant).toBe('100.5');
+    expect(mouvements[1].pru_apres).toBe('110.5');
+    expect(mouvements[1].effet_pru).toBe('10');
+  });
+
+  // Règle 3 : une vente partielle laisse le prix de revient intact. L'effet est nul,
+  // et c'est bien un zéro constaté, pas une donnée absente.
+  it("laisse le prix de revient inchangé lors d'une vente partielle", () => {
+    const { mouvements } = derouler([
+      achat('10', '100.00', '5.00', '2026-01-10', 1),
+      achat('10', '120.00', '5.00', '2026-02-10', 2),
+      vente('5', '150.00', '5.00', '2026-03-10', 3),
+    ]);
+
+    expect(mouvements[2].effet_pru).toBe('0');
+    expect(mouvements[2].pru_apres).toBe('110.5');
+    expect(mouvements[2].quantite_apres).toBe('15');
+  });
+
+  // Règle 4, appliquée à une opération et non au cumul : 5 × (150 − 110,50) − 5.
+  it('rend la plus-value dégagée par chaque vente prise isolément', () => {
+    const { mouvements, position } = derouler([
+      achat('10', '100.00', '5.00', '2026-01-10', 1),
+      achat('10', '120.00', '5.00', '2026-02-10', 2),
+      vente('5', '150.00', '5.00', '2026-03-10', 3),
+      vente('5', '160.00', '0', '2026-04-10', 4),
+    ]);
+
+    expect(mouvements[2].plus_value_realisee).toBe('192.50');
+    expect(mouvements[3].plus_value_realisee).toBe('247.50');
+    // Le cumul de la position doit être exactement la somme des opérations : si les
+    // deux divergeaient, l'écran de détail contredirait le tableau de bord.
+    expect(position.plus_value_realisee).toBe('440.00');
+  });
+
+  // Règle 5 : la vente qui solde la position remet le prix de revient à zéro. L'effet
+  // est alors franchement négatif, et c'est ce chiffre qui explique la remise à zéro.
+  it('signale la remise à zéro du prix de revient sur une vente totale', () => {
+    const { mouvements } = derouler([
+      achat('10', '100.00', '5.00', '2026-01-10', 1),
+      vente('10', '150.00', '0', '2026-02-10', 2),
+    ]);
+
+    expect(mouvements[1].pru_avant).toBe('100.5');
+    expect(mouvements[1].pru_apres).toBe('0');
+    expect(mouvements[1].effet_pru).toBe('-100.5');
+    expect(mouvements[1].quantite_apres).toBe('0');
+  });
+
+  // Règle 6 : le déroulé suit l'ordre chronologique, jamais l'ordre de saisie. Une
+  // opération ancienne saisie après coup doit s'insérer à sa date.
+  it("déroule dans l'ordre chronologique et non dans l'ordre de saisie", () => {
+    const { mouvements } = derouler([
+      achat('10', '120.00', '5.00', '2026-02-10', 2),
+      achat('10', '100.00', '5.00', '2026-01-10', 1),
+    ]);
+
+    expect(mouvements.map((mouvement) => mouvement.id)).toEqual([1, 2]);
+    expect(mouvements[0].pru_apres).toBe('100.5');
+  });
+
+  // Les champs d'origine de la transaction restent présents : la frise affiche la date,
+  // le sens et les frais tels que saisis, à côté des chiffres calculés.
+  it("conserve les champs d'origine de la transaction", () => {
+    const [mouvement] = derouler([achat('10', '100.00', '5.00', '2026-01-10', 7)]).mouvements;
+
+    expect(mouvement.id).toBe(7);
+    expect(mouvement.sens).toBe('achat');
+    expect(mouvement.quantite).toBe('10');
+    expect(mouvement.frais).toBe('5.00');
+    expect(mouvement.date_transaction).toBe('2026-01-10');
   });
 });

--- a/backend/src/services/__tests__/portefeuilleConsolide.test.js
+++ b/backend/src/services/__tests__/portefeuilleConsolide.test.js
@@ -54,6 +54,16 @@ function snapshotsFactices() {
   };
 }
 
+// Historique de cours par position (D81). Vide par defaut : la plupart des cas ne
+// portent pas sur la tendance, et une serie vide est l'etat reel d'un compte neuf.
+function snapshotsCoursFactices(series = []) {
+  return {
+    enregistrerSiAbsent: vi.fn().mockResolvedValue([]),
+    listerParActif: vi.fn().mockResolvedValue(series),
+    listerRecentsParUtilisateur: vi.fn().mockResolvedValue(series),
+  };
+}
+
 beforeEach(() => {
   vi.restoreAllMocks();
 });
@@ -69,6 +79,7 @@ describe('portefeuille consolidé', () => {
         { symbole: 'BTC', cours_eur: '150.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
       ]),
       snapshots,
+      snapshotsCours: snapshotsCoursFactices(),
       actifs,
       transactions,
     });
@@ -88,6 +99,7 @@ describe('portefeuille consolidé', () => {
     const service = creerServicePortefeuille({
       serviceCours: serviceCoursFactice([]),
       snapshots: snapshotsFactices(),
+      snapshotsCours: snapshotsCoursFactices(),
       actifs,
       transactions,
     });
@@ -106,6 +118,7 @@ describe('portefeuille consolidé', () => {
     const service = creerServicePortefeuille({
       serviceCours: serviceCoursFactice([{ symbole: 'BTC', erreur: 'fournisseur injoignable' }]),
       snapshots: snapshotsFactices(),
+      snapshotsCours: snapshotsCoursFactices(),
       actifs,
       transactions,
     });
@@ -126,6 +139,7 @@ describe('portefeuille consolidé', () => {
     const service = creerServicePortefeuille({
       serviceCours: serviceCoursFactice([{ symbole: 'BTC', erreur: 'injoignable' }]),
       snapshots,
+      snapshotsCours: snapshotsCoursFactices(),
       actifs,
       transactions,
     });
@@ -149,6 +163,7 @@ describe('portefeuille consolidé', () => {
         { symbole: 'BTC', cours_eur: '150.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
       ]),
       snapshots,
+      snapshotsCours: snapshotsCoursFactices(),
       actifs,
       transactions,
     });
@@ -165,6 +180,7 @@ describe('portefeuille consolidé', () => {
     const service = creerServicePortefeuille({
       serviceCours: serviceCoursFactice([]),
       snapshots: snapshotsFactices(),
+      snapshotsCours: snapshotsCoursFactices(),
       actifs,
       transactions,
     });
@@ -187,7 +203,11 @@ describe('portefeuille consolidé', () => {
       { symbole: 'BTC', cours_eur: '150.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
       { symbole: 'ETH', cours_eur: '10.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
     ]);
-    const service = creerServicePortefeuille({ serviceCours, snapshots: snapshotsFactices(), actifs, transactions });
+    const service = creerServicePortefeuille({ serviceCours, snapshots: snapshotsFactices(),
+      snapshotsCours: snapshotsCoursFactices(),
+      actifs,
+      transactions,
+    });
 
     await service.obtenirPortefeuille(2);
 
@@ -215,6 +235,7 @@ describe('évaluation des alertes au chargement', () => {
         { symbole: 'BTC', cours_eur: '150.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
       ]),
       snapshots: snapshotsFactices(),
+      snapshotsCours: snapshotsCoursFactices(),
       actifs,
       transactions,
       alertes,
@@ -246,6 +267,7 @@ describe('évaluation des alertes au chargement', () => {
         { symbole: 'BTC', cours_eur: '150.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
       ]),
       snapshots: snapshotsFactices(),
+      snapshotsCours: snapshotsCoursFactices(),
       actifs,
       transactions,
       alertes,
@@ -270,6 +292,7 @@ describe('évaluation des alertes au chargement', () => {
         { symbole: 'BTC', cours_eur: '150.00', horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
       ]),
       snapshots: snapshotsFactices(),
+      snapshotsCours: snapshotsCoursFactices(),
       actifs,
       transactions,
       alertes,
@@ -295,7 +318,11 @@ describe("détail d'un actif", () => {
       source: 'fournisseur',
     });
 
-    const service = creerServicePortefeuille({ serviceCours, snapshots: snapshotsFactices(), actifs, transactions });
+    const service = creerServicePortefeuille({ serviceCours, snapshots: snapshotsFactices(),
+      snapshotsCours: snapshotsCoursFactices(),
+      actifs,
+      transactions,
+    });
     const detail = await service.obtenirDetailActif(1, 2);
 
     expect(detail.pru).toBe('100');
@@ -311,6 +338,7 @@ describe("détail d'un actif", () => {
     const service = creerServicePortefeuille({
       serviceCours: serviceCoursFactice([]),
       snapshots: snapshotsFactices(),
+      snapshotsCours: snapshotsCoursFactices(),
       actifs,
       transactions,
     });
@@ -342,6 +370,7 @@ describe('historique du portefeuille', () => {
     const service = creerServicePortefeuille({
       serviceCours: serviceCoursFactice([]),
       snapshots,
+      snapshotsCours: snapshotsCoursFactices(),
       actifs: depotActifs([]),
       transactions: depotTransactions([]),
       alertes: depotAlertes(),
@@ -362,6 +391,7 @@ describe('historique du portefeuille', () => {
     const service = creerServicePortefeuille({
       serviceCours: serviceCoursFactice([]),
       snapshots,
+      snapshotsCours: snapshotsCoursFactices(),
       actifs: depotActifs([]),
       transactions: depotTransactions([]),
       alertes: depotAlertes(),
@@ -378,6 +408,7 @@ describe('historique du portefeuille', () => {
     const service = creerServicePortefeuille({
       serviceCours: serviceCoursFactice([]),
       snapshots: snapshotsAvecSerie([SERIE[0]]),
+      snapshotsCours: snapshotsCoursFactices(),
       actifs: depotActifs([]),
       transactions: depotTransactions([]),
       alertes: depotAlertes(),
@@ -387,5 +418,115 @@ describe('historique du portefeuille', () => {
 
     expect(historique.points).toHaveLength(1);
     expect(historique.performances.origine).toBeNull();
+  });
+});
+
+// Historique de cours par position (D81).
+//
+// L'alimentation reutilise l'ecriture paresseuse de D49 : aucune tache planifiee, le
+// meme point d'appel, les memes garanties d'effet de bord.
+describe('historique de cours par position', () => {
+  const SERIE_BTC = [
+    { actif_id: 1, date_snapshot: '2026-07-01', cours_eur: '100.00' },
+    { actif_id: 1, date_snapshot: '2026-07-15', cours_eur: '120.00' },
+    { actif_id: 1, date_snapshot: '2026-07-30', cours_eur: '150.00' },
+  ];
+
+  function service(snapshotsCours, cours = '150.00') {
+    return creerServicePortefeuille({
+      serviceCours: serviceCoursFactice([
+        { symbole: 'BTC', cours_eur: cours, horodatage: '2026-07-30T10:00:00Z', source: 'cache' },
+      ]),
+      snapshots: snapshotsFactices(),
+      snapshotsCours,
+      actifs: depotActifs([ACTIF_BTC], ACTIF_BTC),
+      transactions: depotTransactions(TRANSACTIONS_BTC),
+    });
+  }
+
+  it("historise les positions valorisees au meme point d'appel que le portefeuille", async () => {
+    const snapshotsCours = snapshotsCoursFactices();
+    await service(snapshotsCours).obtenirPortefeuille(2);
+
+    expect(snapshotsCours.enregistrerSiAbsent).toHaveBeenCalledTimes(1);
+    const [utilisateurId, positions] = snapshotsCours.enregistrerSiAbsent.mock.calls[0];
+    expect(utilisateurId).toBe(2);
+    expect(positions[0]).toMatchObject({ id: 1, cours_eur: '150.00', quantite_detenue: '1' });
+  });
+
+  // Meme regle que pour le snapshot de valorisation : l'historisation est un effet de
+  // bord, son echec ne prive pas l'utilisateur de son portefeuille.
+  it("rend le portefeuille meme si l'historisation des cours echoue", async () => {
+    const snapshotsCours = snapshotsCoursFactices();
+    snapshotsCours.enregistrerSiAbsent.mockRejectedValue(new Error('base indisponible'));
+
+    const portefeuille = await service(snapshotsCours).obtenirPortefeuille(2);
+
+    expect(portefeuille.valeur_totale).toBe('150.00');
+  });
+
+  it('expose la tendance de chaque position sur la fenetre de trente jours', async () => {
+    const snapshotsCours = snapshotsCoursFactices(SERIE_BTC);
+    const portefeuille = await service(snapshotsCours).obtenirPortefeuille(2);
+
+    expect(snapshotsCours.listerRecentsParUtilisateur).toHaveBeenCalledWith(2, 30);
+    // De 100 a 150, soit cinquante pour cent, verifiable de tete.
+    expect(portefeuille.actifs[0].tendance_30j.variation).toBe('50.00');
+    expect(portefeuille.actifs[0].tendance_30j.points).toEqual(['100.00', '120.00', '150.00']);
+  });
+
+  // Un point isole ne dit rien d'une evolution : la variation est absente, et
+  // l'interface affiche son etat << pas assez de points >> plutot qu'un zero.
+  it('ne fabrique aucune tendance sur un historique trop court', async () => {
+    const snapshotsCours = snapshotsCoursFactices([SERIE_BTC[0]]);
+    const portefeuille = await service(snapshotsCours).obtenirPortefeuille(2);
+
+    expect(portefeuille.actifs[0].tendance_30j.variation).toBeNull();
+  });
+
+  it("rend une tendance absente lorsque la position n'a aucun historique", async () => {
+    const portefeuille = await service(snapshotsCoursFactices()).obtenirPortefeuille(2);
+
+    expect(portefeuille.actifs[0].tendance_30j).toBeNull();
+  });
+
+  // Une lecture d'historique en echec ne doit pas vider le portefeuille : la colonne
+  // de tendance se comporte alors comme pour un actif trop jeune.
+  it('rend le portefeuille meme si la lecture des tendances echoue', async () => {
+    const snapshotsCours = snapshotsCoursFactices();
+    snapshotsCours.listerRecentsParUtilisateur.mockRejectedValue(new Error('base indisponible'));
+
+    const portefeuille = await service(snapshotsCours).obtenirPortefeuille(2);
+
+    expect(portefeuille.valeur_totale).toBe('150.00');
+    expect(portefeuille.actifs[0].tendance_30j).toBeNull();
+  });
+
+  it("joint au detail d'un actif sa serie de cours et la performance de chaque plage", async () => {
+    const snapshotsCours = snapshotsCoursFactices(SERIE_BTC);
+    const detail = await service(snapshotsCours).obtenirDetailActif(1, 2);
+
+    // Le cloisonnement passe par le SQL : le modele recoit toujours le proprietaire.
+    expect(snapshotsCours.listerParActif).toHaveBeenCalledWith(1, 2);
+    expect(detail.historique.points).toHaveLength(3);
+    expect(detail.historique.performances.origine).toBe('50.00');
+  });
+
+  it("rend un historique vide plutot qu'absent pour une position trop jeune", async () => {
+    const detail = await service(snapshotsCoursFactices()).obtenirDetailActif(1, 2);
+
+    expect(detail.historique.points).toEqual([]);
+    expect(detail.historique.performances.origine).toBeNull();
+  });
+
+  it("rend le detail meme si la lecture de l'historique echoue", async () => {
+    const snapshotsCours = snapshotsCoursFactices();
+    snapshotsCours.listerParActif.mockRejectedValue(new Error('base indisponible'));
+
+    const detail = await service(snapshotsCours).obtenirDetailActif(1, 2);
+
+    expect(detail.pru).toBe('100');
+    expect(detail.transactions).toHaveLength(1);
+    expect(detail.historique.points).toEqual([]);
   });
 });

--- a/backend/src/services/calculPortefeuille.js
+++ b/backend/src/services/calculPortefeuille.js
@@ -44,13 +44,23 @@ function trierChronologiquement(transactions) {
   });
 }
 
-function calculerPosition(transactions) {
+// Déroulé complet d'une position : l'état après chaque mouvement, et l'état final.
+//
+// Une seule traversée produit les deux, et c'est délibéré. Le prix de revient après un
+// achat donné ne se retrouve pas en rejouant un calcul séparé : il faut avoir rejoué
+// toute l'histoire de la position dans le même ordre, avec les mêmes arrondis. Deux
+// implémentations parallèles finiraient par diverger sur un cas de bord, et c'est
+// précisément ce chiffre qu'il faut pouvoir défendre au tableau.
+//
+// L'effet de chaque mouvement sur le prix de revient est donc un fait calculé ici, du
+// côté qui détient le moteur, et non une reconstitution faite par l'interface (D69).
+function derouler(transactions) {
   // Quantité et PRU sont tenus à l'échelle des quantités et du PRU, soit 8 décimales.
   let quantite = 0n;
   let pru = 0n;
   let plusValueRealisee = 0n;
 
-  for (const transaction of trierChronologiquement(transactions)) {
+  const mouvements = trierChronologiquement(transactions).map((transaction) => {
     const quantiteTransaction = versUnites(transaction.quantite, ECHELLE_QUANTITE);
     // Prix et frais sont saisis à 2 décimales, remontés à 8 pour rester homogènes
     // avec le PRU pendant le calcul.
@@ -65,6 +75,11 @@ function calculerPosition(transactions) {
       ECHELLE_PRU
     );
 
+    const pruAvant = pru;
+    // Plus-value de cette vente-ci, à distinguer du cumul de la position. Elle reste
+    // nulle sur un achat, qui n'en dégage aucune.
+    let gainDeLOperation = null;
+
     if (transaction.sens === 'achat') {
       // Règles 1 et 2 : moyenne pondérée, frais d'achat inclus au coût de revient.
       const coutExistant = multiplier(pru, quantite, ECHELLE_PRU);
@@ -78,7 +93,8 @@ function calculerPosition(transactions) {
     } else {
       // Règles 3 et 4 : le PRU ne bouge pas, la plus-value réalisée est cumulée.
       const gainUnitaire = prixUnitaire - pru;
-      plusValueRealisee += multiplier(gainUnitaire, quantiteTransaction, ECHELLE_PRU) - frais;
+      gainDeLOperation = multiplier(gainUnitaire, quantiteTransaction, ECHELLE_PRU) - frais;
+      plusValueRealisee += gainDeLOperation;
       quantite -= quantiteTransaction;
 
       // Règle 5 : position soldée, le PRU repart de zéro pour un éventuel rachat.
@@ -87,15 +103,44 @@ function calculerPosition(transactions) {
         pru = 0n;
       }
     }
-  }
+
+    return {
+      ...transaction,
+      // Montant brut de l'opération, frais exclus : ils sont déjà rendus à part et les
+      // additionner ici les compterait deux fois à l'écran.
+      montant: formater(
+        multiplier(prixUnitaire, quantiteTransaction, ECHELLE_PRU),
+        ECHELLE_PRU,
+        ECHELLE_MONTANT
+      ),
+      pru_avant: versChaine(pruAvant, ECHELLE_PRU),
+      pru_apres: versChaine(pru, ECHELLE_PRU),
+      // Zéro sur une vente ordinaire, la règle 3 laissant le prix de revient intact ;
+      // franchement négatif sur une vente qui solde la position, où la règle 5 le
+      // remet à zéro. Les deux cas se lisent sur ce seul chiffre.
+      effet_pru: versChaine(pru - pruAvant, ECHELLE_PRU),
+      quantite_apres: versChaine(quantite, ECHELLE_QUANTITE),
+      plus_value_realisee:
+        gainDeLOperation === null
+          ? null
+          : formater(gainDeLOperation, ECHELLE_PRU, ECHELLE_MONTANT),
+    };
+  });
 
   return {
-    quantite_detenue: versChaine(quantite, ECHELLE_QUANTITE),
-    pru: versChaine(pru, ECHELLE_PRU),
-    // Ce que représente encore la position au prix de revient, frais compris.
-    cout_total: formater(multiplier(pru, quantite, ECHELLE_PRU), ECHELLE_PRU, ECHELLE_MONTANT),
-    plus_value_realisee: formater(plusValueRealisee, ECHELLE_PRU, ECHELLE_MONTANT),
+    mouvements,
+    position: {
+      quantite_detenue: versChaine(quantite, ECHELLE_QUANTITE),
+      pru: versChaine(pru, ECHELLE_PRU),
+      // Ce que représente encore la position au prix de revient, frais compris.
+      cout_total: formater(multiplier(pru, quantite, ECHELLE_PRU), ECHELLE_PRU, ECHELLE_MONTANT),
+      plus_value_realisee: formater(plusValueRealisee, ECHELLE_PRU, ECHELLE_MONTANT),
+    },
   };
+}
+
+function calculerPosition(transactions) {
+  return derouler(transactions).position;
 }
 
 // Valorisation d'une position à un cours donné. Un cours absent ne vaut pas zéro :
@@ -271,6 +316,7 @@ function reculerDe(dateIso, jours) {
 }
 
 module.exports = {
+  derouler,
   calculerPosition,
   valoriser,
   consolider,

--- a/backend/src/services/calculPortefeuille.js
+++ b/backend/src/services/calculPortefeuille.js
@@ -267,9 +267,14 @@ function repartir(valeurParType, valeurTotale) {
 // raisons : la fonction reste pure et testable sans figer le temps, et la performance
 // d'une plage se lit entre deux mesures réelles, pas entre une mesure et une date à
 // laquelle rien n'a été relevé.
+//
+// Le nom de la colonne mesurée est un paramètre : la même mécanique sert la valeur
+// totale du portefeuille et le cours d'une position, deux séries de même forme dont
+// seule l'étiquette diffère. En écrire une seconde copie garantirait qu'un jour les
+// deux sélecteurs de période ne comptent plus les jours de la même façon.
 const PLAGES_EN_JOURS = { jour: 1, semaine: 7, mois: 30, annee: 365 };
 
-function calculerPerformances(instantanes) {
+function calculerPerformances(instantanes, champ = 'valeur_totale_eur') {
   const plages = Object.keys(PLAGES_EN_JOURS);
 
   // Un point isolé ne dit rien d'une évolution : aucune plage n'est calculable.
@@ -283,23 +288,29 @@ function calculerPerformances(instantanes) {
     const debut = reculerDe(derniereDate, PLAGES_EN_JOURS[plage]);
     // Les dates sont au format AAAA-MM-JJ : leur ordre lexicographique est leur ordre
     // chronologique, aucune conversion n'est nécessaire pour filtrer.
-    return [plage, performanceSurPeriode(instantanes.filter((point) => point.date_snapshot >= debut))];
+    return [
+      plage,
+      performanceSurPeriode(
+        instantanes.filter((point) => point.date_snapshot >= debut),
+        champ
+      ),
+    ];
   });
 
   return {
     ...Object.fromEntries(performances),
-    origine: performanceSurPeriode(instantanes),
+    origine: performanceSurPeriode(instantanes, champ),
   };
 }
 
 // Variation entre le premier et le dernier point d'une série.
-function performanceSurPeriode(points) {
+function performanceSurPeriode(points, champ = 'valeur_totale_eur') {
   if (points.length < 2) {
     return null;
   }
 
-  const depart = versUnites(points[0].valeur_totale_eur, ECHELLE_MONTANT);
-  const arrivee = versUnites(points[points.length - 1].valeur_totale_eur, ECHELLE_MONTANT);
+  const depart = versUnites(points[0][champ], ECHELLE_MONTANT);
+  const arrivee = versUnites(points[points.length - 1][champ], ECHELLE_MONTANT);
 
   return pourcentageVariation(arrivee - depart, depart);
 }
@@ -321,5 +332,6 @@ module.exports = {
   valoriser,
   consolider,
   calculerPerformances,
+  performanceSurPeriode,
   trierChronologiquement,
 };

--- a/backend/src/services/portefeuilleConsolide.js
+++ b/backend/src/services/portefeuilleConsolide.js
@@ -11,6 +11,7 @@ const modeleAlerte = require('../models/alerte');
 const { evaluerAlertes } = require('./evaluationAlertes');
 const { creerServiceCours } = require('./cours');
 const {
+  derouler,
   calculerPosition,
   valoriser,
   consolider,
@@ -187,8 +188,11 @@ function creerServicePortefeuille({
       throw new ErreurIntrouvable('Actif introuvable.');
     }
 
+    // Un seul déroulé sert les deux besoins de l'écran de détail : l'état courant de la
+    // position, et l'effet de chaque mouvement sur le prix de revient. Les mouvements
+    // sortent donc enrichis, dans l'ordre chronologique du calcul.
     const transactions = await depotTransactions.listerParActifEtUtilisateur(actifId, utilisateurId);
-    const position = calculerPosition(transactions);
+    const { mouvements, position } = derouler(transactions);
 
     let coursActif = null;
     try {
@@ -203,7 +207,7 @@ function creerServicePortefeuille({
       source_cours: coursActif?.source ?? null,
       horodatage_cours: coursActif?.horodatage ?? null,
       ...valoriser(position, coursActif?.cours_eur ?? null),
-      transactions,
+      transactions: mouvements,
     };
   }
 

--- a/backend/src/services/portefeuilleConsolide.js
+++ b/backend/src/services/portefeuilleConsolide.js
@@ -272,6 +272,11 @@ function creerServicePortefeuille({
       ...valoriser(position, coursActif?.cours_eur ?? null),
       transactions: mouvements,
       historique: await obtenirHistoriqueCours(actifId, utilisateurId),
+      // Même taux que celui du portefeuille, et pour la même raison (D43, D69) : la
+      // bascule euro/dollar ne doit déclencher aucune requête. Sans lui, l'écran de
+      // détail afficherait des euros alors que les deux écrans qui y mènent affichent
+      // des dollars, ce qui se lirait comme une erreur de chiffres.
+      taux_affichage: await obtenirTauxAffichage(),
     };
   }
 

--- a/backend/src/services/portefeuilleConsolide.js
+++ b/backend/src/services/portefeuilleConsolide.js
@@ -7,6 +7,7 @@
 const modeleActif = require('../models/actif');
 const modeleTransaction = require('../models/transaction');
 const modeleSnapshot = require('../models/snapshot');
+const modeleSnapshotCours = require('../models/snapshotCours');
 const modeleAlerte = require('../models/alerte');
 const { evaluerAlertes } = require('./evaluationAlertes');
 const { creerServiceCours } = require('./cours');
@@ -16,15 +17,22 @@ const {
   valoriser,
   consolider,
   calculerPerformances,
+  performanceSurPeriode,
 } = require('./calculPortefeuille');
 const { ECHELLE_PRU, versUnites, versChaine, diviser } = require('../utils/decimal');
 const { ErreurIntrouvable } = require('../erreurs');
+
+// Fenêtre de la tendance affichée en regard de chaque position dans le tableau des
+// positions. Trente jours : c'est la plage que porte la maquette desktop, et celle qui
+// correspond au rythme réel de consultation d'un patrimoine.
+const JOURS_DE_TENDANCE = 30;
 
 // Les modèles et le service de cours sont injectables : le service s'exécute alors
 // sans base ni réseau dans les tests, avec le même code qu'en production.
 function creerServicePortefeuille({
   serviceCours = creerServiceCours(),
   snapshots = modeleSnapshot,
+  snapshotsCours = modeleSnapshotCours,
   actifs: depotActifs = modeleActif,
   transactions: depotTransactions = modeleTransaction,
   alertes: depotAlertes = modeleAlerte,
@@ -118,9 +126,17 @@ function creerServicePortefeuille({
     await historiser(utilisateurId, totaux.valeur_totale, positions, coursIndisponibles);
     const alertesDeclenchees = await traiterAlertes(utilisateurId, totaux.valeur_totale, positions);
 
+    // L'historisation précède la lecture des tendances : le point du jour vient d'être
+    // écrit et doit compter dans la fenêtre, sans quoi la tendance affichée s'arrêterait
+    // systématiquement la veille.
+    const tendances = await obtenirTendances(utilisateurId);
+
     return {
       ...totaux,
-      actifs: positions,
+      actifs: positions.map((position) => ({
+        ...position,
+        tendance_30j: tendances.get(position.id) ?? null,
+      })),
       cours_indisponibles: coursIndisponibles,
       taux_affichage: tauxAffichage,
       alertes_declenchees: alertesDeclenchees,
@@ -179,6 +195,53 @@ function creerServicePortefeuille({
       // l'utilisateur de son portefeuille.
       console.error("Enregistrement du snapshot impossible :", erreur.message);
     }
+
+    // Historique par position (D81), alimenté par le même déclencheur et au même
+    // endroit : les positions valorisées sont déjà là, aucune tâche planifiée n'est
+    // introduite. Les positions sans cours sont écartées par le modèle plutôt que
+    // enregistrées à zéro, pour la même raison qu'au-dessus : un trou dans la courbe
+    // est préférable à un point faux.
+    try {
+      await snapshotsCours.enregistrerSiAbsent(utilisateurId, positions);
+    } catch (erreur) {
+      console.error("Enregistrement de l'historique des cours impossible :", erreur.message);
+    }
+  }
+
+  // Tendance récente de chaque position, indexée par identifiant d'actif.
+  //
+  // La variation est calculée ici et non côté interface : c'est une valeur dérivée de
+  // deux cours, donc du ressort du serveur (D69). Les points, eux, ne servent qu'au
+  // tracé de la courbe miniature, où seule compte la forme.
+  async function obtenirTendances(utilisateurId) {
+    try {
+      const releves = await snapshotsCours.listerRecentsParUtilisateur(
+        utilisateurId,
+        JOURS_DE_TENDANCE
+      );
+
+      const parActif = new Map();
+      for (const releve of releves) {
+        const serie = parActif.get(releve.actif_id) ?? [];
+        serie.push(releve);
+        parActif.set(releve.actif_id, serie);
+      }
+
+      return new Map(
+        [...parActif.entries()].map(([actifId, serie]) => [
+          actifId,
+          {
+            variation: performanceSurPeriode(serie, 'cours_eur'),
+            points: serie.map((point) => point.cours_eur),
+          },
+        ])
+      );
+    } catch (erreur) {
+      // Une tendance absente n'empêche pas de lire son portefeuille : la colonne
+      // affiche alors son état « pas assez de points », comme pour un actif trop jeune.
+      console.error('Lecture des tendances impossible :', erreur.message);
+      return new Map();
+    }
   }
 
   // Détail d'un actif : position, valorisation et historique de ses transactions.
@@ -208,7 +271,27 @@ function creerServicePortefeuille({
       horodatage_cours: coursActif?.horodatage ?? null,
       ...valoriser(position, coursActif?.cours_eur ?? null),
       transactions: mouvements,
+      historique: await obtenirHistoriqueCours(actifId, utilisateurId),
     };
+  }
+
+  // Historique de cours d'une position, avec la performance de chacune des plages du
+  // sélecteur de période.
+  //
+  // La série entière part dans la réponse plutôt qu'une fenêtre à la demande : quatre-
+  // vingt-dix points pèsent moins qu'un aller-retour, et changer de plage devient
+  // immédiat. Les performances, elles, portent toujours sur l'historique complet, la
+  // performance sur un an ne se déduisant pas d'une fenêtre d'une semaine.
+  async function obtenirHistoriqueCours(actifId, utilisateurId) {
+    try {
+      const points = await snapshotsCours.listerParActif(actifId, utilisateurId);
+      return { points, performances: calculerPerformances(points, 'cours_eur') };
+    } catch (erreur) {
+      // Un historique illisible ne prive pas l'utilisateur du reste de la fiche : le
+      // graphe affiche alors son état « pas assez de points ».
+      console.error("Lecture de l'historique de cours impossible :", erreur.message);
+      return { points: [], performances: calculerPerformances([], 'cours_eur') };
+    }
   }
 
   // Historique du portefeuille : les points de la plage demandée, et la performance de

--- a/docs/cahier-des-charges.md
+++ b/docs/cahier-des-charges.md
@@ -255,7 +255,7 @@ Les cours sont appelés exclusivement côté serveur (D6). Chaque fournisseur es
 
 ## 7. Modèle de données
 
-Six entités : `utilisateur`, `actif`, `transaction`, `alerte`, `snapshot_valorisation`, `annonce`. Modèle conceptuel, modèle logique, cardinalités et diagramme : `conception/modele-de-donnees.md`. Script de création : `../backend/db/schema.sql`.
+Sept entités : `utilisateur`, `actif`, `transaction`, `alerte`, `snapshot_valorisation`, `snapshot_cours`, `annonce`. Modèle conceptuel, modèle logique, cardinalités et diagramme : `conception/modele-de-donnees.md`. Script de création : `../backend/db/schema.sql`.
 
 Trois partis pris de modélisation méritent d'être signalés ici, car ils conditionnent le comportement fonctionnel :
 

--- a/docs/conception/architecture.md
+++ b/docs/conception/architecture.md
@@ -28,7 +28,8 @@ Architecture front / back séparée. Le client React ne parle qu'à l'API Expres
         |                              clé cours:{type}:{symbole}, TTL par classe
         v
 [ PostgreSQL ]
-  utilisateur / actif / transaction / alerte / snapshot_valorisation / annonce
+  utilisateur / actif / transaction / alerte / snapshot_valorisation /
+  snapshot_cours / annonce
 ```
 
 ## Justification des choix
@@ -97,6 +98,8 @@ Chaque fournisseur implémente la même interface : `getCours(symbole) -> { symb
 **Évaluation des alertes** : à chaque consultation du tableau de bord, après le calcul de la valeur du portefeuille et des plus-values par actif, le service d'alertes compare les alertes actives de l'utilisateur (statut = active) aux valeurs courantes (cours d'un actif ou capital total) ; toute alerte franchie passe au statut declenchee et est signalée au front. Aucune tâche planifiée en tâche de fond dans la version MVP : l'évaluation reste liée au chargement du tableau de bord (version light retenue).
 
 **Alimentation de l'historique de valorisation** : à la première consultation du tableau de bord d'une journée donnée, si aucun snapshot n'existe encore pour ce jour, le service de portefeuille enregistre un snapshot_valorisation avec la valeur totale calculée. La courbe d'évolution du tableau de bord se construit ensuite par simple lecture des snapshots existants, sans rappeler les API de cours pour les jours passés.
+
+**Alimentation de l'historique de cours par position** : au même point d'appel et par le même déclencheur, le service enregistre pour chaque position valorisée son cours du jour et la quantité détenue dans snapshot_cours. Aucune tâche planifiée n'est introduite : les positions valorisées sont déjà disponibles à cet endroit, l'écriture s'y ajoute. Une position dont le cours n'a pas pu être obtenu est écartée plutôt qu'enregistrée à zéro, pour la même raison qu'un portefeuille entièrement sans cours n'est pas historisé — un trou dans la courbe est préférable à un point faux. Cet historique alimente le graphe de cours de l'écran de détail et la tendance sur trente jours du tableau des positions.
 
 **Bascule d'affichage euro/dollar (D43)** : le tableau de bord peut présenter les montants en euro ou en dollar. La devise de référence de calcul et de stockage reste l'euro ; la bascule est une simple conversion à l'affichage, appliquée au taux EUR/USD de Frankfurter déjà présent en cache pour les actions, sans appel supplémentaire. Aucun montant en dollar n'est stocké, aucun PRU n'est recalculé par devise ; les snapshots restent enregistrés en euro et sont convertis au taux courant à la lecture. Le multi-devise de référence complet reste hors périmètre.
 

--- a/docs/conception/modele-de-donnees.md
+++ b/docs/conception/modele-de-donnees.md
@@ -2,7 +2,7 @@
 
 ## Modèle conceptuel de données (MCD, formalisme Merise)
 
-Six entités couvrent le périmètre du MVP. Les trois premières (utilisateur, actif, transaction) forment le socle initial. Deux entités complémentaires ont été ajoutées le 14/07/2026 (D15, D16) pour les alertes de seuil et l'historique de valorisation, puis une sixième le 16/07/2026 (D22) pour les annonces internes publiées par l'administrateur. La même date, le type d'actif `action` a été ajouté (D20, réintégration de la bourse au MVP) et la colonne `role` sur l'utilisateur (D23). Le 06/08/2026, la colonne `actif` a complété l'utilisateur (D60), le modèle ne permettant jusque-là pas de représenter la désactivation d'un compte que le rôle d'administration prévoit pourtant de déclencher.
+Sept entités couvrent le périmètre du MVP. Les trois premières (utilisateur, actif, transaction) forment le socle initial. Deux entités complémentaires ont été ajoutées le 14/07/2026 (D15, D16) pour les alertes de seuil et l'historique de valorisation, puis une sixième le 16/07/2026 (D22) pour les annonces internes publiées par l'administrateur. La même date, le type d'actif `action` a été ajouté (D20, réintégration de la bourse au MVP) et la colonne `role` sur l'utilisateur (D23). Le 06/08/2026, la colonne `actif` a complété l'utilisateur (D60), le modèle ne permettant jusque-là pas de représenter la désactivation d'un compte que le rôle d'administration prévoit pourtant de déclencher. Le 23/08/2026, une septième entité a été ajoutée (D81) : l'historique de cours par position, sans lequel ni le graphe de cours de l'écran de détail ni la tendance sur trente jours du tableau des positions n'étaient alimentables.
 
 ### Entités
 
@@ -45,6 +45,12 @@ Six entités couvrent le périmètre du MVP. Les trois premières (utilisateur, 
 - date_snapshot
 - valeur_totale_eur
 
+**SNAPSHOT_COURS**
+- id_snapshot_cours (identifiant)
+- date_snapshot
+- cours_eur (cours unitaire du jour, en euros)
+- quantite (quantité détenue ce jour-là)
+
 **ANNONCE**
 - id_annonce (identifiant)
 - titre
@@ -60,10 +66,11 @@ ACTIF       (1,n) --- COMPORTER ----- (1,1) TRANSACTION
 UTILISATEUR (1,n) --- DEFINIR ------- (1,1) ALERTE
 ACTIF       (0,n) --- CONCERNER ----- (0,1) ALERTE
 UTILISATEUR (1,n) --- ENREGISTRER --- (1,1) SNAPSHOT_VALORISATION
+ACTIF       (1,n) --- RELEVER ------- (1,1) SNAPSHOT_COURS
 UTILISATEUR (0,n) --- PUBLIER ------- (1,1) ANNONCE
 ```
 
-Lecture : un utilisateur possède un ou plusieurs actifs suivis ; un actif appartient à un et un seul utilisateur. Un actif comporte une ou plusieurs transactions ; une transaction porte sur un et un seul actif. Un utilisateur définit une ou plusieurs alertes ; une alerte appartient à un et un seul utilisateur. Une alerte concerne éventuellement un actif précis (type_cible = actif) ou aucun (type_cible = capital_total, portant alors sur l'ensemble du portefeuille) ; un actif peut être la cible de zéro, une ou plusieurs alertes. Un utilisateur enregistre un ou plusieurs snapshots de valorisation ; un snapshot appartient à un et un seul utilisateur. Un utilisateur publie zéro ou plusieurs annonces ; une annonce est publiée par un et un seul utilisateur, la restriction « seul un admin publie » étant une règle de gestion portée par le rôle, vérifiée côté serveur, pas par la structure du modèle.
+Lecture : un utilisateur possède un ou plusieurs actifs suivis ; un actif appartient à un et un seul utilisateur. Un actif comporte une ou plusieurs transactions ; une transaction porte sur un et un seul actif. Un utilisateur définit une ou plusieurs alertes ; une alerte appartient à un et un seul utilisateur. Une alerte concerne éventuellement un actif précis (type_cible = actif) ou aucun (type_cible = capital_total, portant alors sur l'ensemble du portefeuille) ; un actif peut être la cible de zéro, une ou plusieurs alertes. Un utilisateur enregistre un ou plusieurs snapshots de valorisation ; un snapshot appartient à un et un seul utilisateur. Un actif fait l'objet d'un ou plusieurs relevés de cours ; un relevé porte sur un et un seul actif, et son propriétaire se lit par cet actif, jamais par une colonne qui lui serait propre. Un utilisateur publie zéro ou plusieurs annonces ; une annonce est publiée par un et un seul utilisateur, la restriction « seul un admin publie » étant une règle de gestion portée par le rôle, vérifiée côté serveur, pas par la structure du modèle.
 
 Choix de conception discutés :
 
@@ -71,6 +78,8 @@ Choix de conception discutés :
 - Le PRU et la plus-value ne sont pas stockés : ce sont des valeurs calculées à partir des transactions, les stocker créerait un risque d'incohérence (D8).
 - Un référentiel d'actifs partagé entre utilisateurs (table de symboles commune) a été envisagé puis écarté : il complexifie le modèle sans bénéfice au MVP, chaque utilisateur déclare simplement les symboles qu'il suit (D9).
 - SNAPSHOT_VALORISATION déroge en apparence à la règle « pas de valeur dérivée stockée » : la dérogation est volontaire (D16). Une valeur de portefeuille à une date passée n'est pas recalculable après coup dès lors que les cours historiques des fournisseurs ne sont pas conservés côté CapitAll ; un snapshot est donc un fait historique à part entière, pas une donnée redondante avec les transactions. Il sert aussi à éviter de rappeler les API de cours pour reconstituer une courbe d'évolution.
+- SNAPSHOT_COURS déroge à la même règle et pour la même raison que SNAPSHOT_VALORISATION (D81). Un cours passé ne se recalcule pas : les fournisseurs ne conservent pas leur historique de la même façon selon la classe d'actif, et l'un d'eux n'en expose aucun. Ce que l'application n'a pas relevé le jour même est perdu, ce qui fait de chaque ligne un fait daté. La quantité détenue y est jointe au cours, faute de quoi reconstituer la valeur passée d'une position obligerait à rejouer toutes ses transactions antérieures à chaque point de la courbe.
+- SNAPSHOT_COURS ne porte pas d'`utilisateur_id`, alors que SNAPSHOT_VALORISATION en porte un. La différence n'est pas une inconséquence : un snapshot de valorisation porte sur le portefeuille entier, dont l'utilisateur est la seule clé possible, tandis qu'un relevé de cours porte sur un actif, qui connaît déjà son propriétaire. Dupliquer l'information créerait une seconde vérité sur le cloisonnement, avec la certitude qu'elles divergent un jour ; le cloisonnement se lit donc par jointure, comme pour TRANSACTION.
 - ALERTE ne référence pas systématiquement un actif : `actif_id` est nul lorsque l'alerte porte sur le capital total du portefeuille plutôt que sur un actif précis. Contrairement à la règle « quantité vendue disponible » qui nécessite une agrégation sur plusieurs lignes de transaction et reste donc du ressort du serveur, la cohérence entre `type_cible` et la présence de `actif_id` ne porte que sur des colonnes de la même ligne : elle est directement portée par une contrainte CHECK au niveau du MPD.
 
 ## Modèle logique de données (MLD)
@@ -98,6 +107,10 @@ snapshot_valorisation (#id, ->utilisateur_id NOT NULL, date_snapshot NOT NULL,
                         valeur_totale_eur NOT NULL,
                         UNIQUE(utilisateur_id, date_snapshot))
 
+snapshot_cours (#id, ->actif_id NOT NULL, date_snapshot NOT NULL,
+                cours_eur NOT NULL, quantite NOT NULL,
+                UNIQUE(actif_id, date_snapshot))
+
 annonce (#id, ->auteur_id NOT NULL, titre NOT NULL, contenu NOT NULL,
          epinglee NOT NULL DEFAULT false, date_publication NOT NULL)
 ```
@@ -112,9 +125,10 @@ Contraintes de domaine prévues pour le MPD (PostgreSQL) :
 - `sens_seuil` restreint à ('au_dessus', 'en_dessous') par contrainte CHECK
 - `statut` de l'alerte restreint à ('active', 'declenchee', 'desactivee') par contrainte CHECK
 - `quantite > 0`, `prix_unitaire >= 0`, `frais >= 0`, `valeur_seuil > 0`, `valeur_totale_eur >= 0`
+- sur `snapshot_cours` : `cours_eur >= 0` et `quantite >= 0`, la quantité pouvant valoir zéro avant le premier achat de l'actif
 - montants et quantités en `NUMERIC` (pas de flottant sur des valeurs financières)
 - suppression en cascade des transactions à la suppression d'un actif (`ON DELETE CASCADE`), suppression d'un utilisateur en cascade sur ses actifs, ses alertes, ses snapshots et ses annonces
-- suppression d'un actif en cascade sur les alertes qui le ciblent (`ON DELETE CASCADE` sur alerte.actif_id)
+- suppression d'un actif en cascade sur les alertes qui le ciblent et sur ses relevés de cours (`ON DELETE CASCADE` sur alerte.actif_id et snapshot_cours.actif_id) ; la suppression d'un compte atteint donc ces relevés en deux sauts, par ses actifs
 - la règle « quantité vendue disponible » (on ne vend pas plus que ce que l'on détient) porte sur l'agrégation de plusieurs transactions : elle est vérifiée côté serveur, pas par une contrainte SQL
 - la cohérence entre `type_cible` et la présence de `actif_id` (actif_id renseigné si et seulement si type_cible = 'actif') ne porte que sur la même ligne : elle est portée par une contrainte CHECK au niveau du MPD
 
@@ -129,6 +143,7 @@ erDiagram
     UTILISATEUR ||--o{ ALERTE : definit
     ACTIF |o--o{ ALERTE : concerne
     UTILISATEUR ||--o{ SNAPSHOT_VALORISATION : enregistre
+    ACTIF ||--o{ SNAPSHOT_COURS : releve
     UTILISATEUR ||--o{ ANNONCE : publie
 
     UTILISATEUR {
@@ -174,6 +189,13 @@ erDiagram
         int utilisateur_id FK
         date date_snapshot
         numeric valeur_totale_eur
+    }
+    SNAPSHOT_COURS {
+        int id PK
+        int actif_id FK
+        date date_snapshot
+        numeric cours_eur
+        numeric quantite
     }
     ANNONCE {
         int id PK

--- a/docs/conception/specification-fonctionnelle.md
+++ b/docs/conception/specification-fonctionnelle.md
@@ -228,8 +228,9 @@ En desktop, tableau à colonnes : Actif, Quantité, Cours, Prix de revient, Valo
 
 **Accessibilité.** La frise est une liste ordonnée sémantique. La ligne de prix de revient est décrite dans l'`aria-label` du graphe. Les onglets suivent le motif ARIA d'onglets, navigables aux flèches, avec `aria-controls`. La confirmation de suppression capture le focus, se ferme par Échap, et son bouton destructeur n'est jamais le premier dans l'ordre de tabulation.
 
-**Questions ouvertes.**
-1. La colonne « effet sur le prix de revient » suppose un calcul historique que l'API ne renvoie pas aujourd'hui. Deux options : la calculer côté client par reconstitution séquentielle, ou l'ajouter à la réponse de l'API. Recommandation : côté serveur, dans le détail d'actif, le moteur de calcul étant déjà là et le client ne devant pas refaire de calcul métier. **Impact API à valider.**
+**Questions tranchées.**
+1. La colonne « effet sur le prix de revient » est calculée **côté serveur**, dans le détail d'actif, conformément à la recommandation. Chaque mouvement y porte le prix de revient avant et après, son déplacement, la quantité restante, le montant de l'opération et, pour une vente, la plus-value qu'elle dégage à elle seule. Le chiffre ne se retrouve pas en rejouant un calcul isolé : il faut avoir rejoué toute l'histoire de la position dans le même ordre et avec les mêmes arrondis, ce que seul le moteur sait faire.
+2. Le graphe de cours est alimenté par l'historique par position introduit par **D81**. Un actif dont l'historique compte moins de deux points affiche l'état « pas assez de points », jamais une interpolation.
 
 ---
 
@@ -338,7 +339,6 @@ Ces règles sont énoncées à l'écran, en français, pour que le comportement 
 
 ## Points de vigilance identifiés
 
-1. La colonne « effet sur le prix de revient » de E4 n'est pas fournie par l'API (question ouverte E4.1).
-2. Deux routes restent à créer pour E7.
-3. L'écran d'administration prévu au périmètre n'est pas spécifié ici : il relève d'un parcours distinct et d'un rôle distinct.
-4. Le formatage des valeurs doit passer sans exception par le module dédié, sous peine de divergence entre écrans.
+1. Deux routes restent à créer pour E7.
+2. L'écran d'administration prévu au périmètre n'est pas spécifié ici : il relève d'un parcours distinct et d'un rôle distinct.
+3. Le formatage des valeurs doit passer sans exception par le module dédié, sous peine de divergence entre écrans.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Connexion from './pages/Connexion';
 import Inscription from './pages/Inscription';
 import Patrimoine from './pages/Patrimoine';
 import Positions from './pages/Positions';
+import DetailPosition from './pages/DetailPosition';
 import Introuvable from './pages/Introuvable';
 
 export default function App() {
@@ -26,6 +27,7 @@ export default function App() {
           >
             <Route path="/patrimoine" element={<Patrimoine />} />
             <Route path="/positions" element={<Positions />} />
+            <Route path="/positions/:id" element={<DetailPosition />} />
           </Route>
 
           <Route path="/" element={<Navigate to="/patrimoine" replace />} />

--- a/frontend/src/composants/BarreProgression.css
+++ b/frontend/src/composants/BarreProgression.css
@@ -1,0 +1,46 @@
+.barre-progression {
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-2);
+}
+
+.barre-progression__piste {
+  height: 6px;
+  border-radius: var(--rayon-pilule);
+  background: var(--couleur-carte-haute);
+  overflow: hidden;
+}
+
+.barre-progression__remplissage {
+  display: block;
+  height: 100%;
+  background: var(--couleur-accent);
+  border-radius: var(--rayon-pilule);
+}
+
+/* Un seuil franchi n'est plus une progression mais un fait : la barre prend la couleur
+   d'avertissement, celle que D70 réserve aux états qui demandent un regard. */
+.barre-progression__piste--atteint .barre-progression__remplissage {
+  background: var(--couleur-avertissement);
+}
+
+.barre-progression__reperes {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--espace-2);
+  margin: 0;
+  color: var(--couleur-texte-attenue);
+}
+
+.barre-progression__cible {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--espace-1);
+}
+
+.barre-progression__indisponible {
+  margin: 0;
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+}

--- a/frontend/src/composants/BarreProgression.jsx
+++ b/frontend/src/composants/BarreProgression.jsx
@@ -1,0 +1,84 @@
+import './BarreProgression.css';
+import Montant from './Montant';
+
+// Avancement d'une valeur vers un seuil.
+//
+// La barre répond à une seule question, celle que pose la spécification devant chaque
+// ligne de seuil : suis-je proche ? Elle ne remplace jamais les chiffres, elle les
+// accompagne — les deux montants sont écrits à côté d'elle, mis en forme par le module
+// de formatage comme partout ailleurs.
+//
+// La seule conversion numérique est celle de la fraction, qui donne une largeur en
+// pourcentage. C'est de la géométrie, au même titre que l'ordonnée d'un point de
+// courbe : rien de ce qui est lu par l'utilisateur ne passe par un nombre flottant.
+//
+// L'échelle ARIA est volontairement normalisée de 0 à 100 plutôt que calée sur les
+// montants réels. Un aria-valuenow exprimé en euros supposerait de faire traverser un
+// montant par un nombre pour une valeur restituée à la voix, ce que la politique de
+// formatage interdit. aria-valuetext porte les deux montants en toutes lettres, et
+// c'est lui que les lecteurs d'écran annoncent.
+//
+// Un cours indisponible ne donne pas une barre à zéro, qui se lirait comme « très
+// loin du seuil » : la barre disparaît au profit d'une mention explicite.
+// La barre dit toujours la même chose : à quelle distance du déclenchement on se
+// trouve, pleine au moment du franchissement. Un seuil bas se lit donc à l'envers d'un
+// seuil haut — s'en éloigner, pour lui, c'est monter. Rapporter les deux au même
+// rapport ferait qu'un seuil bas très éloigné afficherait une barre pleine.
+function fraction(valeur, cible, sens) {
+  const cours = Number(valeur);
+  const seuil = Number(cible);
+
+  if (!Number.isFinite(cours) || !Number.isFinite(seuil) || cours <= 0 || seuil <= 0) {
+    return null;
+  }
+
+  const rapport = sens === 'en_dessous' ? seuil / cours : cours / seuil;
+  return Math.min(Math.max(rapport, 0), 1);
+}
+
+export default function BarreProgression({
+  valeur,
+  cible,
+  devise = 'EUR',
+  libelle,
+  sens = 'au_dessus',
+  atteint = false,
+}) {
+  const avancement =
+    valeur === null || valeur === undefined ? null : fraction(valeur, cible, sens);
+
+  if (avancement === null) {
+    return (
+      <p className="barre-progression__indisponible">
+        Cours indisponible : la progression vers ce seuil n'est pas calculable.
+      </p>
+    );
+  }
+
+  const pourcentage = Math.round(avancement * 100);
+  const description = sens === 'au_dessus' ? 'seuil haut' : 'seuil bas';
+
+  return (
+    <div className="barre-progression">
+      <div
+        className={`barre-progression__piste${atteint ? ' barre-progression__piste--atteint' : ''}`}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={pourcentage}
+        aria-valuetext={`${pourcentage} % du ${description}`}
+        aria-label={libelle}
+      >
+        <span className="barre-progression__remplissage" style={{ width: `${pourcentage}%` }} />
+      </div>
+      <p className="barre-progression__reperes">
+        <Montant valeur={valeur} devise={devise} taille="legende" />
+        <span className="barre-progression__cible">
+          <span aria-hidden="true">/</span>
+          <span className="lecteur-ecran-seulement">sur un seuil de</span>
+          <Montant valeur={cible} devise={devise} taille="legende" />
+        </span>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/composants/Bouton.css
+++ b/frontend/src/composants/Bouton.css
@@ -32,3 +32,17 @@
 .bouton--secondaire:hover:not(:disabled) {
   border-color: var(--couleur-accent);
 }
+
+/* Action destructrice. Le rouge est celui des moins-values : c'est la seule couleur du
+   système qui signale déjà une perte, et l'employer ici n'en introduit aucune autre. Le
+   bouton reste en contour plutôt qu'en aplat, pour qu'il n'attire pas l'oeil davantage
+   que l'annulation placée à côté de lui. */
+.bouton--danger {
+  background: transparent;
+  color: var(--couleur-negatif);
+  border-color: var(--couleur-negatif);
+}
+
+.bouton--danger:hover:not(:disabled) {
+  background: rgba(240, 86, 79, 0.12);
+}

--- a/frontend/src/composants/Confirmation.css
+++ b/frontend/src/composants/Confirmation.css
@@ -1,0 +1,48 @@
+.confirmation__voile {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--espace-4);
+  background: rgba(16, 20, 24, 0.72);
+}
+
+.confirmation {
+  width: 100%;
+  max-width: 420px;
+  background: var(--couleur-carte);
+  border: 1px solid var(--couleur-bordure);
+  border-radius: var(--rayon-carte);
+  padding: var(--espace-6);
+}
+
+.confirmation__titre {
+  margin: 0 0 var(--espace-3);
+  font-size: var(--taille-titre);
+  font-weight: var(--graisse-forte);
+}
+
+.confirmation__consequence {
+  margin: 0 0 var(--espace-6);
+  font-size: var(--taille-corps);
+  color: var(--couleur-texte-attenue);
+  line-height: 1.5;
+}
+
+.confirmation__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--espace-3);
+}
+
+/* Sous le point de rupture, les deux boutons s'empilent sur toute la largeur, et
+   l'inversion place l'annulation en bas, là où le pouce arrive naturellement. Le
+   bouton destructeur reste ainsi celui qu'il faut aller chercher, sans changer pour
+   autant l'ordre du document ni celui de la tabulation. */
+@media (max-width: 480px) {
+  .confirmation__actions {
+    flex-direction: column-reverse;
+  }
+}

--- a/frontend/src/composants/Confirmation.jsx
+++ b/frontend/src/composants/Confirmation.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef } from 'react';
+import './Confirmation.css';
+import Bouton from './Bouton';
+
+// Dialogue de confirmation d'une action destructrice.
+//
+// Il ne demande pas « êtes-vous sûr », question à laquelle personne ne peut répondre
+// utilement : il énonce ce qui va disparaître et ce que cela entraîne. C'est
+// l'appelant qui fournit cette conséquence, parce que lui seul la connaît.
+//
+// Trois règles d'accessibilité, toutes exigées par la spécification et toutes vérifiées
+// par les tests de l'écran.
+//
+// Le focus entre dans le dialogue à l'ouverture et n'en sort plus tant qu'il est
+// ouvert : sans cela, la tabulation continuerait dans la page située derrière, qui est
+// pourtant inerte. Il retourne à son point de départ à la fermeture, faute de quoi
+// l'utilisateur se retrouverait projeté en haut du document.
+//
+// Le bouton destructeur n'est jamais celui qui reçoit le focus, ni le premier de
+// l'ordre de tabulation. Une confirmation validée par une frappe d'Entrée réflexe
+// n'aurait rien confirmé du tout.
+//
+// Échap annule. C'est le geste attendu de tout dialogue, et il doit rester la sortie la
+// moins coûteuse.
+export default function Confirmation({
+  titre,
+  consequence,
+  libelleConfirmation = 'Supprimer',
+  enCours = false,
+  surConfirmation,
+  surAnnulation,
+}) {
+  const dialogue = useRef(null);
+  const declencheur = useRef(null);
+
+  useEffect(() => {
+    // L'élément actif au moment de l'ouverture est le bouton qui a demandé la
+    // suppression : c'est là que le focus doit revenir.
+    declencheur.current = document.activeElement;
+    // Le premier bouton du dialogue est celui d'annulation : le focus y entre, et
+    // jamais sur le bouton destructeur.
+    dialogue.current?.querySelector('button')?.focus();
+
+    return () => {
+      declencheur.current?.focus?.();
+    };
+  }, []);
+
+  function auClavier(evenement) {
+    if (evenement.key === 'Escape') {
+      evenement.preventDefault();
+      surAnnulation?.();
+      return;
+    }
+
+    if (evenement.key !== 'Tab') {
+      return;
+    }
+
+    // Piège à focus : la tabulation boucle entre le premier et le dernier élément
+    // atteignable du dialogue.
+    const atteignables = dialogue.current?.querySelectorAll('button:not([disabled])');
+    if (!atteignables || atteignables.length === 0) {
+      return;
+    }
+
+    const premier = atteignables[0];
+    const dernier = atteignables[atteignables.length - 1];
+
+    if (evenement.shiftKey && document.activeElement === premier) {
+      evenement.preventDefault();
+      dernier.focus();
+    } else if (!evenement.shiftKey && document.activeElement === dernier) {
+      evenement.preventDefault();
+      premier.focus();
+    }
+  }
+
+  return (
+    // Le voile n'est pas cliquable pour fermer : une fermeture par clic accidentel hors
+    // du dialogue conviendrait à une feuille d'information, pas à la dernière barrière
+    // avant une suppression.
+    <div className="confirmation__voile">
+      <div
+        className="confirmation"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="titre-confirmation"
+        aria-describedby="consequence-confirmation"
+        ref={dialogue}
+        onKeyDown={auClavier}
+      >
+        <h2 id="titre-confirmation" className="confirmation__titre">
+          {titre}
+        </h2>
+        <p id="consequence-confirmation" className="confirmation__consequence">
+          {consequence}
+        </p>
+        <div className="confirmation__actions">
+          <Bouton variante="secondaire" onClick={surAnnulation} desactive={enCours}>
+            Annuler
+          </Bouton>
+          <Bouton variante="danger" onClick={surConfirmation} enCours={enCours}>
+            {libelleConfirmation}
+          </Bouton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/composants/Courbe.jsx
+++ b/frontend/src/composants/Courbe.jsx
@@ -31,7 +31,7 @@ import { bornes, hauteurDeBascule } from '../utils/echelleCourbe';
 // gain et quand elle a été en perte. Une aire d'une seule teinte ne dirait que le solde
 // du jour, et raterait l'essentiel du produit.
 
-function decrire(points, devise) {
+function decrire(points, devise, sujet, prixDeRevient) {
   if (points.length < 2) {
     return 'Évolution indisponible.';
   }
@@ -40,9 +40,21 @@ function decrire(points, devise) {
   const debut = points[0];
   const fin = points[points.length - 1];
 
+  const evolution =
+    `Évolution ${sujet}, du ${debut.date} au ${fin.date}, ` +
+    `de ${formaterMontant(debut.valeur, { symbole })} à ${formaterMontant(fin.valeur, { symbole })}.`;
+
+  if (prixDeRevient === null) {
+    return evolution;
+  }
+
+  // D79 : la ligne de prix de revient est nommée explicitement dans la description.
+  // Sans cela, le tracé annoncerait une évolution sans dire par rapport à quoi il se
+  // teinte, et c'est précisément ce que le graphe existe pour montrer.
   return (
-    `Évolution de la valeur du portefeuille, du ${debut.date} au ${fin.date}, ` +
-    `de ${formaterMontant(debut.valeur, { symbole })} à ${formaterMontant(fin.valeur, { symbole })}.`
+    `${evolution} Le prix de revient, ${formaterMontant(prixDeRevient, { symbole })}, ` +
+    "est figuré par une ligne horizontale pointillée : l'aire est teintée en positif " +
+    'au-dessus et en négatif en dessous.'
   );
 }
 
@@ -52,6 +64,10 @@ export default function Courbe({
   masque = false,
   sens = 'hausse',
   prixDeRevient = null,
+  // Ce que la courbe donne à lire. Le tableau de bord trace un patrimoine, l'écran de
+  // détail le cours d'une position : la description ne peut pas être la même, et une
+  // description fausse vaut moins qu'une absence de description.
+  sujet = 'de la valeur du portefeuille',
   ...proprietes
 }) {
   const symbole = symboleDevise(devise);
@@ -83,7 +99,11 @@ export default function Courbe({
     <div
       className="courbe"
       role="img"
-      aria-label={masque ? 'Évolution de la valeur du portefeuille, montants masqués.' : decrire(points, devise)}
+      aria-label={
+        masque
+          ? `Évolution ${sujet}, montants masqués.`
+          : decrire(points, devise, sujet, prixDeRevient)
+      }
       {...proprietes}
     >
       <ResponsiveContainer width="100%" height={200}>
@@ -131,7 +151,25 @@ export default function Courbe({
           />
 
           {aireBicolore && (
-            <ReferenceLine y={seuil} stroke="var(--couleur-texte-attenue)" strokeDasharray="4 4" />
+            <ReferenceLine
+              y={seuil}
+              stroke="var(--couleur-texte-attenue)"
+              strokeDasharray="4 4"
+              // Le libellé chiffré accompagne la ligne (D79) : sans lui, le trait
+              // pointillé ne dirait pas à quelle hauteur il se trouve, et l'aire
+              // bicolore basculerait sur une frontière sans nom. Il disparaît avec le
+              // masquage, au même titre que l'échelle.
+              label={
+                masque
+                  ? undefined
+                  : {
+                      value: `Prix de revient ${formaterMontant(prixDeRevient, { symbole })}`,
+                      position: 'insideTopLeft',
+                      fill: 'var(--couleur-texte-attenue)',
+                      fontSize: 11,
+                    }
+              }
+            />
           )}
 
           <Area

--- a/frontend/src/composants/CourbeMiniature.css
+++ b/frontend/src/composants/CourbeMiniature.css
@@ -1,0 +1,22 @@
+.courbe-miniature {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+
+.courbe-miniature__trace--hausse {
+  stroke: var(--couleur-positif);
+}
+
+.courbe-miniature__trace--baisse {
+  stroke: var(--couleur-negatif);
+}
+
+.courbe-miniature__trace--stable {
+  stroke: var(--couleur-texte-attenue);
+}
+
+.courbe-miniature--absente {
+  color: var(--couleur-texte-attenue);
+}

--- a/frontend/src/composants/CourbeMiniature.jsx
+++ b/frontend/src/composants/CourbeMiniature.jsx
@@ -1,0 +1,88 @@
+import './CourbeMiniature.css';
+import Variation from './Variation';
+import { sensVariation } from '../utils/formatage';
+
+// Tendance récente d'une position, dans une cellule de tableau.
+//
+// Tracée à la main en SVG plutôt qu'avec la bibliothèque de graphiques : une polyligne
+// de trente points n'a besoin ni d'axes, ni d'échelle affichée, ni d'infobulle, et
+// charger trois cents kilooctets de bibliothèque pour la dessiner dans une colonne de
+// quatre-vingt-dix pixels serait hors de proportion.
+//
+// La courbe ne porte jamais l'information seule : la variation chiffrée l'accompagne,
+// et c'est elle que lit un lecteur d'écran. Le tracé est décoratif au sens strict, il
+// donne la forme du mouvement, pas sa mesure. Une cellule qui ne contiendrait que le
+// dessin serait vide pour qui ne le voit pas.
+//
+// Les conversions numériques ci-dessous produisent des coordonnées en pixels. Aucune
+// n'aboutit à une valeur affichée : la variation vient du serveur et passe par le
+// module de formatage comme partout ailleurs.
+
+const LARGEUR = 80;
+const HAUTEUR = 24;
+const MARGE = 2;
+
+function trace(points) {
+  const hauteurs = points.map(Number).filter(Number.isFinite);
+
+  if (hauteurs.length < 2) {
+    return null;
+  }
+
+  const minimum = Math.min(...hauteurs);
+  const maximum = Math.max(...hauteurs);
+  const amplitude = maximum - minimum;
+  const utile = HAUTEUR - 2 * MARGE;
+
+  return hauteurs
+    .map((hauteur, index) => {
+      const x = (index / (hauteurs.length - 1)) * LARGEUR;
+      // Une série parfaitement plate n'a pas d'amplitude : elle se trace au milieu du
+      // cadre plutôt que de provoquer une division par zéro.
+      const y =
+        amplitude === 0
+          ? HAUTEUR / 2
+          : HAUTEUR - MARGE - ((hauteur - minimum) / amplitude) * utile;
+      return `${index === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+}
+
+export default function CourbeMiniature({ tendance }) {
+  const chemin = tendance ? trace(tendance.points ?? []) : null;
+
+  // Une position trop jeune n'a pas assez de points. Tracer une ligne plate reviendrait
+  // à affirmer une stagnation qui n'a pas été constatée.
+  if (chemin === null) {
+    return (
+      <span className="courbe-miniature courbe-miniature--absente">
+        <span aria-hidden="true">—</span>
+        <span className="lecteur-ecran-seulement">tendance indisponible, historique trop court</span>
+      </span>
+    );
+  }
+
+  return (
+    <span className="courbe-miniature">
+      <svg
+        viewBox={`0 0 ${LARGEUR} ${HAUTEUR}`}
+        width={LARGEUR}
+        height={HAUTEUR}
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          d={chemin}
+          fill="none"
+          strokeWidth="1.5"
+          // Le sens vient du module de formatage, seul juge du signe d'un montant,
+          // et non d'une comparaison improvisée ici.
+          className={`courbe-miniature__trace courbe-miniature__trace--${
+            sensVariation(tendance.variation) ?? 'stable'
+          }`}
+        />
+      </svg>
+      <Variation valeur={tendance.variation} />
+    </span>
+  );
+}

--- a/frontend/src/composants/FriseMouvements.css
+++ b/frontend/src/composants/FriseMouvements.css
@@ -1,0 +1,146 @@
+.frise-mouvements {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 var(--espace-4);
+  /* Le filet vertical est la frise elle-même : il relie les événements entre eux et
+     matérialise la continuité du temps, qu'une simple pile de cartes ne montrerait pas. */
+  border-left: 1px solid var(--couleur-bordure);
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-6);
+}
+
+.frise-mouvements__evenement {
+  position: relative;
+}
+
+/* Le point posé sur le filet marque la date de l'événement. Décoratif : la liste
+   ordonnée porte déjà la chronologie pour un lecteur d'écran. */
+.frise-mouvements__evenement::before {
+  content: '';
+  position: absolute;
+  left: calc(-1 * var(--espace-4) - 4px);
+  top: 6px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--couleur-texte-attenue);
+}
+
+.frise-mouvements__evenement--achat::before {
+  background: var(--couleur-accent);
+}
+
+.frise-mouvements__evenement--vente::before {
+  background: var(--couleur-avertissement);
+}
+
+.frise-mouvements__tete {
+  display: flex;
+  align-items: baseline;
+  gap: var(--espace-2);
+  flex-wrap: wrap;
+}
+
+.frise-mouvements__etiquette {
+  font-size: var(--taille-legende);
+  font-weight: var(--graisse-forte);
+  border-radius: var(--rayon-pilule);
+  padding: 1px var(--espace-2);
+  border: 1px solid;
+}
+
+.frise-mouvements__etiquette--achat {
+  color: var(--couleur-accent);
+  border-color: var(--couleur-accent);
+}
+
+.frise-mouvements__etiquette--vente {
+  color: var(--couleur-avertissement);
+  border-color: var(--couleur-avertissement);
+}
+
+.frise-mouvements__date {
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+}
+
+.frise-mouvements__quantite {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--graisse-forte);
+}
+
+.frise-mouvements__details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--espace-2) var(--espace-4);
+  margin: var(--espace-3) 0 0;
+  padding: var(--espace-3);
+  background: var(--couleur-carte-haute);
+  border-radius: var(--rayon-carte);
+}
+
+.frise-mouvements__details dt {
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+}
+
+.frise-mouvements__details dd {
+  margin: 2px 0 0;
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--graisse-forte);
+}
+
+/* L'effet sur le prix de revient occupe toute la largeur : c'est l'information propre à
+   cet écran, elle ne se range pas comme une donnée de saisie parmi les autres. */
+.frise-mouvements__effet {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--couleur-bordure);
+  padding-top: var(--espace-2);
+}
+
+.frise-mouvements__inchange {
+  color: var(--couleur-texte-attenue);
+  font-weight: var(--graisse-normale);
+}
+
+.frise-mouvements__suppression {
+  font-family: var(--police);
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  /* Zone tactile de 44 px en mobile (D77), obtenue par le remplissage : le libellé
+     reste discret, il n'a pas à concurrencer les chiffres. */
+  padding: var(--espace-3) 0;
+  min-height: 44px;
+  text-decoration: underline;
+}
+
+.frise-mouvements__suppression:hover {
+  color: var(--couleur-negatif);
+}
+
+.frise-mouvements__vide {
+  margin: 0;
+  color: var(--couleur-texte-attenue);
+}
+
+@media (min-width: 768px) {
+  .frise-mouvements__details {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .frise-mouvements__effet {
+    grid-column: auto;
+    border-top: 0;
+    padding-top: 0;
+  }
+
+  .frise-mouvements__suppression {
+    min-height: 0;
+    padding: var(--espace-2) 0;
+  }
+}

--- a/frontend/src/composants/FriseMouvements.jsx
+++ b/frontend/src/composants/FriseMouvements.jsx
@@ -1,0 +1,152 @@
+import './FriseMouvements.css';
+import Montant from './Montant';
+import Variation from './Variation';
+import { comparerDecimales } from '../utils/formatage';
+
+// Chronologie des mouvements d'une position.
+//
+// Une frise et non un tableau, et ce n'est pas un choix décoratif : un mouvement n'est
+// pas une ligne de données mais un événement daté qui déplace le prix de revient. La
+// frise donne à lire cette causalité dans l'ordre où elle s'est produite.
+//
+// L'effet sur le prix de revient est le chiffre le plus difficile à défendre à l'oral,
+// et c'est aussi celui que l'interface ne calcule pas : il arrive tel quel du serveur,
+// qui détient le moteur et l'a produit en rejouant toute l'histoire de la position.
+//
+// Liste ordonnée sémantique, conformément à la spécification : la chronologie fait
+// partie de l'information, elle ne doit pas reposer sur la seule disposition visuelle.
+
+const LIBELLES_SENS = { achat: 'Achat', vente: 'Vente' };
+
+function formaterDate(horodatage) {
+  const date = new Date(horodatage);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' });
+}
+
+// Le prix de revient n'est pas déplacé par tous les mouvements : une vente partielle le
+// laisse intact. Le dire en toutes lettres vaut mieux que d'afficher « +0,00 », que
+// l'utilisateur devrait interpréter.
+//
+// La comparaison passe par le comparateur exact du module de formatage, et non par une
+// conversion en nombre. La règle vaut aussi pour un test : « vaut-il zéro » est une
+// question posée sur un montant, et y répondre en flottant rouvrirait la porte que
+// toute la chaîne s'emploie à tenir fermée.
+function estNul(montant) {
+  return montant === null || montant === undefined || comparerDecimales(montant, '0') === 0;
+}
+
+export default function FriseMouvements({
+  mouvements = [],
+  classe,
+  symbole,
+  devise = 'EUR',
+  masque = false,
+  surSuppression,
+}) {
+  if (mouvements.length === 0) {
+    return (
+      <p className="frise-mouvements__vide">
+        Aucun mouvement enregistré sur cette position.
+      </p>
+    );
+  }
+
+  // Le serveur rend les mouvements dans l'ordre du calcul, du plus ancien au plus
+  // récent. L'affichage les renverse : ce qui vient de se produire est ce qu'on vient
+  // consulter. L'inversion se fait sur une copie, la liste reçue n'appartenant pas à
+  // ce composant.
+  const duPlusRecent = [...mouvements].reverse();
+
+  return (
+    <ol className="frise-mouvements">
+      {duPlusRecent.map((mouvement) => {
+        const date = formaterDate(mouvement.date_transaction);
+
+        return (
+          <li key={mouvement.id} className={`frise-mouvements__evenement frise-mouvements__evenement--${mouvement.sens}`}>
+            <div className="frise-mouvements__tete">
+              <span className={`frise-mouvements__etiquette frise-mouvements__etiquette--${mouvement.sens}`}>
+                {LIBELLES_SENS[mouvement.sens] ?? mouvement.sens}
+              </span>
+              {date && <span className="frise-mouvements__date">{date}</span>}
+              <span className="frise-mouvements__quantite">
+                {/* Le signe double une information déjà portée par l'étiquette Achat ou
+                    Vente : il aide le balayage visuel, il n'a rien à annoncer de plus. */}
+                <span aria-hidden="true">{mouvement.sens === 'achat' ? '+' : '−'}</span>
+                <Montant
+                  valeur={mouvement.quantite}
+                  type="quantite"
+                  classe={classe}
+                  symbole={symbole}
+                />
+              </span>
+            </div>
+
+            <dl className="frise-mouvements__details">
+              <div>
+                <dt>Prix unitaire</dt>
+                <dd>
+                  {masque ? '••••' : <Montant valeur={mouvement.prix_unitaire} type="cours" devise={devise} />}
+                </dd>
+              </div>
+              <div>
+                <dt>Montant</dt>
+                <dd>{masque ? '••••' : <Montant valeur={mouvement.montant} devise={devise} />}</dd>
+              </div>
+              {!estNul(mouvement.frais) && (
+                <div>
+                  <dt>Frais</dt>
+                  <dd>{masque ? '••••' : <Montant valeur={mouvement.frais} devise={devise} />}</dd>
+                </div>
+              )}
+              {mouvement.plus_value_realisee !== null && (
+                <div>
+                  <dt>Plus-value réalisée</dt>
+                  <dd>
+                    {masque ? (
+                      '••••'
+                    ) : (
+                      <Variation valeur={mouvement.plus_value_realisee} mode="absolue" devise={devise} />
+                    )}
+                  </dd>
+                </div>
+              )}
+              <div className="frise-mouvements__effet">
+                <dt>Effet sur le prix de revient</dt>
+                <dd>
+                  {estNul(mouvement.effet_pru) ? (
+                    <span className="frise-mouvements__inchange">inchangé</span>
+                  ) : masque ? (
+                    '••••'
+                  ) : (
+                    <Variation valeur={mouvement.effet_pru} mode="absolue" devise={devise} />
+                  )}
+                </dd>
+              </div>
+            </dl>
+
+            {surSuppression && (
+              <button
+                type="button"
+                className="frise-mouvements__suppression"
+                onClick={() => surSuppression(mouvement)}
+              >
+                {/* Le libellé nomme le mouvement visé : « Supprimer », lu seul dans une
+                    liste de liens, ne dirait pas lequel des quatre serait supprimé. */}
+                <span aria-hidden="true">Supprimer</span>
+                <span className="lecteur-ecran-seulement">
+                  Supprimer {LIBELLES_SENS[mouvement.sens]?.toLowerCase()} du {date}
+                </span>
+              </button>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/frontend/src/composants/Onglets.css
+++ b/frontend/src/composants/Onglets.css
@@ -1,0 +1,52 @@
+.onglets {
+  display: flex;
+  gap: var(--espace-1);
+  border-bottom: 1px solid var(--couleur-bordure);
+  margin-bottom: var(--espace-4);
+}
+
+.onglets__onglet {
+  display: flex;
+  align-items: center;
+  gap: var(--espace-2);
+  font-family: var(--police);
+  font-size: var(--taille-corps);
+  font-weight: var(--graisse-forte);
+  color: var(--couleur-texte-attenue);
+  background: transparent;
+  border: 0;
+  /* La zone tactile atteint 44 px de haut sans que l'onglet ne grossisse visuellement
+     (D77) : c'est le remplissage qui s'étend, pas le libellé. */
+  padding: var(--espace-3) var(--espace-4);
+  min-height: 44px;
+  cursor: pointer;
+  /* Le trait de sélection est réservé en permanence : sans cela, l'onglet actif
+     déplacerait ses voisins de deux pixels au changement. */
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+
+.onglets__onglet:hover {
+  color: var(--couleur-texte);
+}
+
+.onglets__onglet--actif {
+  color: var(--couleur-texte);
+  border-bottom-color: var(--couleur-accent);
+}
+
+.onglets__compteur {
+  font-size: var(--taille-legende);
+  font-variant-numeric: tabular-nums;
+  color: var(--couleur-texte-attenue);
+  background: var(--couleur-carte-haute);
+  border-radius: var(--rayon-pilule);
+  padding: 1px var(--espace-2);
+}
+
+@media (min-width: 768px) {
+  .onglets__onglet {
+    min-height: 0;
+    padding: var(--espace-2) var(--espace-3);
+  }
+}

--- a/frontend/src/composants/Onglets.jsx
+++ b/frontend/src/composants/Onglets.jsx
@@ -1,0 +1,81 @@
+import { useRef } from 'react';
+import './Onglets.css';
+
+// Groupe d'onglets, au sens ARIA du terme.
+//
+// Le sélecteur de période suit déjà ce motif, mais avec ses propres plages et sa propre
+// mise en forme : celui-ci est le cas général, une liste d'onglets nommés commandant un
+// panneau. Les deux ne se fondent pas en un seul composant, l'un affichant une
+// performance par onglet et l'autre un simple compteur.
+//
+// Conséquence concrète du motif : une seule tabulation entre dans le groupe, les flèches
+// circulent d'un onglet à l'autre, et le panneau commandé est désigné. Une rangée de
+// boutons obligerait à tabuler autant de fois qu'il y a d'onglets pour atteindre le
+// contenu, ce que ce motif existe précisément pour éviter.
+//
+// Le panneau reste à la charge de l'appelant : c'est lui qui sait ce qu'il contient. Il
+// lui suffit de porter role="tabpanel", l'identifiant transmis, et aria-labelledby
+// pointant vers l'onglet sélectionné.
+export default function Onglets({ onglets = [], actif, surChangement, identifiantPanneau, libelle }) {
+  const references = useRef([]);
+
+  // Activation automatique au déplacement : l'onglet reçu par la flèche est aussitôt
+  // sélectionné. C'est le comportement attendu quand changer d'onglet ne coûte rien,
+  // le contenu étant déjà chargé.
+  function auClavier(evenement, index) {
+    const deplacements = {
+      ArrowRight: 1,
+      ArrowLeft: -1,
+      Home: -index,
+      End: onglets.length - 1 - index,
+    };
+    const deplacement = deplacements[evenement.key];
+
+    if (deplacement === undefined) {
+      return;
+    }
+
+    evenement.preventDefault();
+    const cible = (index + deplacement + onglets.length) % onglets.length;
+    references.current[cible]?.focus();
+    surChangement?.(onglets[cible].code);
+  }
+
+  return (
+    <div className="onglets" role="tablist" aria-label={libelle}>
+      {onglets.map(({ code, libelle: intitule, compteur }, index) => {
+        const selectionne = code === actif;
+
+        return (
+          <button
+            key={code}
+            type="button"
+            role="tab"
+            id={`onglet-${code}`}
+            aria-selected={selectionne}
+            aria-controls={identifiantPanneau}
+            tabIndex={selectionne ? 0 : -1}
+            ref={(noeud) => {
+              references.current[index] = noeud;
+            }}
+            className={`onglets__onglet${selectionne ? ' onglets__onglet--actif' : ''}`}
+            onClick={() => surChangement?.(code)}
+            onKeyDown={(evenement) => auClavier(evenement, index)}
+          >
+            {intitule}
+            {/* Le compteur est répété dans le libellé vocal : lu seul, un « 4 » collé
+                au nom de l'onglet ne dirait pas de quoi il est le nombre. */}
+            {compteur !== undefined && (
+              <>
+                <span className="onglets__compteur" aria-hidden="true">
+                  {compteur}
+                </span>
+                <span className="lecteur-ecran-seulement">, {compteur}</span>
+              </>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/composants/TableauPositions.jsx
+++ b/frontend/src/composants/TableauPositions.jsx
@@ -4,6 +4,7 @@ import Montant from './Montant';
 import Variation from './Variation';
 import JetonClasse from './JetonClasse';
 import PastilleFraicheur from './PastilleFraicheur';
+import CourbeMiniature from './CourbeMiniature';
 import { LIBELLES_CLASSE } from '../utils/classesActifs';
 import { formaterMontant, symboleDevise } from '../utils/formatage';
 
@@ -29,6 +30,10 @@ const COLONNES = [
   { cle: 'pru', libelle: 'Prix de revient', triable: true, numerique: true },
   { cle: 'valeur', libelle: 'Valorisation', triable: true, numerique: true },
   { cle: 'plus_value_latente', libelle: 'Plus-value', triable: true, numerique: true },
+  // Tendance sur trente jours, alimentée par l'historique de cours par position
+  // (D81). Elle n'a pas d'équivalent dans la liste mobile, qui n'a pas la place
+  // d'une seconde variation à côté de celle depuis l'origine.
+  { cle: 'tendance', libelle: '30 jours', triable: true, numerique: true },
 ];
 
 // aria-sort ne se pose que sur la colonne effectivement triée : l'annoncer sur toutes
@@ -179,6 +184,12 @@ export default function TableauPositions({
                     amplitude={position.pourcentage_variation}
                   />
                 )}
+              </td>
+              {/* La tendance est une variation relative : elle ne dit rien de ce que
+                  l'utilisateur possède et échappe donc au masquage, comme les
+                  performances du sélecteur de période. */}
+              <td className="positions-liste__colonne-nombre">
+                <CourbeMiniature tendance={position.tendance_30j} />
               </td>
             </tr>
           ))}

--- a/frontend/src/pages/DetailPosition.css
+++ b/frontend/src/pages/DetailPosition.css
@@ -190,3 +190,14 @@
     border-radius: var(--rayon-carte);
   }
 }
+
+.detail__evolution {
+  padding: var(--espace-4);
+}
+
+.detail__evolution-absente {
+  margin: 0;
+  padding: var(--espace-6) 0;
+  text-align: center;
+  color: var(--couleur-texte-attenue);
+}

--- a/frontend/src/pages/DetailPosition.css
+++ b/frontend/src/pages/DetailPosition.css
@@ -1,0 +1,192 @@
+.detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-6);
+}
+
+.detail__entete {
+  display: flex;
+  align-items: center;
+  gap: var(--espace-3);
+}
+
+.detail__retour {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Zone tactile de 44 px (D77) pour une flèche qui n'en mesure que douze. */
+  min-width: 44px;
+  min-height: 44px;
+  margin-left: calc(-1 * var(--espace-3));
+  font-size: 20px;
+  color: var(--couleur-texte-attenue);
+  text-decoration: none;
+}
+
+.detail__retour:hover {
+  color: var(--couleur-texte);
+}
+
+.detail__identite {
+  min-width: 0;
+}
+
+.detail__nom {
+  margin: 0;
+  font-size: var(--taille-titre);
+  font-weight: var(--graisse-forte);
+}
+
+.detail__signalement {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--espace-2);
+  margin: 2px 0 0;
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+}
+
+.detail__outils {
+  display: flex;
+  align-items: center;
+  gap: var(--espace-2);
+  margin-left: auto;
+}
+
+/*
+  Bloc dominant de l'écran, seul de niveau 2 ici comme le total l'est sur le patrimoine.
+  Le fond relevé le détache sans le border d'une carte : c'est un aplat de valeur, pas
+  un contenant.
+*/
+.detail__valorisation {
+  background: var(--couleur-carte-haute);
+  border-radius: var(--rayon-carte);
+  padding: var(--espace-4) var(--espace-6);
+}
+
+.detail__intitule {
+  margin: 0;
+  font-size: var(--taille-legende);
+  font-weight: var(--graisse-normale);
+  color: var(--couleur-texte-attenue);
+}
+
+.detail__valeur {
+  display: block;
+  margin: var(--espace-2) 0 0;
+  font-size: var(--taille-montant);
+  font-weight: var(--graisse-forte);
+  font-variant-numeric: tabular-nums;
+}
+
+.detail__variations {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--espace-2);
+  margin: var(--espace-2) 0 0;
+}
+
+.detail__depuis {
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+}
+
+/*
+  Trio de contexte : quantité, cours, prix de revient. Trois lignes filetées et non
+  trois cartes, pour la même raison que sur l'écran Patrimoine — ce sont des repères,
+  pas des indicateurs de tête (D78).
+*/
+.detail__trio {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 0;
+}
+
+.detail__repere {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--espace-4);
+  padding: var(--espace-3) 0;
+  border-bottom: 1px solid var(--couleur-bordure);
+}
+
+.detail__repere:last-child {
+  border-bottom: 0;
+}
+
+.detail__repere dt {
+  color: var(--couleur-texte-attenue);
+}
+
+.detail__repere dd {
+  margin: 0;
+  font-weight: var(--graisse-forte);
+  font-variant-numeric: tabular-nums;
+}
+
+.detail__onglets {
+  padding: var(--espace-4) var(--espace-4) var(--espace-6);
+}
+
+.detail__seuils {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-6);
+}
+
+.detail__seuil-intitule {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--espace-2);
+  margin: 0 0 var(--espace-3);
+}
+
+.detail__seuil-franchi {
+  font-size: var(--taille-legende);
+  font-weight: var(--graisse-forte);
+  color: var(--couleur-avertissement);
+  border: 1px solid var(--couleur-avertissement);
+  border-radius: var(--rayon-pilule);
+  padding: 1px var(--espace-2);
+}
+
+.detail__sans-seuil {
+  margin: 0;
+  color: var(--couleur-texte-attenue);
+}
+
+.detail__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--espace-3);
+  justify-content: space-between;
+}
+
+@media (min-width: 768px) {
+  /* En desktop, le trio devient une rangée : la place existe, et les trois repères se
+     comparent mieux côte à côte qu'empilés. */
+  .detail__trio {
+    flex-direction: row;
+    gap: var(--espace-4);
+  }
+
+  .detail__repere {
+    flex: 1;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--espace-1);
+    padding: var(--espace-4);
+    border-bottom: 0;
+    background: var(--couleur-carte);
+    border: 1px solid var(--couleur-bordure);
+    border-radius: var(--rayon-carte);
+  }
+}

--- a/frontend/src/pages/DetailPosition.jsx
+++ b/frontend/src/pages/DetailPosition.jsx
@@ -1,0 +1,419 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useAuthentification } from '../contexte/contexteAuthentification';
+import { api, ErreurApi } from '../services/api';
+import { convertir } from '../utils/conversion';
+import { LIBELLES_CLASSE } from '../utils/classesActifs';
+import Carte from '../composants/Carte';
+import Montant from '../composants/Montant';
+import Variation from '../composants/Variation';
+import JetonClasse from '../composants/JetonClasse';
+import PastilleFraicheur from '../composants/PastilleFraicheur';
+import Onglets from '../composants/Onglets';
+import FriseMouvements from '../composants/FriseMouvements';
+import BarreProgression from '../composants/BarreProgression';
+import Confirmation from '../composants/Confirmation';
+import Bouton from '../composants/Bouton';
+import Squelette from '../composants/Squelette';
+import MessageErreur from '../composants/MessageErreur';
+import Message from '../composants/Message';
+import EtatVide from '../composants/EtatVide';
+import BasculeDevise from '../composants/BasculeDevise';
+import MasquageMontants from '../composants/MasquageMontants';
+import {
+  lirePreference,
+  ecrirePreference,
+  CLE_DEVISE,
+  CLE_MASQUAGE,
+} from '../utils/preferences';
+import './DetailPosition.css';
+
+// Écran de détail d'une position.
+//
+// Il répond à quatre questions : ce que la position vaut, ce qu'elle a coûté, comment
+// on y est arrivé, et ce qui la surveille. La composition suit cet ordre.
+//
+// Tout ce qui est chiffré vient de `GET /api/actifs/:id`. L'effet de chaque mouvement
+// sur le prix de revient y compris : il est calculé par le serveur, qui détient le
+// moteur, et non reconstitué ici (D69). Les seules opérations numériques de l'écran
+// sont l'application du taux d'affichage, en arithmétique exacte, et la géométrie des
+// barres de progression.
+//
+// Une position appartenant à un autre compte répond 404 et non 403 (D52). L'écran la
+// traite donc exactement comme une position inexistante, sans chercher à distinguer
+// les deux : c'est précisément ce que la règle vise.
+
+function natureDeLErreur(erreur) {
+  if (!(erreur instanceof ErreurApi)) {
+    return 'api';
+  }
+  if (erreur.statut === 0) {
+    return 'reseau';
+  }
+  return erreur.statut === 401 ? 'session' : 'api';
+}
+
+// Seuls les seuils encore en vigueur ou déjà franchis concernent l'écran : un seuil
+// désactivé n'a plus rien à surveiller.
+const STATUTS_AFFICHES = ['active', 'declenchee'];
+
+export default function DetailPosition() {
+  const { id } = useParams();
+  const { jeton } = useAuthentification();
+  const naviguer = useNavigate();
+
+  const [position, setPosition] = useState(null);
+  const [seuils, setSeuils] = useState([]);
+  const [erreur, setErreur] = useState(null);
+  const [chargement, setChargement] = useState(true);
+  const [onglet, setOnglet] = useState('mouvements');
+  const [aSupprimer, setASupprimer] = useState(null);
+  const [suppressionEnCours, setSuppressionEnCours] = useState(false);
+
+  const [devise, setDevise] = useState(() => lirePreference(CLE_DEVISE, 'EUR'));
+  const [masque, setMasque] = useState(() => lirePreference(CLE_MASQUAGE, 'non') === 'oui');
+
+  const charger = useCallback(async () => {
+    setChargement(true);
+    setErreur(null);
+
+    try {
+      const detail = await api.actif(jeton, id);
+      setPosition(detail);
+
+      // Les seuils sont secondaires : leur indisponibilité ne doit pas emporter la
+      // fiche entière, qui reste lisible sans l'onglet de surveillance.
+      try {
+        const alertes = await api.alertes(jeton);
+        setSeuils(
+          alertes.filter(
+            (alerte) =>
+              String(alerte.actif_id) === String(id) && STATUTS_AFFICHES.includes(alerte.statut)
+          )
+        );
+      } catch {
+        setSeuils([]);
+      }
+    } catch (echec) {
+      setErreur(echec);
+    } finally {
+      setChargement(false);
+    }
+  }, [jeton, id]);
+
+  useEffect(() => {
+    charger();
+  }, [charger]);
+
+  const taux = position?.taux_affichage?.eur_vers_usd ?? null;
+
+  const afficher = useCallback(
+    (montantEnEuros) => {
+      if (montantEnEuros === null || montantEnEuros === undefined) {
+        return null;
+      }
+      if (devise === 'EUR' || !taux) {
+        return montantEnEuros;
+      }
+      return convertir(montantEnEuros, taux);
+    },
+    [devise, taux]
+  );
+
+  async function confirmerSuppression() {
+    setSuppressionEnCours(true);
+
+    try {
+      if (aSupprimer.type === 'position') {
+        await api.supprimerActif(jeton, id);
+        // La position n'existe plus : rester sur sa fiche afficherait un écran mort.
+        naviguer('/positions', { replace: true });
+        return;
+      }
+
+      await api.supprimerTransaction(jeton, id, aSupprimer.mouvement.id);
+      setASupprimer(null);
+      // Le prix de revient et toutes les valeurs qui en dépendent viennent de changer :
+      // c'est le serveur qui les recalcule, l'écran se recharge plutôt que de retirer
+      // une ligne de son côté.
+      await charger();
+    } catch (echec) {
+      setASupprimer(null);
+      setErreur(echec);
+    } finally {
+      setSuppressionEnCours(false);
+    }
+  }
+
+  if (chargement && !position) {
+    return (
+      <div className="detail" aria-busy="true">
+        <p className="lecteur-ecran-seulement" role="status">
+          Chargement de la position.
+        </p>
+        <Squelette forme="ligne" />
+        <Squelette forme="bloc" />
+        <Carte>
+          <Squelette forme="ligne" />
+          <Squelette forme="ligne" />
+          <Squelette forme="ligne" />
+        </Carte>
+      </div>
+    );
+  }
+
+  // Une position introuvable, ou appartenant à un autre compte : le serveur répond 404
+  // dans les deux cas et l'écran ne fait pas la différence non plus.
+  if (erreur && !position) {
+    const nature = natureDeLErreur(erreur);
+
+    if (erreur instanceof ErreurApi && erreur.statut === 404) {
+      return (
+        <div className="detail">
+          <EtatVide
+            titre="Position introuvable"
+            explication="Cette position n'existe pas ou n'est plus suivie."
+            libelleAction="Revenir aux positions"
+            surAction={() => naviguer('/positions')}
+          />
+        </div>
+      );
+    }
+
+    return (
+      <div className="detail">
+        <MessageErreur
+          nature={nature}
+          message={nature === 'api' ? erreur.message : undefined}
+          libelleAction={nature === 'session' ? 'Se reconnecter' : 'Réessayer'}
+          surAction={nature === 'session' ? () => naviguer('/connexion') : charger}
+        />
+      </div>
+    );
+  }
+
+  const classe = LIBELLES_CLASSE[position.type] ?? position.type;
+  const enRepli = position.source_cours === 'repli';
+  const sansCours = position.cours_eur === null;
+  const mouvements = position.transactions ?? [];
+
+  return (
+    <div className="detail">
+      <div className="detail__entete">
+        <Link to="/positions" className="detail__retour">
+          <span aria-hidden="true">‹</span>
+          <span className="lecteur-ecran-seulement">Revenir aux positions</span>
+        </Link>
+
+        <JetonClasse classe={position.type} />
+        <div className="detail__identite">
+          <h1 className="detail__nom">{position.nom}</h1>
+          <p className="detail__signalement">
+            <span>
+              {position.symbole} · {classe}
+            </span>
+            {position.source_cours && (
+              <PastilleFraicheur
+                source={position.source_cours}
+                horodatage={position.horodatage_cours}
+                enRepli={enRepli}
+              />
+            )}
+          </p>
+        </div>
+
+        <div className="detail__outils">
+          <BasculeDevise
+            devise={devise}
+            indisponible={!taux}
+            surChangement={(choix) => {
+              setDevise(choix);
+              ecrirePreference(CLE_DEVISE, choix);
+            }}
+          />
+          <MasquageMontants
+            masque={masque}
+            surChangement={(valeur) => {
+              setMasque(valeur);
+              ecrirePreference(CLE_MASQUAGE, valeur ? 'oui' : 'non');
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Une erreur survenue alors que la fiche est déjà affichée ne la vide pas. */}
+      {erreur && position && (
+        <MessageErreur nature={natureDeLErreur(erreur)} surAction={charger} />
+      )}
+
+      {sansCours && (
+        <Message variante="avertissement">
+          Aucun cours disponible pour {position.symbole} : cette position n'est pas valorisée.
+        </Message>
+      )}
+
+      {enRepli && (
+        <Message variante="avertissement">
+          Cours momentanément indisponible : la valorisation utilise le dernier cours connu.
+        </Message>
+      )}
+
+      <section className="detail__valorisation" aria-labelledby="titre-valorisation">
+        <h2 id="titre-valorisation" className="detail__intitule">
+          Valorisation de la position
+        </h2>
+        {masque ? (
+          <p className="detail__valeur" aria-label="Montant masqué">
+            ••••••
+          </p>
+        ) : (
+          <Montant
+            valeur={afficher(position.valeur)}
+            devise={devise}
+            taille="principal"
+            className="detail__valeur"
+          />
+        )}
+        <p className="detail__variations">
+          {!masque && (
+            <Variation
+              valeur={afficher(position.plus_value_latente)}
+              mode="absolue"
+              devise={devise}
+              amplitude={position.pourcentage_variation}
+            />
+          )}
+          {position.pourcentage_variation !== null && (
+            <Variation valeur={position.pourcentage_variation} />
+          )}
+          <span className="detail__depuis">de plus-value latente</span>
+        </p>
+      </section>
+
+      <dl className="detail__trio">
+        <div className="detail__repere">
+          <dt>Quantité détenue</dt>
+          <dd>
+            <Montant
+              valeur={position.quantite_detenue}
+              type="quantite"
+              classe={position.type}
+              symbole={position.symbole}
+            />
+          </dd>
+        </div>
+        <div className="detail__repere">
+          <dt>Cours actuel</dt>
+          <dd>
+            {masque ? (
+              <span aria-label="Montant masqué">••••</span>
+            ) : (
+              <Montant valeur={afficher(position.cours_eur)} type="cours" devise={devise} />
+            )}
+          </dd>
+        </div>
+        <div className="detail__repere">
+          <dt>Prix de revient</dt>
+          <dd>
+            {masque ? (
+              <span aria-label="Montant masqué">••••</span>
+            ) : (
+              <Montant valeur={afficher(position.pru)} type="cours" devise={devise} />
+            )}
+          </dd>
+        </div>
+      </dl>
+
+      <Carte className="detail__onglets">
+        <Onglets
+          libelle="Détail de la position"
+          identifiantPanneau="panneau-detail"
+          actif={onglet}
+          surChangement={setOnglet}
+          onglets={[
+            { code: 'mouvements', libelle: 'Mouvements', compteur: mouvements.length },
+            { code: 'seuils', libelle: 'Seuils', compteur: seuils.length },
+          ]}
+        />
+
+        <div id="panneau-detail" role="tabpanel" aria-labelledby={`onglet-${onglet}`}>
+          {onglet === 'mouvements' ? (
+            <FriseMouvements
+              mouvements={mouvements}
+              classe={position.type}
+              symbole={position.symbole}
+              devise={devise}
+              masque={masque}
+              surSuppression={(mouvement) => setASupprimer({ type: 'mouvement', mouvement })}
+            />
+          ) : seuils.length === 0 ? (
+            <p className="detail__sans-seuil">
+              Aucun seuil ne surveille cette position.
+            </p>
+          ) : (
+            <ul className="detail__seuils">
+              {seuils.map((seuil) => (
+                <li key={seuil.id}>
+                  <p className="detail__seuil-intitule">
+                    {/* Valeurs contraintes par le schéma : 'au_dessus' ou 'en_dessous'.
+                        Elles se lisent dans backend/db/schema.sql. */}
+                    {seuil.sens_seuil === 'au_dessus' ? 'Au-dessus de' : 'En dessous de'}{' '}
+                    <Montant valeur={afficher(seuil.valeur_seuil)} devise={devise} />
+                    {seuil.statut === 'declenchee' && (
+                      <span className="detail__seuil-franchi">franchi</span>
+                    )}
+                  </p>
+                  <BarreProgression
+                    valeur={afficher(position.cours_eur)}
+                    cible={afficher(seuil.valeur_seuil)}
+                    devise={devise}
+                    sens={seuil.sens_seuil}
+                    atteint={seuil.statut === 'declenchee'}
+                    libelle={`Progression vers le seuil de ${position.symbole}`}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </Carte>
+
+      <div className="detail__actions">
+        <Bouton variante="secondaire" onClick={() => naviguer('/mouvement')}>
+          Nouveau mouvement
+        </Bouton>
+        <Bouton variante="danger" onClick={() => setASupprimer({ type: 'position' })}>
+          Supprimer la position
+        </Bouton>
+      </div>
+
+      {aSupprimer?.type === 'position' && (
+        <Confirmation
+          titre={`Supprimer ${position.nom} ?`}
+          consequence={`Les ${mouvements.length} mouvement${mouvements.length > 1 ? 's' : ''} enregistré${mouvements.length > 1 ? 's' : ''} sur cette position seront supprimés avec elle, ainsi que les seuils qui la surveillent. Le prix de revient et les plus-values de cette position seront perdus. Cette opération est irréversible.`}
+          libelleConfirmation="Supprimer la position"
+          enCours={suppressionEnCours}
+          surConfirmation={confirmerSuppression}
+          surAnnulation={() => setASupprimer(null)}
+        />
+      )}
+
+      {aSupprimer?.type === 'mouvement' && (
+        <Confirmation
+          titre={
+            aSupprimer.mouvement.sens === 'achat' ? 'Supprimer cet achat ?' : 'Supprimer cette vente ?'
+          }
+          consequence={
+            aSupprimer.mouvement.sens === 'achat'
+              ? "La suppression de cet achat recalculera le prix de revient de la position, ainsi que la quantité détenue et la plus-value latente."
+              : "La suppression de cette vente recalculera la quantité détenue et la plus-value réalisée de la position."
+          }
+          libelleConfirmation="Supprimer le mouvement"
+          enCours={suppressionEnCours}
+          surConfirmation={confirmerSuppression}
+          surAnnulation={() => setASupprimer(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/DetailPosition.jsx
+++ b/frontend/src/pages/DetailPosition.jsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
+import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useAuthentification } from '../contexte/contexteAuthentification';
 import { api, ErreurApi } from '../services/api';
 import { convertir } from '../utils/conversion';
+import { sensVariation } from '../utils/formatage';
 import { LIBELLES_CLASSE } from '../utils/classesActifs';
 import Carte from '../composants/Carte';
 import Montant from '../composants/Montant';
@@ -10,6 +11,7 @@ import Variation from '../composants/Variation';
 import JetonClasse from '../composants/JetonClasse';
 import PastilleFraicheur from '../composants/PastilleFraicheur';
 import Onglets from '../composants/Onglets';
+import SelecteurPeriode from '../composants/SelecteurPeriode';
 import FriseMouvements from '../composants/FriseMouvements';
 import BarreProgression from '../composants/BarreProgression';
 import Confirmation from '../composants/Confirmation';
@@ -27,6 +29,17 @@ import {
   CLE_MASQUAGE,
 } from '../utils/preferences';
 import './DetailPosition.css';
+
+// Même arbitrage que sur le tableau de bord : la bibliothèque de tracé pèse plus lourd
+// que tout le reste de l'application, elle n'est chargée qu'à l'affichage du graphe.
+const Courbe = lazy(() => import('../composants/Courbe'));
+
+// Nombre de points repris pour chaque plage. La série est journalière et continue :
+// borner la fenêtre revient à en garder la fin. C'est de la présentation, les
+// performances de chaque plage restant calculées par le serveur sur la série entière.
+const JOURS_PAR_PERIODE = { jour: 2, semaine: 7, mois: 30, annee: 365, origine: null };
+
+const PERIODE_PAR_DEFAUT = 'mois';
 
 // Écran de détail d'une position.
 //
@@ -67,6 +80,7 @@ export default function DetailPosition() {
   const [erreur, setErreur] = useState(null);
   const [chargement, setChargement] = useState(true);
   const [onglet, setOnglet] = useState('mouvements');
+  const [periode, setPeriode] = useState(PERIODE_PAR_DEFAUT);
   const [aSupprimer, setASupprimer] = useState(null);
   const [suppressionEnCours, setSuppressionEnCours] = useState(false);
 
@@ -119,6 +133,20 @@ export default function DetailPosition() {
     },
     [devise, taux]
   );
+
+  // Points du graphe, bornés à la plage choisie puis convertis à l'affichage. La
+  // conversion vient après le découpage : convertir quatre-vingt-dix points pour n'en
+  // tracer sept serait du travail perdu.
+  const points = useMemo(() => {
+    const serie = position?.historique?.points ?? [];
+    const jours = JOURS_PAR_PERIODE[periode];
+    const fenetre = jours ? serie.slice(-jours) : serie;
+
+    return fenetre.map((point) => ({
+      date: point.date_snapshot,
+      valeur: afficher(point.cours_eur) ?? point.cours_eur,
+    }));
+  }, [position, periode, afficher]);
 
   async function confirmerSuppression() {
     setSuppressionEnCours(true);
@@ -196,6 +224,11 @@ export default function DetailPosition() {
   const enRepli = position.source_cours === 'repli';
   const sansCours = position.cours_eur === null;
   const mouvements = position.transactions ?? [];
+  const performances = position.historique?.performances ?? {};
+
+  // Le sens du tracé vient de la performance calculée par le serveur, jamais d'une
+  // comparaison entre deux montants convertis en nombres.
+  const sensDeLaPeriode = sensVariation(performances[periode] ?? '0') ?? 'stable';
 
   return (
     <div className="detail">
@@ -323,6 +356,42 @@ export default function DetailPosition() {
           </dd>
         </div>
       </dl>
+
+      {/*
+        Le graphe de cours et sa ligne de prix de revient (D79). L'aire se teinte de part
+        et d'autre de cette ligne : c'est le geste graphique propre à l'application, celui
+        qui donne à voir d'un regard quand la position a été en gain et quand elle a été
+        en perte. Il s'insère entre le trio de contexte et la carte à onglets.
+      */}
+      <Carte className="detail__evolution">
+        <SelecteurPeriode
+          periode={periode}
+          performances={performances}
+          surChangement={setPeriode}
+          identifiantPanneau="panneau-cours"
+        />
+        <div id="panneau-cours" role="tabpanel" aria-labelledby={`onglet-periode-${periode}`}>
+          {/* Une série trop courte ne trace rien et laisserait croire à une perte de
+              données. L'historique s'amorce à la première consultation : il n'est jamais
+              interpolé pour combler les jours manquants. */}
+          {points.length < 2 ? (
+            <p className="detail__evolution-absente">
+              L'évolution du cours s'affichera après quelques jours de suivi.
+            </p>
+          ) : (
+            <Suspense fallback={<Squelette forme="graphe" />}>
+              <Courbe
+                points={points}
+                devise={devise}
+                masque={masque}
+                sens={sensDeLaPeriode}
+                prixDeRevient={afficher(position.pru)}
+                sujet={`du cours de ${position.nom}`}
+              />
+            </Suspense>
+          )}
+        </div>
+      </Carte>
 
       <Carte className="detail__onglets">
         <Onglets

--- a/frontend/src/pages/Positions.jsx
+++ b/frontend/src/pages/Positions.jsx
@@ -36,9 +36,25 @@ const TRIS = [
   { cle: 'quantite_detenue', libelle: 'Quantité' },
   { cle: 'cours_eur', libelle: 'Cours' },
   { cle: 'pru', libelle: 'Prix de revient' },
+  // La tendance sur trente jours n'existe que dans le tableau desktop : la liste
+  // mobile ne l'affiche pas, et proposer de trier sur une colonne invisible rendrait
+  // l'ordre de la liste inexplicable. Elle reste triable par son en-tête de colonne,
+  // et donc admise dans l'adresse.
+  { cle: 'tendance', libelle: '30 jours', surMobile: false },
 ];
 
 const TRIS_AUTORISES = TRIS.map((option) => option.cle);
+
+// Le tri porte sur des chaînes de montants. Toutes se lisent directement sur la
+// position, sauf la tendance, qui est un objet : son accès est décrit ici plutôt que
+// dans le comparateur, qui n'a pas à connaître la forme de la réponse.
+const VALEURS_DE_TRI = {
+  tendance: (position) => position.tendance_30j?.variation ?? null,
+};
+
+function valeurDeTri(position, cle) {
+  return (VALEURS_DE_TRI[cle] ?? ((ligne) => ligne[cle]))(position);
+}
 
 // Tri par défaut : la valorisation décroissante. C'est l'ordre qui répond à la question
 // posée en arrivant sur l'écran, « qu'est-ce qui pèse le plus ».
@@ -135,7 +151,9 @@ export default function Positions() {
         : positions.filter((position) => classesFiltrees.includes(position.type));
 
     return [...retenues].sort((a, b) =>
-      comparerDecimales(a[tri.cle], b[tri.cle], { descendant: tri.descendant })
+      comparerDecimales(valeurDeTri(a, tri.cle), valeurDeTri(b, tri.cle), {
+        descendant: tri.descendant,
+      })
     );
   }, [positions, classesFiltrees, tri]);
 
@@ -288,7 +306,7 @@ export default function Positions() {
               modifierParametres({ tri: cle, sens });
             }}
           >
-            {TRIS.map((option) => (
+            {TRIS.filter((option) => option.surMobile !== false).map((option) => (
               <optgroup key={option.cle} label={option.libelle}>
                 <option value={`${option.cle}:desc`}>{option.libelle}, décroissant</option>
                 <option value={`${option.cle}:asc`}>{option.libelle}, croissant</option>

--- a/frontend/src/pages/__tests__/DetailPosition.test.jsx
+++ b/frontend/src/pages/__tests__/DetailPosition.test.jsx
@@ -1,0 +1,380 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import DetailPosition from '../DetailPosition';
+import * as contexte from '../../contexte/contexteAuthentification';
+import { api, ErreurApi } from '../../services/api';
+
+// L'écran est testé sur ce qui se casse en silence : l'effet des mouvements sur le prix
+// de revient, l'ordre de la frise, et les deux confirmations de suppression, dont la
+// formulation est ce qui distingue un garde-fou d'un simple clic de plus.
+//
+// Les mouvements sont ceux que le serveur renvoie, déjà enrichis : aucune de ces valeurs
+// n'est recalculée par l'interface, et le jeu d'essai reproduit donc la forme exacte de
+// la réponse plutôt qu'une forme inventée.
+
+const MOUVEMENTS = [
+  {
+    id: 1,
+    sens: 'achat',
+    quantite: '0.50000000',
+    prix_unitaire: '54000.00',
+    frais: '15.00',
+    date_transaction: '2026-05-27T10:00:00.000Z',
+    note: 'Achat initial',
+    montant: '27000.00',
+    pru_avant: '0',
+    pru_apres: '54030',
+    effet_pru: '54030',
+    quantite_apres: '0.5',
+    plus_value_realisee: null,
+  },
+  {
+    id: 2,
+    sens: 'achat',
+    quantite: '0.30000000',
+    prix_unitaire: '61000.00',
+    frais: '10.00',
+    date_transaction: '2026-07-02T10:00:00.000Z',
+    note: 'Renforcement',
+    montant: '18300.00',
+    pru_avant: '54030',
+    pru_apres: '56636.25',
+    effet_pru: '2606.25',
+    quantite_apres: '0.8',
+    plus_value_realisee: null,
+  },
+  {
+    id: 3,
+    sens: 'vente',
+    quantite: '0.20000000',
+    prix_unitaire: '63500.00',
+    frais: '8.00',
+    date_transaction: '2026-08-03T10:00:00.000Z',
+    note: 'Prise de bénéfice partielle',
+    montant: '12700.00',
+    pru_avant: '56636.25',
+    pru_apres: '56636.25',
+    effet_pru: '0',
+    quantite_apres: '0.6',
+    plus_value_realisee: '1364.75',
+  },
+];
+
+const DETAIL = {
+  id: 1,
+  utilisateur_id: 2,
+  type: 'crypto',
+  symbole: 'BTC',
+  nom: 'Bitcoin',
+  date_ajout: '2026-05-27T10:00:00.000Z',
+  cours_eur: '60801.20',
+  source_cours: 'coinbase',
+  horodatage_cours: '2026-08-23T08:00:00.000Z',
+  quantite_detenue: '0.6',
+  pru: '56636.25',
+  cout_total: '33981.75',
+  valeur: '36480.72',
+  plus_value_latente: '2498.97',
+  plus_value_realisee: '1364.75',
+  pourcentage_variation: '7.35',
+  transactions: MOUVEMENTS,
+  historique: { points: [], performances: {} },
+  taux_affichage: {
+    eur_vers_usd: '1.1699',
+    usd_vers_eur: '0.85477',
+    horodatage: '2026-08-23T00:00:00.000Z',
+  },
+};
+
+// Deux seuils, dont un sur le capital total : il ne cible pas cette position et ne doit
+// pas apparaître ici.
+const ALERTES = [
+  {
+    id: 5,
+    utilisateur_id: 2,
+    actif_id: 1,
+    type_cible: 'actif',
+    sens_seuil: 'au_dessus',
+    valeur_seuil: '70000.00',
+    statut: 'active',
+    date_creation: '2026-06-01T10:00:00.000Z',
+    date_declenchement: null,
+    symbole: 'BTC',
+    nom_actif: 'Bitcoin',
+  },
+  {
+    id: 6,
+    utilisateur_id: 2,
+    actif_id: null,
+    type_cible: 'capital_total',
+    sens_seuil: 'au_dessus',
+    valeur_seuil: '45000.00',
+    statut: 'active',
+    date_creation: '2026-06-01T10:00:00.000Z',
+    date_declenchement: null,
+    symbole: null,
+    nom_actif: null,
+  },
+];
+
+function rendre() {
+  vi.spyOn(contexte, 'useAuthentification').mockReturnValue({
+    jeton: 'jeton-de-test',
+    utilisateur: { pseudo: 'Camille' },
+    estConnecte: true,
+  });
+
+  return render(
+    <MemoryRouter initialEntries={['/positions/1']}>
+      <Routes>
+        <Route path="/positions" element={<p>Liste des positions</p>} />
+        <Route path="/positions/:id" element={<DetailPosition />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+function evenementsDeLaFrise() {
+  return within(screen.getByRole('list', { name: '' })).queryAllByRole('listitem');
+}
+
+beforeEach(() => {
+  vi.spyOn(api, 'actif').mockResolvedValue(DETAIL);
+  vi.spyOn(api, 'alertes').mockResolvedValue(ALERTES);
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('composition de la fiche', () => {
+  it("nomme la position, sa classe et la source de son cours", async () => {
+    rendre();
+
+    expect(await screen.findByRole('heading', { name: 'Bitcoin', level: 1 })).toBeTruthy();
+    expect(screen.getByText(/BTC · Cryptomonnaie/)).toBeTruthy();
+    expect(screen.getByLabelText(/Cours à jour, source coinbase/)).toBeTruthy();
+  });
+
+  it('présente la valorisation, la plus-value et le trio de contexte', async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    expect(screen.getByText('Valorisation de la position')).toBeTruthy();
+    expect(screen.getByText('Quantité détenue')).toBeTruthy();
+    expect(screen.getByText('Cours actuel')).toBeTruthy();
+    expect(screen.getByText('Prix de revient')).toBeTruthy();
+  });
+
+  // Le serveur répond 404 sur la ressource d'un autre compte comme sur une ressource
+  // inexistante (D52) : l'écran ne cherche pas non plus à les distinguer.
+  it('traite une position introuvable sans révéler si elle existe ailleurs', async () => {
+    api.actif.mockRejectedValue(new ErreurApi('Actif introuvable.', 404));
+    rendre();
+
+    expect(await screen.findByText('Position introuvable')).toBeTruthy();
+    expect(screen.queryByText(/appartient/i)).toBeNull();
+  });
+
+  it("signale un cours indisponible sans vider la fiche", async () => {
+    api.actif.mockResolvedValue({
+      ...DETAIL,
+      cours_eur: null,
+      source_cours: null,
+      valeur: null,
+      plus_value_latente: null,
+      pourcentage_variation: null,
+    });
+    rendre();
+
+    expect(await screen.findByText(/Aucun cours disponible pour BTC/)).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Bitcoin', level: 1 })).toBeTruthy();
+  });
+
+  // Cas impossible dans le modèle, un actif naissant d'un premier achat. Traité en
+  // défensif : la fiche reste lisible et le dit en clair.
+  it("reste lisible sur une position sans aucun mouvement", async () => {
+    api.actif.mockResolvedValue({ ...DETAIL, transactions: [] });
+    rendre();
+
+    expect(await screen.findByText('Aucun mouvement enregistré sur cette position.')).toBeTruthy();
+  });
+});
+
+describe('frise des mouvements', () => {
+  it('chiffre le déplacement du prix de revient provoqué par chaque mouvement', async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    // Un intitulé par mouvement : la colonne n'est pas réservée aux achats.
+    expect(screen.getAllByText('Effet sur le prix de revient')).toHaveLength(3);
+  });
+
+  // Une vente partielle laisse le prix de revient intact. Le dire vaut mieux que
+  // d'afficher « +0,00 », que l'utilisateur aurait à interpréter.
+  it("écrit « inchangé » plutôt qu'un zéro sur une vente partielle", async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    expect(screen.getByText('inchangé')).toBeTruthy();
+  });
+
+  it('affiche la plus-value dégagée par une vente, et par elle seule', async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    expect(screen.getAllByText('Plus-value réalisée')).toHaveLength(1);
+  });
+
+  it('va du plus récent au plus ancien', async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    const evenements = evenementsDeLaFrise();
+    expect(evenements[0].textContent).toContain('Vente');
+    expect(evenements[evenements.length - 1].textContent).toContain('Achat initial'.slice(0, 5));
+  });
+
+  it('est une liste ordonnée sémantique', async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    expect(screen.getByRole('list').tagName).toBe('OL');
+  });
+});
+
+describe('onglets', () => {
+  it("bascule vers les seuils aux flèches du clavier", async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    const mouvements = screen.getByRole('tab', { name: /Mouvements/ });
+    mouvements.focus();
+    await utilisateur.keyboard('{ArrowRight}');
+
+    expect(screen.getByRole('tab', { name: /Seuils/ }).getAttribute('aria-selected')).toBe('true');
+    expect(mouvements.getAttribute('aria-selected')).toBe('false');
+  });
+
+  // Un seul onglet est atteignable à la tabulation : c'est ce qui distingue un groupe
+  // d'onglets d'une rangée de boutons.
+  it("ne place qu'un seul onglet dans l'ordre de tabulation", async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    const atteignables = screen
+      .getAllByRole('tab')
+      .filter((onglet) => onglet.getAttribute('tabindex') === '0');
+    expect(atteignables).toHaveLength(1);
+  });
+
+  it("n'affiche que les seuils posés sur cette position", async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    await utilisateur.click(screen.getByRole('tab', { name: /Seuils/ }));
+
+    expect(screen.getByText(/Au-dessus de/)).toBeTruthy();
+    // Le seuil sur le capital total ne cible pas cette position.
+    expect(screen.getAllByRole('progressbar')).toHaveLength(1);
+  });
+
+  // La barre ne porte jamais l'information seule : les deux montants l'accompagnent, et
+  // l'avancement est énoncé en toutes lettres pour un lecteur d'écran.
+  it('énonce la progression vers le seuil autrement que par la barre', async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+    await utilisateur.click(screen.getByRole('tab', { name: /Seuils/ }));
+
+    const barre = screen.getByRole('progressbar');
+    expect(barre.getAttribute('aria-valuetext')).toMatch(/% du seuil haut/);
+  });
+});
+
+describe('suppression', () => {
+  it("nomme la conséquence avant de supprimer un achat", async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    const suppressions = screen.getAllByRole('button', { name: /Supprimer achat/ });
+    await utilisateur.click(suppressions[0]);
+
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText(/recalculera le prix de revient/)).toBeTruthy();
+  });
+
+  it("annonce que les mouvements disparaîtront avec la position", async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Supprimer la position' }));
+
+    expect(screen.getByText(/3 mouvements enregistrés sur cette position seront supprimés/)).toBeTruthy();
+    expect(screen.getByText(/irréversible/)).toBeTruthy();
+  });
+
+  // Le bouton destructeur ne doit jamais recevoir le focus à l'ouverture : une
+  // confirmation validée par une frappe d'Entrée réflexe n'aurait rien confirmé.
+  it("place le focus sur l'annulation et non sur le bouton destructeur", async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Supprimer la position' }));
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Annuler' }));
+  });
+
+  it('se ferme par Échap sans rien supprimer', async () => {
+    const utilisateur = userEvent.setup();
+    vi.spyOn(api, 'supprimerActif').mockResolvedValue(null);
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Supprimer la position' }));
+    await utilisateur.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(api.supprimerActif).not.toHaveBeenCalled();
+  });
+
+  it('supprime la position confirmée et revient à la liste', async () => {
+    const utilisateur = userEvent.setup();
+    vi.spyOn(api, 'supprimerActif').mockResolvedValue(null);
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Supprimer la position' }));
+    // Le dialogue est modal : c'est son propre bouton qu'il faut viser, et non celui de
+    // la page qui l'a ouvert, qui porte le même libellé.
+    const dialogue = within(screen.getByRole('dialog'));
+    await utilisateur.click(dialogue.getByRole('button', { name: 'Supprimer la position' }));
+
+    expect(api.supprimerActif).toHaveBeenCalledWith('jeton-de-test', '1');
+    expect(await screen.findByText('Liste des positions')).toBeTruthy();
+  });
+
+  // Le prix de revient et tout ce qui en dépend viennent de changer : c'est le serveur
+  // qui les recalcule, l'écran ne retire pas une ligne de son côté.
+  it('recharge la fiche après la suppression d\'un mouvement', async () => {
+    const utilisateur = userEvent.setup();
+    vi.spyOn(api, 'supprimerTransaction').mockResolvedValue(null);
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    await utilisateur.click(screen.getAllByRole('button', { name: /Supprimer achat/ })[0]);
+    await utilisateur.click(screen.getByRole('button', { name: 'Supprimer le mouvement' }));
+
+    expect(api.supprimerTransaction).toHaveBeenCalledWith('jeton-de-test', '1', 2);
+    expect(api.actif).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/pages/__tests__/DetailPosition.test.jsx
+++ b/frontend/src/pages/__tests__/DetailPosition.test.jsx
@@ -267,7 +267,10 @@ describe('onglets', () => {
     rendre();
     await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
 
-    const atteignables = screen
+    // L'écran porte deux groupes d'onglets, le sélecteur de période et celui-ci :
+    // l'assertion vise explicitement le second.
+    const groupe = within(screen.getByRole('tablist', { name: 'Détail de la position' }));
+    const atteignables = groupe
       .getAllByRole('tab')
       .filter((onglet) => onglet.getAttribute('tabindex') === '0');
     expect(atteignables).toHaveLength(1);
@@ -376,5 +379,53 @@ describe('suppression', () => {
 
     expect(api.supprimerTransaction).toHaveBeenCalledWith('jeton-de-test', '1', 2);
     expect(api.actif).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('graphe de cours', () => {
+  const SERIE = [
+    { date_snapshot: '2026-08-19', cours_eur: '54000.00', quantite: '0.6' },
+    { date_snapshot: '2026-08-20', cours_eur: '57200.00', quantite: '0.6' },
+    { date_snapshot: '2026-08-21', cours_eur: '59100.00', quantite: '0.6' },
+    { date_snapshot: '2026-08-22', cours_eur: '60100.00', quantite: '0.6' },
+    { date_snapshot: '2026-08-23', cours_eur: '60801.20', quantite: '0.6' },
+  ];
+
+  // L'historique s'amorce à la première consultation : une position trop jeune n'a pas
+  // assez de points, et rien n'est interpolé pour combler les jours manquants.
+  it("annonce l'absence d'historique plutôt que de tracer une ligne inventée", async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    expect(screen.getByText(/s'affichera après quelques jours de suivi/)).toBeTruthy();
+    expect(screen.queryByRole('img')).toBeNull();
+  });
+
+  // D79 : la description accessible nomme explicitement la ligne de prix de revient.
+  // Sans elle, le tracé annoncerait une évolution sans dire par rapport à quoi il se
+  // teinte, c'est-à-dire sans dire ce que le graphe existe pour montrer.
+  it('nomme la ligne de prix de revient dans sa description', async () => {
+    api.actif.mockResolvedValue({
+      ...DETAIL,
+      historique: { points: SERIE, performances: { jour: '1.17', mois: '12.59', origine: '12.59' } },
+    });
+    rendre();
+
+    const graphe = await screen.findByRole('img');
+    expect(graphe.getAttribute('aria-label')).toMatch(/cours de Bitcoin/);
+    expect(graphe.getAttribute('aria-label')).toMatch(/prix de revient/i);
+    expect(graphe.getAttribute('aria-label')).toMatch(/pointill/);
+  });
+
+  it("affiche la performance de chaque plage sans qu'il faille cliquer", async () => {
+    api.actif.mockResolvedValue({
+      ...DETAIL,
+      historique: { points: SERIE, performances: { jour: '1.17', mois: '12.59', origine: '12.59' } },
+    });
+    rendre();
+    await screen.findByRole('img');
+
+    const plages = within(screen.getByRole('tablist', { name: 'Période de la courbe' }));
+    expect(plages.getAllByRole('tab')).toHaveLength(5);
   });
 });

--- a/frontend/src/pages/__tests__/DetailPosition.test.jsx
+++ b/frontend/src/pages/__tests__/DetailPosition.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest';
 import { render, screen, cleanup, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -139,6 +139,14 @@ function rendre() {
 function evenementsDeLaFrise() {
   return within(screen.getByRole('list', { name: '' })).queryAllByRole('listitem');
 }
+
+// Le graphe est chargé à la demande, dans un fragment séparé. Sans cette précharge, la
+// première assertion qui l'attend court contre la résolution de ce fragment, et échoue
+// par intermittence quand la suite entière s'exécute en parallèle. L'import le résout
+// une fois pour toutes ; ni le composant ni ce qui est vérifié n'en sont modifiés.
+beforeAll(async () => {
+  await import('../../composants/Courbe');
+});
 
 beforeEach(() => {
   vi.spyOn(api, 'actif').mockResolvedValue(DETAIL);

--- a/frontend/src/pages/__tests__/Patrimoine.test.jsx
+++ b/frontend/src/pages/__tests__/Patrimoine.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -51,6 +51,14 @@ function rendre(etat = {}) {
     </MemoryRouter>
   );
 }
+
+// Le graphe est chargé à la demande, dans un fragment séparé. Sans cette précharge, la
+// première assertion qui l'attend court contre la résolution de ce fragment, et échoue
+// par intermittence quand la suite entière s'exécute en parallèle. L'import le résout
+// une fois pour toutes ; ni le composant ni ce qui est vérifié n'en sont modifiés.
+beforeAll(async () => {
+  await import('../../composants/Courbe');
+});
 
 beforeEach(() => {
   vi.spyOn(api, 'portefeuille').mockResolvedValue(PORTEFEUILLE);

--- a/frontend/src/pages/__tests__/Positions.test.jsx
+++ b/frontend/src/pages/__tests__/Positions.test.jsx
@@ -344,3 +344,67 @@ describe('accessibilité et affichage', () => {
     expect(lignesDuTableau()).toHaveLength(3);
   });
 });
+
+// Colonne de tendance sur trente jours (D81). La courbe miniature ne porte jamais
+// l'information seule : c'est la variation chiffrée qui l'accompagne qui est lue.
+describe('tendance sur trente jours', () => {
+  const AVEC_TENDANCES = {
+    ...PORTEFEUILLE,
+    actifs: [
+      { ...POSITIONS[0], tendance_30j: { variation: '12.59', points: ['54000.00', '57200.00', '60801.20'] } },
+      { ...POSITIONS[1], tendance_30j: { variation: '-3.20', points: ['95.20', '93.10', '92.14'] } },
+      // Position trop jeune : un seul relevé, aucune tendance calculable.
+      { ...POSITIONS[2], tendance_30j: { variation: null, points: ['0.8547'] } },
+    ],
+  };
+
+  beforeEach(() => {
+    api.portefeuille.mockResolvedValue(AVEC_TENDANCES);
+  });
+
+  it('chiffre la tendance à côté de la courbe miniature', async () => {
+    rendre();
+    await screen.findByRole('table');
+
+    const entetes = within(screen.getByRole('table')).getAllByRole('columnheader');
+    expect(entetes.some((entete) => entete.textContent.includes('30 jours'))).toBe(true);
+    // La politique de formatage arrondit un pourcentage à une décimale : 12,59 se lit
+    // 12,6. L'expression régulière évite en outre de dépendre de l'espace insécable
+    // qui précède le signe pour cent.
+    expect(screen.getByLabelText(/en hausse de 12,6/)).toBeTruthy();
+    expect(screen.getByLabelText(/en baisse de 3,2/)).toBeTruthy();
+  });
+
+  // Tracer une ligne plate affirmerait une stagnation qui n'a pas été constatée.
+  it("dit l'historique trop court plutôt que de tracer une ligne plate", async () => {
+    rendre();
+    await screen.findByRole('table');
+
+    expect(screen.getByText('tendance indisponible, historique trop court')).toBeTruthy();
+  });
+
+  it('trie sur la colonne, les positions sans tendance restant en dernier', async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('table');
+
+    await utilisateur.click(screen.getByRole('button', { name: /30 jours/ }));
+
+    expect(lignesDuTableau().map((ligne) => ligne.slice(0, 20))).toEqual([
+      expect.stringContaining('Bitcoin'),
+      expect.stringContaining('Or'),
+      expect.stringContaining('Dollar'),
+    ]);
+    expect(adresse.search).toContain('tri=tendance');
+  });
+
+  // La liste mobile n'affiche pas cette colonne : proposer de trier dessus rendrait
+  // l'ordre de la liste inexplicable pour qui ne la voit pas.
+  it('ne propose pas ce tri dans le menu du mobile', async () => {
+    rendre();
+    await screen.findByRole('table');
+
+    const menu = screen.getByLabelText('Trier par');
+    expect(within(menu).queryByText(/30 jours/)).toBeNull();
+  });
+});

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -95,4 +95,13 @@ export const api = {
     requete(jours ? `/portefeuille/historique?jours=${jours}` : '/portefeuille/historique', {
       jeton,
     }),
+  // Détail d'une position : état courant, mouvements enrichis de leur effet sur le prix
+  // de revient, et historique de cours avec la performance de chaque plage. Une
+  // ressource appartenant à un autre compte répond 404, jamais 403 (D52) : l'appelant
+  // ne peut pas distinguer l'inexistant de ce qui ne lui appartient pas.
+  actif: (jeton, id) => requete(`/actifs/${id}`, { jeton }),
+  supprimerActif: (jeton, id) => requete(`/actifs/${id}`, { methode: 'DELETE', jeton }),
+  supprimerTransaction: (jeton, actifId, transactionId) =>
+    requete(`/actifs/${actifId}/transactions/${transactionId}`, { methode: 'DELETE', jeton }),
+  alertes: (jeton) => requete('/alertes', { jeton }),
 };


### PR DESCRIPTION
Écran de détail d'une position (E4), historique de cours par position (D81) et rétablissement de la colonne de tendance du tableau des positions.

Issues : #110, #111, #112, #113.

## Ce que le diff ne montre pas

**Le modèle de données change.** Une septième table, `snapshot_cours`, entre au schéma. Une migration l'accompagne, `2026-08-23_historique-cours-par-position.sql`, à appliquer sur toute base déjà peuplée avant de démarrer le serveur — sans elle, l'historisation et la lecture des tendances échouent, en effet de bord journalisé, et les écrans affichent leur état « pas assez de points ». Sur une base neuve, `schema.sql` suffit.

**Vérifications faites sur la base réelle, pas seulement en test :**

- migration rejouée une seconde fois, sans effet et sans erreur ;
- unicité `(actif_id, date_snapshot)` : seconde insertion du même jour refusée, et `ON CONFLICT DO NOTHING` neutralisée comme prévu ;
- borne `quantite >= 0` opposée à une insertion fautive ;
- suppression en cascade vérifiée aux deux niveaux : depuis l'actif, et depuis le compte en deux sauts ;
- cloisonnement : la même lecture rend 0 ligne pour un autre compte et 90 pour le propriétaire ;
- déterminisme du seed : empreinte MD5 des 540 lignes identique après réexécution.

**Contrat vérifié contre une réponse réelle du serveur**, pas contre la documentation : `GET /api/actifs/1` rend bien les mouvements enrichis, quatre-vingt-dix points d'historique, les cinq performances de plage et le taux d'affichage ; `GET /api/portefeuille` rend la tendance des six positions ; `GET /api/actifs/999` rend 404.

## Extensions du contrat d'API

Trois ajouts, tous additifs sur des réponses existantes. Aucune route nouvelle, aucun champ retiré ni renommé.

1. `GET /api/actifs/:id` — chaque mouvement porte `montant`, `pru_avant`, `pru_apres`, `effet_pru`, `quantite_apres` et, pour une vente, sa `plus_value_realisee` propre. Cela tranche la question ouverte E4.1 de la spécification dans le sens qu'elle recommandait : le calcul reste du côté du moteur, l'interface n'en refait aucun (D69).
2. `GET /api/actifs/:id` — un objet `historique` avec ses points et la performance de chaque plage, et le `taux_affichage` déjà exposé par le portefeuille. Ce dernier évite que la fiche affiche des euros quand les deux écrans qui y mènent affichent des dollars, sans requête supplémentaire au basculement (D43, D69).
3. `GET /api/portefeuille` — chaque position porte `tendance_30j`, sa variation et ses points.

## Points à connaître

- **Deux liens mènent à des écrans qui n'existent pas encore** : « Nouveau mouvement » vise `/mouvement` (lot E5) et l'écran Introuvable s'affiche d'ici là. C'est la même situation que le bouton du portefeuille vide de l'écran Patrimoine. La cible finale est correcte.
- **La création d'un seuil depuis cet écran n'est pas encore proposée** : elle attend la feuille de création du lot E6, dont elle est une variante pré-réglée. L'onglet Seuils lit et affiche, il ne crée pas.
- **La colonne de tendance n'existe que dans le tableau desktop.** La liste mobile n'a pas la place d'une seconde variation à côté de celle depuis l'origine, et le tri sur cette colonne n'est donc pas proposé au menu du mobile.
- **L'écran Patrimoine desktop ne porte pas de tableau de positions** dans l'implémentation, là où la maquette `08 - Patrimoine desktop` en montre un extrait avec la même colonne. Écart antérieur à ce lot, non traité ici.
- **La progression vers un seuil est une géométrie, pas un calcul métier.** La barre rapporte le cours au seuil, à l'endroit pour un seuil haut et à l'envers pour un seuil bas, et n'affiche aucun pourcentage d'écart : celui-ci relève du serveur et sera traité avec l'écran E6.

## Vérifications

- back : 206 tests, 18 fichiers ;
- front : 167 tests, 11 fichiers ;
- `oxlint` muet, `vite build` sans avertissement de taille ;
- courbe miniature tracée en SVG à la main : la bibliothèque de graphiques reste hors du fragment initial.

## Preuve à reprendre

L'ERD était déjà classé « à refaire » depuis D60. La base locale porte maintenant l'état définitif du modèle : c'est le moment de reprendre la capture depuis pgAdmin.
