### PR TITLE
E5 - Écran Mouvement : feuille de saisie, achat et vente, effet calculé avant validation

### DIFF
--- a/backend/src/controllers/actif.js
+++ b/backend/src/controllers/actif.js
@@ -9,11 +9,12 @@
 // « cet actif ne vous appartient pas ».
 
 const modeleActif = require('../models/actif');
-const serviceTransaction = require('../services/transaction');
+const { creerServiceTransaction } = require('../services/transaction');
 const { creerServicePortefeuille } = require('../services/portefeuilleConsolide');
 const { ErreurIntrouvable } = require('../erreurs');
 
 const servicePortefeuille = creerServicePortefeuille();
+const serviceTransaction = creerServiceTransaction();
 
 async function lister(req, res, next) {
   try {
@@ -93,6 +94,22 @@ async function ajouterTransaction(req, res, next) {
   }
 }
 
+// Effet d'un mouvement avant son enregistrement, pour le récapitulatif de l'écran de
+// saisie. Rien n'est écrit : le corps de la requête est celui d'une création, et la
+// réponse est un 200 et non un 201, aucune ressource n'ayant été créée.
+async function simulerTransaction(req, res, next) {
+  try {
+    const effet = await serviceTransaction.simuler({
+      actifId: req.params.id,
+      utilisateurId: req.utilisateur.id,
+      donnees: req.body,
+    });
+    res.status(200).json(effet);
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
 async function supprimerTransaction(req, res, next) {
   try {
     await serviceTransaction.supprimer({
@@ -113,5 +130,6 @@ module.exports = {
   modifier,
   supprimer,
   ajouterTransaction,
+  simulerTransaction,
   supprimerTransaction,
 };

--- a/backend/src/routes/actif.js
+++ b/backend/src/routes/actif.js
@@ -24,6 +24,15 @@ routeur.post(
   valider(creationTransaction),
   controleur.ajouterTransaction
 );
+// Même corps et mêmes contrôles que la création, mais sans écriture : la route rend
+// l'effet qu'aurait le mouvement sur la position. Elle est déclarée avant la route
+// paramétrée par identifiant de transaction, qui ne répond qu'en DELETE.
+routeur.post(
+  '/:id/transactions/simulation',
+  validerParamId('id'),
+  valider(creationTransaction),
+  controleur.simulerTransaction
+);
 routeur.delete(
   '/:id/transactions/:idTransaction',
   validerParamId('id'),

--- a/backend/src/services/__tests__/transaction.test.js
+++ b/backend/src/services/__tests__/transaction.test.js
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+// Le service tire la configuration par sa chaîne d'imports : environnement minimal
+// posé avant l'import dynamique, comme pour les autres modules qui en dépendent.
+let creerServiceTransaction;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = 'postgresql://utilisateur:secret@localhost:5432/capitall';
+  process.env.JWT_SECRET = 'd'.repeat(32);
+  ({ creerServiceTransaction } = await import('../transaction.js'));
+});
+
+// Le service est monté avec des modèles en mémoire : aucune base n'est nécessaire pour
+// vérifier l'enregistrement d'un mouvement ni la simulation de son effet.
+//
+// Les chiffres attendus sont ceux du moteur de calcul, repris de ses six règles (D54) :
+// un achat recalcule le prix de revient en moyenne pondérée, frais compris ; une vente
+// le laisse intact et dégage une plus-value.
+
+const ACTIF = { id: 7, utilisateur_id: 2, type: 'crypto', symbole: 'BTC', nom: 'Bitcoin' };
+
+// 0,5 à 54 000 avec 15 de frais, puis 0,3 à 61 000 avec 10 de frais : (27 015 + 18 310)
+// divisé par 0,8, soit un prix de revient de 56 656,25 sur 0,8 unité détenue.
+const HISTORIQUE = [
+  {
+    id: 1,
+    sens: 'achat',
+    quantite: '0.50000000',
+    prix_unitaire: '54000.00',
+    frais: '15.00',
+    date_transaction: '2026-05-27T10:00:00.000Z',
+  },
+  {
+    id: 2,
+    sens: 'achat',
+    quantite: '0.30000000',
+    prix_unitaire: '61000.00',
+    frais: '10.00',
+    date_transaction: '2026-07-02T10:00:00.000Z',
+  },
+];
+
+function monter({ actif = ACTIF, historique = HISTORIQUE } = {}) {
+  const actifs = { trouverParIdEtUtilisateur: vi.fn().mockResolvedValue(actif) };
+  const transactions = {
+    listerParActifEtUtilisateur: vi.fn().mockResolvedValue(historique),
+    creer: vi.fn().mockImplementation(async (donnees) => ({ id: 42, ...donnees })),
+    supprimer: vi.fn().mockResolvedValue(true),
+  };
+
+  return { service: creerServiceTransaction({ actifs, transactions }), actifs, transactions };
+}
+
+function mouvement(sens, quantite, prixUnitaire, frais = '0', date = '2026-08-24T10:00:00.000Z') {
+  return {
+    sens,
+    quantite,
+    prix_unitaire: prixUnitaire,
+    frais,
+    date_transaction: date,
+  };
+}
+
+describe('enregistrement', () => {
+  it('écrit un achat sans charger l\'historique, qui n\'a rien à contrôler', async () => {
+    const { service, transactions } = monter();
+
+    await service.enregistrer({
+      actifId: 7,
+      utilisateurId: 2,
+      donnees: mouvement('achat', '0.1', '60000.00'),
+    });
+
+    expect(transactions.creer).toHaveBeenCalledTimes(1);
+    expect(transactions.listerParActifEtUtilisateur).not.toHaveBeenCalled();
+  });
+
+  it('refuse une vente supérieure à la quantité détenue', async () => {
+    const { service, transactions } = monter();
+
+    await expect(
+      service.enregistrer({
+        actifId: 7,
+        utilisateurId: 2,
+        donnees: mouvement('vente', '0.9', '63000.00'),
+      })
+    ).rejects.toMatchObject({ statut: 400 });
+
+    expect(transactions.creer).not.toHaveBeenCalled();
+  });
+
+  // Un actif appartenant à un autre compte est indiscernable d'un actif inexistant :
+  // le modèle filtre sur le propriétaire, le service ne voit qu'une absence (D52).
+  it('rend 404 sur un actif qui n\'appartient pas au demandeur', async () => {
+    const { service, transactions } = monter({ actif: null });
+
+    await expect(
+      service.enregistrer({
+        actifId: 7,
+        utilisateurId: 99,
+        donnees: mouvement('achat', '0.1', '60000.00'),
+      })
+    ).rejects.toMatchObject({ statut: 404 });
+
+    expect(transactions.creer).not.toHaveBeenCalled();
+  });
+});
+
+describe('simulation', () => {
+  it('n\'écrit rien', async () => {
+    const { service, transactions } = monter();
+
+    await service.simuler({
+      actifId: 7,
+      utilisateurId: 2,
+      donnees: mouvement('achat', '0.2', '58900.00', '2.40'),
+    });
+
+    expect(transactions.creer).not.toHaveBeenCalled();
+  });
+
+  it('chiffre le déplacement du prix de revient provoqué par un achat', async () => {
+    const { service } = monter();
+
+    const effet = await service.simuler({
+      actifId: 7,
+      utilisateurId: 2,
+      donnees: mouvement('achat', '0.2', '58900.00', '2.40'),
+    });
+
+    // (45 325 + 58 900 × 0,2 + 2,40) / 1 = 57 107,40
+    expect(effet.pru_avant).toBe('56656.25');
+    expect(effet.pru_apres).toBe('57107.4');
+    expect(effet.effet_pru).toBe('451.15');
+    expect(effet.quantite_detenue_avant).toBe('0.8');
+    expect(effet.quantite_detenue_apres).toBe('1');
+    expect(effet.montant).toBe('11780.00');
+    expect(effet.plus_value_realisee).toBeNull();
+  });
+
+  // Règle 3 : une vente ne déplace pas le prix de revient. Le récapitulatif doit le
+  // montrer par un effet nul, et non taire l'information.
+  it('laisse le prix de revient intact sur une vente et chiffre sa plus-value', async () => {
+    const { service } = monter();
+
+    const effet = await service.simuler({
+      actifId: 7,
+      utilisateurId: 2,
+      donnees: mouvement('vente', '0.2', '63500.00', '8.00'),
+    });
+
+    // 0,2 × (63 500 − 56 656,25) − 8 = 1 360,75
+    expect(effet.pru_apres).toBe('56656.25');
+    expect(effet.effet_pru).toBe('0');
+    expect(effet.quantite_detenue_apres).toBe('0.6');
+    expect(effet.plus_value_realisee).toBe('1360.75');
+  });
+
+  // Règle 5 : une vente totale solde la position et remet le prix de revient à zéro.
+  it('montre la remise à zéro du prix de revient sur une vente totale', async () => {
+    const { service } = monter();
+
+    const effet = await service.simuler({
+      actifId: 7,
+      utilisateurId: 2,
+      donnees: mouvement('vente', '0.8', '63500.00'),
+    });
+
+    expect(effet.quantite_detenue_apres).toBe('0');
+    expect(effet.pru_apres).toBe('0');
+    expect(effet.effet_pru).toBe('-56656.25');
+  });
+
+  it('applique la règle de vente avant de calculer quoi que ce soit', async () => {
+    const { service } = monter();
+
+    await expect(
+      service.simuler({
+        actifId: 7,
+        utilisateurId: 2,
+        donnees: mouvement('vente', '0.80000001', '63500.00'),
+      })
+    ).rejects.toMatchObject({ statut: 400 });
+  });
+
+  // Règle 6 : le calcul suit l'ordre chronologique, pas l'ordre de saisie. Un achat
+  // rétroactif doit donc donner le même prix de revient que s'il avait été saisi à sa
+  // date, et l'effet annoncé porte sur l'état final de la position.
+  it('replace une saisie rétroactive à sa date dans le déroulé', async () => {
+    const { service } = monter();
+
+    const retroactif = await service.simuler({
+      actifId: 7,
+      utilisateurId: 2,
+      donnees: mouvement('achat', '0.2', '58900.00', '2.40', '2026-06-15T10:00:00.000Z'),
+    });
+    const courant = await service.simuler({
+      actifId: 7,
+      utilisateurId: 2,
+      donnees: mouvement('achat', '0.2', '58900.00', '2.40'),
+    });
+
+    // Le prix de revient est une moyenne pondérée : l'ordre des achats ne le change
+    // pas, seule leur composition compte.
+    expect(retroactif.pru_apres).toBe(courant.pru_apres);
+    expect(retroactif.quantite_detenue_apres).toBe('1');
+  });
+
+  it('part d\'un prix de revient nul sur une position encore vide', async () => {
+    const { service } = monter({ historique: [] });
+
+    const effet = await service.simuler({
+      actifId: 7,
+      utilisateurId: 2,
+      donnees: mouvement('achat', '0.5', '54000.00', '15.00'),
+    });
+
+    expect(effet.pru_avant).toBe('0');
+    expect(effet.pru_apres).toBe('54030');
+    expect(effet.quantite_detenue_avant).toBe('0');
+  });
+
+  it('rend 404 sur un actif qui n\'appartient pas au demandeur', async () => {
+    const { service } = monter({ actif: null });
+
+    await expect(
+      service.simuler({
+        actifId: 7,
+        utilisateurId: 99,
+        donnees: mouvement('achat', '0.1', '60000.00'),
+      })
+    ).rejects.toMatchObject({ statut: 404 });
+  });
+});
+
+describe('suppression', () => {
+  it('rend 404 lorsque la transaction ne correspond à aucune ligne du compte', async () => {
+    const { service, transactions } = monter();
+    transactions.supprimer.mockResolvedValue(false);
+
+    await expect(
+      service.supprimer({ actifId: 7, idTransaction: 3, utilisateurId: 2 })
+    ).rejects.toMatchObject({ statut: 404 });
+  });
+});

--- a/backend/src/services/transaction.js
+++ b/backend/src/services/transaction.js
@@ -1,42 +1,124 @@
 // Orchestration de l'enregistrement d'une transaction : lecture de l'historique,
 // application de la règle de vente, puis écriture. Les règles de calcul elles-mêmes
-// vivent dans portefeuille.js, qui reste sans dépendance à la base et donc testable seul.
+// vivent dans portefeuille.js et calculPortefeuille.js, qui restent sans dépendance à
+// la base et donc testables seuls.
+//
+// Les modèles sont injectables, comme pour le service de portefeuille et celui
+// d'authentification : le service s'exécute alors sans base dans les tests, avec le
+// même code qu'en production.
 
 const modeleActif = require('../models/actif');
 const modeleTransaction = require('../models/transaction');
 const { verifierVenteAutorisee } = require('./portefeuille');
+const { derouler } = require('./calculPortefeuille');
+const { ECHELLE_PRU, versUnites, versChaine } = require('../utils/decimal');
 const { ErreurIntrouvable } = require('../erreurs');
 
-async function enregistrer({ actifId, utilisateurId, donnees }) {
-  // Contrôle d'existence et de propriété en une seule requête filtrée.
-  const actif = await modeleActif.trouverParIdEtUtilisateur(actifId, utilisateurId);
-  if (!actif) {
-    throw new ErreurIntrouvable('Actif introuvable.');
+// Identifiant prêté au mouvement hypothétique d'une simulation. Il n'est jamais
+// écrit : il sert uniquement à retrouver ce mouvement parmi les autres après le
+// déroulé, qui les réordonne. Le plus grand entier sûr place aussi le mouvement en
+// dernier lorsqu'il partage sa date avec un mouvement déjà enregistré, ce qui est
+// l'ordre dans lequel il serait effectivement inséré.
+const ID_SIMULATION = Number.MAX_SAFE_INTEGER;
+
+function creerServiceTransaction({
+  actifs = modeleActif,
+  transactions = modeleTransaction,
+} = {}) {
+  // Contrôle d'existence et de propriété en une seule requête filtrée. Un actif
+  // appartenant à un autre compte est indiscernable d'un actif inexistant (D52).
+  async function exigerActif(actifId, utilisateurId) {
+    const actif = await actifs.trouverParIdEtUtilisateur(actifId, utilisateurId);
+    if (!actif) {
+      throw new ErreurIntrouvable('Actif introuvable.');
+    }
+    return actif;
   }
 
-  // L'historique n'est chargé que pour une vente : un achat n'a rien à contrôler.
-  if (donnees.sens === 'vente') {
-    const historique = await modeleTransaction.listerParActifEtUtilisateur(actifId, utilisateurId);
-    verifierVenteAutorisee(historique, donnees.quantite);
+  async function enregistrer({ actifId, utilisateurId, donnees }) {
+    await exigerActif(actifId, utilisateurId);
+
+    // L'historique n'est chargé que pour une vente : un achat n'a rien à contrôler.
+    if (donnees.sens === 'vente') {
+      const historique = await transactions.listerParActifEtUtilisateur(actifId, utilisateurId);
+      verifierVenteAutorisee(historique, donnees.quantite);
+    }
+
+    return transactions.creer({
+      actifId,
+      utilisateurId,
+      sens: donnees.sens,
+      quantite: donnees.quantite,
+      prixUnitaire: donnees.prix_unitaire,
+      frais: donnees.frais,
+      dateTransaction: donnees.date_transaction,
+      note: donnees.note,
+    });
   }
 
-  return modeleTransaction.creer({
-    actifId,
-    utilisateurId,
-    sens: donnees.sens,
-    quantite: donnees.quantite,
-    prixUnitaire: donnees.prix_unitaire,
-    frais: donnees.frais,
-    dateTransaction: donnees.date_transaction,
-    note: donnees.note,
-  });
+  // Effet d'un mouvement qui n'est pas encore enregistré : ce que la position vaut
+  // avant, ce qu'elle vaudra après, et ce que l'opération déplace.
+  //
+  // C'est le récapitulatif que l'écran de saisie présente avant validation. Il est
+  // calculé ici et non côté interface (D69) : le prix de revient est une moyenne
+  // pondérée sur toute l'histoire de la position, et une seconde implémentation de
+  // cette règle finirait par diverger de celle du moteur. La simulation rejoue donc
+  // exactement le même déroulé que l'enregistrement, à l'écriture près.
+  //
+  // La règle de vente est appliquée avant tout calcul : une vente impossible se
+  // signale au moment de la saisie, avec le message qu'aurait rendu la validation.
+  async function simuler({ actifId, utilisateurId, donnees }) {
+    await exigerActif(actifId, utilisateurId);
+
+    const historique = await transactions.listerParActifEtUtilisateur(actifId, utilisateurId);
+    if (donnees.sens === 'vente') {
+      verifierVenteAutorisee(historique, donnees.quantite);
+    }
+
+    const hypothetique = {
+      id: ID_SIMULATION,
+      sens: donnees.sens,
+      quantite: donnees.quantite,
+      prix_unitaire: donnees.prix_unitaire,
+      frais: donnees.frais,
+      date_transaction: donnees.date_transaction,
+    };
+
+    const avant = derouler(historique).position;
+    const { mouvements, position: apres } = derouler([...historique, hypothetique]);
+    const simule = mouvements.find((mouvement) => mouvement.id === ID_SIMULATION);
+
+    return {
+      sens: donnees.sens,
+      // Montant brut de l'opération, frais exclus : ils sont rendus à part, comme
+      // dans la frise des mouvements, où les additionner les compterait deux fois.
+      montant: simule.montant,
+      frais: donnees.frais,
+      quantite_detenue_avant: avant.quantite_detenue,
+      quantite_detenue_apres: apres.quantite_detenue,
+      pru_avant: avant.pru,
+      pru_apres: apres.pru,
+      // Déplacement du prix de revient de la position, et non celui que le seul
+      // mouvement provoque à sa place dans l'histoire : une saisie rétroactive
+      // change l'état final sans être le dernier mouvement du déroulé.
+      effet_pru: versChaine(
+        versUnites(apres.pru, ECHELLE_PRU) - versUnites(avant.pru, ECHELLE_PRU),
+        ECHELLE_PRU
+      ),
+      // Nulle sur un achat, qui ne dégage aucune plus-value.
+      plus_value_realisee: simule.plus_value_realisee,
+      cout_total_apres: apres.cout_total,
+    };
+  }
+
+  async function supprimer({ actifId, idTransaction, utilisateurId }) {
+    const supprimee = await transactions.supprimer(idTransaction, actifId, utilisateurId);
+    if (!supprimee) {
+      throw new ErreurIntrouvable('Transaction introuvable.');
+    }
+  }
+
+  return { enregistrer, simuler, supprimer };
 }
 
-async function supprimer({ actifId, idTransaction, utilisateurId }) {
-  const supprimee = await modeleTransaction.supprimer(idTransaction, actifId, utilisateurId);
-  if (!supprimee) {
-    throw new ErreurIntrouvable('Transaction introuvable.');
-  }
-}
-
-module.exports = { enregistrer, supprimer };
+module.exports = { creerServiceTransaction };

--- a/docs/cahier-des-charges.md
+++ b/docs/cahier-des-charges.md
@@ -280,6 +280,7 @@ Toutes les routes privées attendent le jeton dans l'en-tête d'autorisation. Un
 | PATCH | `/api/actifs/:id` | propriétaire | modification du nom | 200, 400, 401, 404 |
 | DELETE | `/api/actifs/:id` | propriétaire | suppression, en cascade sur les transactions et alertes liées | 204, 401, 404 |
 | POST | `/api/actifs/:id/transactions` | propriétaire | enregistrement d'une transaction | 201, 400, 401, 404 |
+| POST | `/api/actifs/:id/transactions/simulation` | propriétaire | effet d'une transaction sur la position, avant enregistrement et sans écriture | 200, 400, 401, 404 |
 | DELETE | `/api/actifs/:id/transactions/:idTransaction` | propriétaire | suppression d'une transaction | 204, 401, 404 |
 | GET | `/api/portefeuille` | authentifié | consolidation : valeur totale, coût de revient, plus-values, répartition, taux de change, alertes franchies | 200, 401 |
 | GET | `/api/portefeuille/historique` | authentifié | instantanés de valorisation | 200, 401 |
@@ -307,12 +308,15 @@ Les structures de données échangées par chaque point d'entrée seront documen
 |---|---|---|
 | `/connexion` | public | formulaire de connexion |
 | `/inscription` | public | formulaire d'inscription |
-| `/tableau-de-bord` | authentifié | consolidation, répartition, courbe d'évolution, alertes franchies, annonces |
-| `/actifs` | authentifié | liste des actifs suivis |
-| `/actifs/:id` | propriétaire | détail d'un actif et de ses transactions |
-| `/actifs/:id/transactions/nouvelle` | propriétaire | saisie d'une transaction |
-| `/alertes` | authentifié | gestion des seuils |
+| `/patrimoine` | authentifié | consolidation, répartition, courbe d'évolution, seuils franchis |
+| `/positions` | authentifié | liste des positions, filtres par classe et tri |
+| `/positions/:id` | propriétaire | détail d'une position, ses mouvements et ses seuils |
+| `/seuils` | authentifié | gestion des seuils |
 | `/compte` | authentifié | profil, sécurité, préférences d'affichage, mentions |
+
+Les libellés et les chemins suivent le lexique du projet : patrimoine, position, seuil.
+
+La saisie d'un mouvement n'a pas de route à elle : c'est une feuille glissante en mobile et un dialogue centré en desktop, ouverts par-dessus l'écran courant, dont ils préservent le contexte. Leur ouverture est portée par le paramètre `?mouvement` de l'écran d'origine, de sorte qu'elle survive à un rechargement et se referme par le bouton de retour du navigateur.
 
 Toute route privée atteinte sans jeton valide redirige vers la connexion.
 

--- a/docs/conception/specification-fonctionnelle.md
+++ b/docs/conception/specification-fonctionnelle.md
@@ -244,19 +244,23 @@ En desktop, tableau à colonnes : Actif, Quantité, Cours, Prix de revient, Valo
 
 **Informations affichées et hiérarchie.** Bascule achat ou vente en tête, colorée et explicite. Sélection de l'actif, avec création d'un actif inexistant dans le même geste. Quantité et prix unitaire. Date. Frais, facultatif. Puis, en bas et mis en évidence, le **récapitulatif recalculé en direct** : montant de l'opération, quantité détenue après, nouveau prix de revient et son écart. Pour une vente : plus-value réalisée par l'opération.
 
-**Composants.** `Feuille`, `Champ`, `JetonClasse`, `Bouton`, `Montant`, `MessageErreur`, sélecteur d'actif avec recherche.
+**Composants.** `Feuille`, `Champ`, `JetonClasse`, `Bouton`, `Montant`, `Variation`, `Message`, et un sélecteur d'actif. Celui-ci est une liste déroulante native, comme dans la maquette : elle se parcourt à la frappe, reste utilisable au clavier comme au doigt sans code à maintenir, et un portefeuille de quelques dizaines de positions ne justifie pas un champ de recherche.
 
 **Interactions.** Le prix unitaire est pré-rempli au cours du jour et reste modifiable, avec une mention explicite. Une vente ne propose jamais une quantité supérieure à la quantité détenue : le champ est borné et un raccourci « tout vendre » est proposé. La date ne peut pas être future. La validation est bloquée tant que le récapitulatif ne peut pas être calculé. À l'enregistrement, la feuille se ferme et l'écran d'origine se rafraîchit, avec confirmation brève.
 
 **Validations.** Quantité strictement positive, dans la précision de la classe. Prix unitaire positif. Date passée ou du jour. Frais positifs ou nuls. Les messages nomment le champ et la règle, jamais un code.
 
-**États particuliers.** *Actif nouveau* : les champs de classe et de symbole apparaissent, le symbole étant vérifié auprès du service de cours avant validation. *Cours indisponible* : le prix unitaire n'est pas pré-rempli, un message l'explique, la saisie manuelle reste possible. *Erreur 422* : les messages du serveur sont replacés sur les champs concernés, jamais affichés en bloc. *Enregistrement en cours* : bouton désactivé, formulaire verrouillé.
+**États particuliers.** *Actif nouveau* : les champs de classe, de symbole et de nom apparaissent, et l'actif est créé avant la saisie du mouvement. *Cours indisponible* : le prix unitaire n'est pas pré-rempli, un message l'explique, la saisie manuelle reste possible. *Erreur de validation* : le serveur répond 400 en nommant chaque champ fautif, et ces messages sont replacés sur les champs concernés, jamais affichés en bloc ; un refus de règle de gestion, qui ne nomme pas de champ, s'affiche tel quel. *Enregistrement en cours* : bouton désactivé, formulaire verrouillé.
 
 **Accessibilité.** La feuille est un dialogue modal : focus capturé, retour au déclencheur à la fermeture, fermeture par Échap. Le récapitulatif est une région `aria-live="polite"` : ses recalculs sont annoncés sans interrompre la saisie. Les champs numériques portent `inputmode="decimal"`. La bascule achat ou vente est un groupe de boutons radio, pas une paire de boutons.
 
-**Questions ouvertes.**
-1. Faut-il permettre la création d'un actif depuis ce formulaire, ou imposer un écran séparé ? Recommandation : dans le formulaire. Séparer impose deux parcours pour une même intention et double le nombre d'écrans.
-2. Le champ frais est-il utile au MVP ? Il entre dans le prix de revient et enrichit le calcul, mais allonge le formulaire. Recommandation : le conserver, replié derrière un lien « ajouter des frais », visible mais non imposé.
+**Questions tranchées.**
+1. La création d'un actif se fait **depuis le formulaire**, conformément à la recommandation. Elle y forme une étape distincte : l'actif est créé, puis le mouvement se saisit sur la position ainsi ouverte. Sans cela, le récapitulatif ne pourrait porter sur rien et la règle « pas de validation sans récapitulatif » tomberait précisément sur le premier achat, celui d'un portefeuille vide.
+2. Le champ frais est **conservé et visible**, apparié à la date comme dans la maquette validée, plutôt que replié derrière un lien. Il porte la mention « facultatif » et rappelle que les frais d'achat entrent dans le prix de revient.
+
+**Impacts API.** `POST /api/actifs/:id/transactions/simulation` rend l'effet du mouvement sur la position sans rien écrire : montant, quantité détenue avant et après, prix de revient avant et après, déplacement du prix de revient, et plus-value dégagée par une vente. Le récapitulatif est un état métier, il ne se reconstitue pas dans l'interface (D69).
+
+**Devise de saisie.** Le formulaire est en euros, devise de référence des calculs et du stockage. La bascule euro-dollar des écrans de restitution ne s'y applique pas : elle ne change que l'affichage, alors qu'un montant saisi est celui qui sera enregistré.
 
 ---
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,6 +28,14 @@ export default function App() {
             <Route path="/patrimoine" element={<Patrimoine />} />
             <Route path="/positions" element={<Positions />} />
             <Route path="/positions/:id" element={<DetailPosition />} />
+
+            {/* La saisie d'un mouvement est une feuille posée sur l'écran d'origine, et
+                non une page : elle n'a pas de route à elle. L'adresse reste toutefois
+                atteignable, et ouvre la feuille par-dessus le patrimoine. */}
+            <Route
+              path="/mouvement"
+              element={<Navigate to="/patrimoine?mouvement=nouveau" replace />}
+            />
           </Route>
 
           <Route path="/" element={<Navigate to="/patrimoine" replace />} />

--- a/frontend/src/composants/Feuille.css
+++ b/frontend/src/composants/Feuille.css
@@ -1,0 +1,135 @@
+/*
+  Feuille glissante en mobile, dialogue centré en desktop. Le point de rupture est celui
+  du reste de l'application : au-delà, la place ne manque plus et une feuille ancrée en
+  bas d'un grand écran obligerait à parcourir toute la hauteur du regard.
+*/
+
+.feuille__voile {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  background: rgba(16, 20, 24, 0.72);
+}
+
+.feuille {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-height: 92vh;
+  background: var(--couleur-carte);
+  border: 1px solid var(--couleur-bordure);
+  border-radius: 18px 18px 0 0;
+  padding: var(--espace-3) var(--espace-4) var(--espace-4);
+}
+
+/* Le dialogue reçoit le focus à l'ouverture : sans cette règle, le navigateur en
+   dessinerait le contour sur toute la feuille, ce qui se lirait comme une erreur. Le
+   focus reste bien posé, et les contrôles gardent le leur. */
+.feuille:focus {
+  outline: none;
+}
+
+/* Poignée de préhension : elle annonce une feuille que l'on peut faire glisser, et
+   marque le haut du contenu. Purement décorative, donc masquée à la restitution. */
+.feuille__poignee {
+  align-self: center;
+  width: 36px;
+  height: 4px;
+  margin-bottom: var(--espace-3);
+  border-radius: var(--rayon-pilule);
+  background: var(--couleur-bordure);
+}
+
+.feuille__entete {
+  display: flex;
+  align-items: center;
+  gap: var(--espace-3);
+  margin-bottom: var(--espace-3);
+}
+
+.feuille__titre {
+  flex: 1;
+  margin: 0;
+  font-size: var(--taille-titre);
+  font-weight: var(--graisse-forte);
+}
+
+/* Zone tactile de 44 px en mobile (D77), le glyphe restant plus petit. */
+.feuille__fermer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0;
+  font-size: var(--taille-corps);
+  color: var(--couleur-texte-attenue);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--rayon-carte);
+  cursor: pointer;
+}
+
+.feuille__fermer:hover:not(:disabled) {
+  color: var(--couleur-texte);
+  border-color: var(--couleur-bordure);
+}
+
+.feuille__fermer:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* Le corps défile, l'en-tête et le pied restent visibles : le bouton d'enregistrement
+   ne doit pas se trouver hors de portée sur un petit écran. */
+.feuille__corps {
+  flex: 1;
+  overflow-y: auto;
+}
+
+/* Actions de la feuille. Elles vivent dans le formulaire qu'elles valident, et non dans
+   un pied de dialogue : un bouton de soumission séparé de son formulaire ne serait plus
+   déclenché par la touche Entrée. L'inversion place l'annulation sous l'action
+   principale en mobile, là où le pouce arrive naturellement, sans changer pour autant
+   l'ordre du document ni celui de la tabulation. */
+.feuille__actions {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: var(--espace-3);
+  padding-top: var(--espace-4);
+  border-top: 1px solid var(--couleur-bordure);
+  margin-top: var(--espace-4);
+}
+
+@media (min-width: 720px) {
+  .feuille__voile {
+    align-items: center;
+    padding: var(--espace-6);
+  }
+
+  .feuille {
+    max-width: 520px;
+    max-height: 88vh;
+    border-radius: var(--rayon-carte);
+    padding: var(--espace-6);
+  }
+
+  .feuille__poignee {
+    display: none;
+  }
+
+  /* Au-dessus du point de rupture, les deux actions reprennent l'ordre du document et
+     s'alignent à droite, comme dans le dialogue de confirmation. */
+  .feuille__actions {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+
+  .feuille__fermer {
+    min-width: 32px;
+    min-height: 32px;
+  }
+}

--- a/frontend/src/composants/Feuille.jsx
+++ b/frontend/src/composants/Feuille.jsx
@@ -1,0 +1,121 @@
+import { useEffect, useId, useRef } from 'react';
+import './Feuille.css';
+
+// Conteneur des saisies : feuille glissante en mobile, dialogue centré en desktop.
+//
+// Jamais une page. La saisie se fait par-dessus l'écran d'origine, qui reste visible
+// derrière le voile : c'est ce qui permet de vérifier une valeur pendant qu'on la
+// saisit, et de retrouver son contexte à la fermeture.
+//
+// Le même composant sert les deux points de rupture. Seule la mise en forme change :
+// ancrée en bas et pleine largeur sous 720 px, centrée et bornée en largeur au-dessus.
+// Deux composants distincts auraient fait diverger deux comportements identiques.
+//
+// Accessibilité, mêmes règles que le dialogue de confirmation, dont celui-ci reprend la
+// mécanique : le focus entre à l'ouverture, ne sort plus par la tabulation, revient à
+// son point de départ à la fermeture, et Échap referme.
+//
+// Le focus entre sur le dialogue lui-même et non sur son premier champ : le titre et
+// l'intention de la feuille sont ainsi énoncés avant que la saisie ne commence, et la
+// tabulation suivante atteint le premier contrôle dans l'ordre du document.
+
+// Tout ce qui peut recevoir le focus dans une feuille de saisie. Le dialogue de
+// confirmation se contentait des boutons ; ici, les champs comptent aussi.
+const ATTEIGNABLES =
+  'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), a[href]';
+
+export default function Feuille({
+  titre,
+  children,
+  surFermeture,
+  // Pendant un enregistrement, la feuille ne se referme plus : ni par le bouton, ni
+  // par Échap. Fermer une fenêtre dont la requête est partie laisserait l'utilisateur
+  // sans réponse sur ce qui a été écrit.
+  verrouillee = false,
+}) {
+  const dialogue = useRef(null);
+  const declencheur = useRef(null);
+  const identifiant = useId();
+  const idTitre = `${identifiant}-titre`;
+
+  useEffect(() => {
+    declencheur.current = document.activeElement;
+    dialogue.current?.focus();
+
+    // Le fond ne défile plus tant que la feuille est ouverte : sur mobile, le
+    // défilement se poursuivrait sous la feuille au lieu de la parcourir.
+    const defilementInitial = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = defilementInitial;
+      declencheur.current?.focus?.();
+    };
+  }, []);
+
+  function auClavier(evenement) {
+    if (evenement.key === 'Escape') {
+      evenement.preventDefault();
+      if (!verrouillee) {
+        surFermeture?.();
+      }
+      return;
+    }
+
+    if (evenement.key !== 'Tab') {
+      return;
+    }
+
+    const atteignables = dialogue.current?.querySelectorAll(ATTEIGNABLES);
+    if (!atteignables || atteignables.length === 0) {
+      return;
+    }
+
+    const premier = atteignables[0];
+    const dernier = atteignables[atteignables.length - 1];
+
+    if (evenement.shiftKey && document.activeElement === premier) {
+      evenement.preventDefault();
+      dernier.focus();
+    } else if (!evenement.shiftKey && document.activeElement === dernier) {
+      evenement.preventDefault();
+      premier.focus();
+    }
+  }
+
+  return (
+    // Le voile ne referme pas au clic : une saisie en cours ne doit pas disparaître sur
+    // un clic manqué à côté de la feuille. La sortie explicite reste à un geste, par le
+    // bouton de fermeture ou par Échap.
+    <div className="feuille__voile">
+      <div
+        className="feuille"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={idTitre}
+        tabIndex={-1}
+        ref={dialogue}
+        onKeyDown={auClavier}
+      >
+        <span className="feuille__poignee" aria-hidden="true" />
+
+        <header className="feuille__entete">
+          <h2 id={idTitre} className="feuille__titre">
+            {titre}
+          </h2>
+          <button
+            type="button"
+            className="feuille__fermer"
+            onClick={surFermeture}
+            disabled={verrouillee}
+            aria-label="Fermer"
+          >
+            <span aria-hidden="true">✕</span>
+          </button>
+        </header>
+
+        <div className="feuille__corps">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/composants/FeuilleMouvement.css
+++ b/frontend/src/composants/FeuilleMouvement.css
@@ -1,0 +1,209 @@
+/*
+  Formulaire de saisie d'un mouvement. La mise en forme suit la maquette : bascule de
+  sens en tête, champs par paires, récapitulatif détaché en bas.
+*/
+
+.mouvement {
+  display: flex;
+  flex-direction: column;
+}
+
+.mouvement__sens,
+.mouvement__creation {
+  margin: 0 0 var(--espace-4);
+  padding: 0;
+  border: none;
+}
+
+.mouvement__legende {
+  padding: 0;
+  margin-bottom: var(--espace-1);
+  font-size: var(--taille-legende);
+  font-weight: var(--graisse-forte);
+  color: var(--couleur-texte-attenue);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Bascule achat ou vente. Le choix retenu se distingue par sa couleur, mais aussi par
+   sa graisse et par son fond : la couleur ne porte jamais seule l'information, et un
+   bouton radio coché reste annoncé comme tel quoi qu'il arrive. */
+.mouvement__bascule {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--espace-1);
+  padding: var(--espace-1);
+  background: var(--couleur-fond);
+  border: 1px solid var(--couleur-bordure);
+  border-radius: var(--rayon-carte);
+}
+
+.mouvement__choix {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: var(--espace-2) var(--espace-3);
+  font-size: var(--taille-corps);
+  color: var(--couleur-texte-attenue);
+  border-radius: var(--rayon-carte);
+  cursor: pointer;
+}
+
+.mouvement__choix--actif {
+  font-weight: var(--graisse-forte);
+}
+
+.mouvement__choix--achat.mouvement__choix--actif {
+  color: var(--couleur-positif);
+  background: rgba(52, 199, 123, 0.16);
+}
+
+.mouvement__choix--vente.mouvement__choix--actif {
+  color: var(--couleur-negatif);
+  background: rgba(240, 86, 79, 0.16);
+}
+
+/* Le bouton radio est masqué visuellement, jamais retiré de l'ordre de tabulation :
+   c'est lui qui reçoit le focus, et le libellé qui le montre. */
+.mouvement__choix:focus-within {
+  outline: 2px solid var(--couleur-accent);
+  outline-offset: 2px;
+}
+
+.mouvement__paire {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--espace-3);
+}
+
+/* Sous 360 px, deux champs côte à côte deviennent illisibles : ils s'empilent. */
+@media (max-width: 380px) {
+  .mouvement__paire {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+}
+
+.mouvement__quantite {
+  position: relative;
+}
+
+.mouvement__appoint {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--espace-3);
+  margin-bottom: var(--espace-4);
+}
+
+/* Action secondaire présentée en lien : elle n'entre pas en concurrence visuelle avec
+   l'enregistrement. La zone tactile reste à 44 px de haut (D77). */
+.mouvement__lien {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0;
+  font-family: var(--police);
+  font-size: var(--taille-legende);
+  color: var(--couleur-accent);
+  background: none;
+  border: none;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.mouvement__lien:disabled {
+  color: var(--couleur-texte-attenue);
+  cursor: not-allowed;
+  text-decoration: none;
+}
+
+.mouvement__quantite .mouvement__lien {
+  margin-top: calc(var(--espace-4) * -1);
+  margin-bottom: var(--espace-4);
+}
+
+.mouvement__creation-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--espace-3);
+}
+
+.mouvement__aide {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--espace-1);
+  margin: 0 0 var(--espace-4);
+  padding: var(--espace-3);
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+  background: var(--couleur-fond);
+  border-radius: var(--rayon-carte);
+}
+
+/* Récapitulatif : niveau 2 de contenant, seul fond accentué admis par la palette (D70).
+   C'est le bloc que l'œil doit trouver en dernier, et sur lequel il doit s'arrêter. */
+.mouvement__recapitulatif {
+  padding: var(--espace-3) var(--espace-4);
+  background: var(--couleur-carte-haute);
+  border: 1px solid var(--couleur-bordure);
+  border-radius: var(--rayon-carte);
+}
+
+.mouvement__intitule {
+  margin: 0 0 var(--espace-2);
+  font-size: var(--taille-legende);
+  font-weight: var(--graisse-forte);
+  color: var(--couleur-texte-attenue);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.mouvement__recapitulatif-absent {
+  margin: 0;
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+  line-height: 1.5;
+}
+
+.mouvement__effet {
+  margin: 0;
+}
+
+.mouvement__effet > div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--espace-3);
+  padding: var(--espace-1) 0;
+  font-size: var(--taille-legende);
+}
+
+.mouvement__effet dt {
+  color: var(--couleur-texte-attenue);
+}
+
+.mouvement__effet dd {
+  display: flex;
+  align-items: baseline;
+  gap: var(--espace-2);
+  margin: 0;
+  text-align: right;
+}
+
+.mouvement__effet-total {
+  margin-top: var(--espace-1);
+  padding-top: var(--espace-2);
+  border-top: 1px solid var(--couleur-bordure);
+}
+
+.mouvement__effet-total dt {
+  font-weight: var(--graisse-forte);
+  color: var(--couleur-texte);
+}
+
+.mouvement__inchange {
+  color: var(--couleur-texte-attenue);
+}

--- a/frontend/src/composants/FeuilleMouvement.jsx
+++ b/frontend/src/composants/FeuilleMouvement.jsx
@@ -1,0 +1,721 @@
+import { useEffect, useId, useMemo, useState } from 'react';
+import { useAuthentification } from '../contexte/contexteAuthentification';
+import { api, ErreurApi } from '../services/api';
+import { comparerDecimales, formaterQuantite, CLASSES_QUANTITE } from '../utils/formatage';
+import { LIBELLES_CLASSE } from '../utils/classesActifs';
+import Feuille from './Feuille';
+import Champ from './Champ';
+import Bouton from './Bouton';
+import Montant from './Montant';
+import Variation from './Variation';
+import JetonClasse from './JetonClasse';
+import Message from './Message';
+import './FeuilleMouvement.css';
+
+// Saisie d'un mouvement, achat ou vente.
+//
+// C'est l'écran où se crée la donnée, et le seul de l'application dont le contenu ne
+// soit pas qu'une restitution. Deux principes le gouvernent.
+//
+// Le premier est que l'utilisateur voit l'effet de sa saisie avant de valider : le
+// récapitulatif annonce le montant de l'opération, la quantité qu'il détiendra ensuite,
+// le nouveau prix de revient et son déplacement, et pour une vente la plus-value
+// dégagée. C'est ce qui distingue un outil de suivi de patrimoine d'un formulaire.
+//
+// Le second est que ce récapitulatif n'est pas calculé ici. Le prix de revient est une
+// moyenne pondérée sur toute l'histoire de la position, et une seconde implémentation de
+// cette règle finirait par diverger de celle du moteur (D69). L'interface interroge donc
+// le serveur, qui rejoue le déroulé sans rien écrire, et affiche ce qu'il rend. Les
+// seules opérations faites ici sont des contrôles de forme sur les champs et des
+// comparaisons de quantités, toutes exactes et sans conversion en flottant.
+//
+// La saisie est en euros, devise de référence des calculs et du stockage (D11). La
+// bascule euro-dollar des écrans de restitution ne s'applique pas ici : elle ne change
+// que l'affichage, alors qu'un montant saisi est celui qui sera enregistré.
+
+const SENS = [
+  { code: 'achat', libelle: 'Achat' },
+  { code: 'vente', libelle: 'Vente' },
+];
+
+// Précisions admises par les colonnes NUMERIC du schéma : 8 décimales pour une
+// quantité, 2 pour un montant. Ces contrôles reprennent ceux des schémas Zod du
+// serveur, qui reste seul décisionnaire.
+const MOTIF_QUANTITE = /^\d+(\.\d{1,8})?$/;
+const MOTIF_MONTANT = /^\d+(\.\d{1,2})?$/;
+
+// Délai d'inactivité avant de demander le récapitulatif. Assez court pour que le chiffre
+// suive la frappe, assez long pour ne pas envoyer une requête par caractère.
+const DELAI_RECAPITULATIF = 350;
+
+// Date du jour dans le fuseau de l'utilisateur, au format attendu par un champ de date.
+// L'heure UTC ne conviendrait pas : passé minuit, elle désignerait encore la veille.
+function aujourdhui() {
+  const maintenant = new Date();
+  const decalage = maintenant.getTimezoneOffset() * 60000;
+  return new Date(maintenant.getTime() - decalage).toISOString().slice(0, 10);
+}
+
+// Un champ de date rend un jour, la colonne attend un instant.
+//
+// Le jour courant part avec l'heure courante : l'opération a lieu maintenant. Un jour
+// passé part à midi UTC, et non à minuit, pour que la date relue reste la même quel que
+// soit le fuseau d'affichage. Minuit UTC se relit la veille dès qu'on est à l'ouest de
+// Greenwich, ce qui décalerait la frise des mouvements d'un jour.
+function versHorodatage(jour) {
+  return jour === aujourdhui() ? new Date().toISOString() : `${jour}T12:00:00.000Z`;
+}
+
+// Une saisie décimale peut arriver avec une virgule, des espaces de groupement, ou les
+// deux : c'est ce que produit un clavier français. La normalisation ne juge pas de la
+// validité, elle rend une chaîne comparable au motif.
+function normaliser(valeur) {
+  return String(valeur ?? '')
+    .trim()
+    .replace(/[\s ]/g, '')
+    .replace(',', '.');
+}
+
+function estNul(montant) {
+  return montant === null || montant === undefined || comparerDecimales(montant, '0') === 0;
+}
+
+// Correspondance entre les champs du serveur et ceux du formulaire. Les noms coïncident,
+// mais la table est explicite : une erreur de validation doit se poser sur le champ
+// concerné, jamais dans un bloc en marge du formulaire.
+const CHAMPS_SERVEUR = [
+  'sens',
+  'quantite',
+  'prix_unitaire',
+  'frais',
+  'date_transaction',
+  'type',
+  'symbole',
+  'nom',
+];
+
+function erreursDuServeur(echec) {
+  if (!(echec instanceof ErreurApi) || !Array.isArray(echec.champs)) {
+    return null;
+  }
+
+  const erreurs = {};
+  for (const { champ, message } of echec.champs) {
+    if (CHAMPS_SERVEUR.includes(champ)) {
+      erreurs[champ] = message;
+    }
+  }
+
+  return Object.keys(erreurs).length > 0 ? erreurs : null;
+}
+
+export default function FeuilleMouvement({
+  // Positions déjà valorisées par le serveur, telles que l'écran d'origine les a
+  // reçues : aucune requête n'est refaite pour la liste, et la quantité détenue comme
+  // le cours du jour arrivent avec elles.
+  actifs = [],
+  actifInitialId = null,
+  surFermeture,
+  surEnregistrement,
+}) {
+  const { jeton } = useAuthentification();
+  const identifiant = useId();
+
+  // Actifs créés depuis la feuille, tant que l'écran d'origine n'a pas rechargé sa
+  // liste. Sans eux, l'actif que l'on vient d'ajouter disparaîtrait du sélecteur.
+  const [ajoutes, setAjoutes] = useState([]);
+
+  const catalogue = useMemo(() => {
+    const connus = new Set(actifs.map((position) => String(position.id)));
+    return [...actifs, ...ajoutes.filter((position) => !connus.has(String(position.id)))];
+  }, [actifs, ajoutes]);
+
+  const idInitial = useMemo(() => {
+    const initial = actifs.find((position) => String(position.id) === String(actifInitialId));
+    if (initial) {
+      return String(initial.id);
+    }
+    return actifs.length === 1 ? String(actifs[0].id) : '';
+  }, [actifs, actifInitialId]);
+
+  const [sens, setSens] = useState('achat');
+  const [actifId, setActifId] = useState(idInitial);
+  const [quantite, setQuantite] = useState('');
+  const [prixUnitaire, setPrixUnitaire] = useState(
+    () => actifs.find((position) => String(position.id) === idInitial)?.cours_eur ?? ''
+  );
+  const [date, setDate] = useState(aujourdhui);
+  const [frais, setFrais] = useState('');
+
+  // Un portefeuille vide n'a rien à sélectionner : la feuille s'ouvre alors directement
+  // sur la création, sans quoi le tout premier mouvement serait impossible à saisir.
+  const [creation, setCreation] = useState(actifs.length === 0);
+  const [nouvelActif, setNouvelActif] = useState({ type: 'crypto', symbole: '', nom: '' });
+  const [creationEnCours, setCreationEnCours] = useState(false);
+
+  // Un message d'erreur n'apparaît pas pendant qu'on remplit un champ, mais lorsqu'on
+  // le quitte, ou à la validation : signaler « 0, n'est pas un nombre » à la deuxième
+  // frappe ferait clignoter le formulaire sans rien apprendre.
+  const [quittes, setQuittes] = useState({});
+  const [erreurs, setErreurs] = useState({});
+  const [messageServeur, setMessageServeur] = useState(null);
+  const [envoi, setEnvoi] = useState(false);
+
+  const [recapitulatif, setRecapitulatif] = useState(null);
+  const [recapitulatifEnCours, setRecapitulatifEnCours] = useState(false);
+  const [erreurRecapitulatif, setErreurRecapitulatif] = useState(null);
+
+  const actif = useMemo(
+    () => catalogue.find((position) => String(position.id) === String(actifId)) ?? null,
+    [catalogue, actifId]
+  );
+
+  const quantiteDetenue = actif?.quantite_detenue ?? null;
+
+  // Contrôles de forme, repris de ceux du serveur. Les messages nomment le champ et la
+  // règle : un code d'erreur n'apprendrait rien à qui saisit.
+  const validation = useMemo(() => {
+    const trouvees = {};
+    const quantiteNormalisee = normaliser(quantite);
+    const prixNormalise = normaliser(prixUnitaire);
+    const fraisNormalises = normaliser(frais);
+
+    if (!actifId) {
+      trouvees.actif = "Choisissez l'actif concerné par ce mouvement.";
+    }
+
+    if (quantiteNormalisee === '') {
+      trouvees.quantite = 'La quantité est obligatoire.';
+    } else if (!MOTIF_QUANTITE.test(quantiteNormalisee)) {
+      trouvees.quantite = 'La quantité doit être un nombre positif, avec au plus 8 décimales.';
+    } else if (comparerDecimales(quantiteNormalisee, '0') <= 0) {
+      trouvees.quantite = 'La quantité doit être supérieure à zéro.';
+    }
+
+    if (prixNormalise === '') {
+      trouvees.prix_unitaire = 'Le prix unitaire est obligatoire.';
+    } else if (!MOTIF_MONTANT.test(prixNormalise)) {
+      trouvees.prix_unitaire =
+        'Le prix unitaire doit être un montant positif, avec au plus 2 décimales.';
+    }
+
+    if (fraisNormalises !== '' && !MOTIF_MONTANT.test(fraisNormalises)) {
+      trouvees.frais = 'Les frais doivent être un montant positif ou nul, avec au plus 2 décimales.';
+    }
+
+    if (!date) {
+      trouvees.date_transaction = 'La date est obligatoire.';
+    } else if (date > aujourdhui()) {
+      trouvees.date_transaction = "La date ne peut pas être postérieure à aujourd'hui.";
+    }
+
+    return trouvees;
+  }, [actifId, quantite, prixUnitaire, frais, date]);
+
+  // Bornage de la vente à la quantité réellement détenue.
+  //
+  // La règle appartient au serveur, qui refuse la transaction et dont le message fait
+  // foi : l'interface se contente de l'annoncer avant l'envoi, à partir de la quantité
+  // qu'il a lui-même rendue. Elle est signalée sans attendre que le champ soit quitté,
+  // parce qu'elle annonce un refus et non une faute de frappe.
+  const depassement = useMemo(() => {
+    const quantiteNormalisee = normaliser(quantite);
+
+    if (
+      sens !== 'vente' ||
+      quantiteDetenue === null ||
+      !MOTIF_QUANTITE.test(quantiteNormalisee) ||
+      comparerDecimales(quantiteNormalisee, quantiteDetenue) <= 0
+    ) {
+      return null;
+    }
+
+    return `Vous détenez ${formaterQuantite(quantiteDetenue, actif?.type, actif?.symbole)} : une vente ne peut pas dépasser cette quantité.`;
+  }, [sens, quantite, quantiteDetenue, actif]);
+
+  const complet = Object.keys(validation).length === 0 && !depassement;
+
+  // Corps envoyé au serveur, identique pour la simulation et pour l'enregistrement : les
+  // deux routes partagent le même schéma de validation.
+  const corps = useMemo(
+    () => ({
+      sens,
+      quantite: normaliser(quantite),
+      prix_unitaire: normaliser(prixUnitaire),
+      frais: normaliser(frais) === '' ? '0' : normaliser(frais),
+      date_transaction: versHorodatage(date),
+    }),
+    [sens, quantite, prixUnitaire, frais, date]
+  );
+
+  // Récapitulatif recalculé à chaque modification, après un court délai d'inactivité.
+  //
+  // Seule la réponse la plus récente est retenue : sans le drapeau d'annulation, une
+  // requête partie plus tôt et revenue plus tard écraserait un récapitulatif plus juste.
+  useEffect(() => {
+    if (!complet || !actifId) {
+      setRecapitulatif(null);
+      setErreurRecapitulatif(null);
+      setRecapitulatifEnCours(false);
+      return undefined;
+    }
+
+    let annule = false;
+    setRecapitulatifEnCours(true);
+
+    const minuteur = setTimeout(async () => {
+      try {
+        const effet = await api.simulerTransaction(jeton, actifId, corps);
+        if (!annule) {
+          setRecapitulatif(effet);
+          setErreurRecapitulatif(null);
+        }
+      } catch (echec) {
+        if (!annule) {
+          setRecapitulatif(null);
+          setErreurRecapitulatif(echec.message);
+        }
+      } finally {
+        if (!annule) {
+          setRecapitulatifEnCours(false);
+        }
+      }
+    }, DELAI_RECAPITULATIF);
+
+    return () => {
+      annule = true;
+      clearTimeout(minuteur);
+    };
+  }, [jeton, actifId, complet, corps]);
+
+  // Changer d'actif change de cours : la proposition de prix suit la sélection. Elle
+  // n'est pas posée par un effet, qui la réappliquerait à chaque rafraîchissement de la
+  // liste et effacerait une valeur saisie à la main.
+  function choisirActif(identifiantActif) {
+    setActifId(identifiantActif);
+    setPrixUnitaire(
+      catalogue.find((position) => String(position.id) === String(identifiantActif))?.cours_eur ?? ''
+    );
+  }
+
+  function marquerQuitte(champ) {
+    setQuittes((precedents) => ({ ...precedents, [champ]: true }));
+  }
+
+  // Erreur affichée sous un champ : celle du serveur d'abord, puis le contrôle local
+  // une fois le champ quitté ou la validation tentée.
+  function erreurDe(champ) {
+    return erreurs[champ] ?? (quittes[champ] ? validation[champ] : undefined);
+  }
+
+  async function ajouterActif() {
+    const symbole = nouvelActif.symbole.trim();
+    const nom = nouvelActif.nom.trim();
+
+    if (!symbole || !nom) {
+      setErreurs({
+        symbole: symbole ? undefined : 'Le symbole est obligatoire.',
+        nom: nom ? undefined : 'Le nom est obligatoire.',
+      });
+      return;
+    }
+
+    setCreationEnCours(true);
+    setErreurs({});
+    setMessageServeur(null);
+
+    try {
+      // L'actif est créé avant la saisie du mouvement, et non avec lui : le
+      // récapitulatif interroge le serveur sur une position qui existe, et la règle
+      // « pas de validation sans récapitulatif » vaut alors aussi pour un premier achat.
+      const cree = await api.creerActif(jeton, { type: nouvelActif.type, symbole, nom });
+
+      // La création rend la ligne de la table, sans cours ni quantité : la position
+      // n'existe pas encore. Les deux champs sont posés explicitement pour que le reste
+      // de la feuille les lise comme « aucun cours » et « rien de détenu ».
+      setAjoutes((precedents) => [...precedents, { ...cree, cours_eur: null, quantite_detenue: '0' }]);
+      setActifId(String(cree.id));
+      setPrixUnitaire('');
+      setCreation(false);
+      setNouvelActif({ type: 'crypto', symbole: '', nom: '' });
+    } catch (echec) {
+      const duServeur = erreursDuServeur(echec);
+      if (duServeur) {
+        setErreurs(duServeur);
+      } else if (echec instanceof ErreurApi && echec.statut === 409) {
+        // Le symbole est déjà suivi : l'information appartient au champ qui le porte.
+        setErreurs({ symbole: echec.message });
+      } else {
+        setMessageServeur(echec.message);
+      }
+    } finally {
+      setCreationEnCours(false);
+    }
+  }
+
+  async function soumettre(evenement) {
+    evenement.preventDefault();
+
+    if (!complet) {
+      setQuittes({
+        quantite: true,
+        prix_unitaire: true,
+        frais: true,
+        date_transaction: true,
+      });
+      return;
+    }
+
+    setEnvoi(true);
+    setErreurs({});
+    setMessageServeur(null);
+
+    try {
+      const enregistre = await api.creerTransaction(jeton, actifId, corps);
+
+      // La confirmation est rédigée ici, où le sens, la classe et le symbole sont
+      // connus, et remise à l'écran d'origine qui l'affichera après le rafraîchissement.
+      // La quantité reprise est celle que le serveur a enregistrée, pas celle qui a été
+      // saisie : ce sont les mêmes, et c'est justement ce que la confirmation atteste.
+      const quantiteEnregistree =
+        formaterQuantite(enregistre.quantite, actif?.type, actif?.symbole) ?? enregistre.quantite;
+
+      surEnregistrement?.({
+        transaction: enregistre,
+        actif,
+        sens,
+        resume:
+          sens === 'achat'
+            ? `Achat de ${quantiteEnregistree} enregistré.`
+            : `Vente de ${quantiteEnregistree} enregistrée.`,
+      });
+    } catch (echec) {
+      const duServeur = erreursDuServeur(echec);
+      if (duServeur) {
+        setErreurs(duServeur);
+      } else {
+        // Règle de gestion refusée ou incident : le message du serveur part tel quel,
+        // sans être reformulé ni remplacé par un code.
+        setMessageServeur(echec.message);
+      }
+    } finally {
+      setEnvoi(false);
+    }
+  }
+
+  const verrouille = envoi || creationEnCours;
+
+  return (
+    <Feuille titre="Nouveau mouvement" surFermeture={surFermeture} verrouillee={verrouille}>
+      <form className="mouvement" onSubmit={soumettre} noValidate>
+        {/* Le sens est un groupe de boutons radio et non une paire de boutons : les deux
+            options sont exclusives, et les flèches du clavier doivent passer de l'une à
+            l'autre sans quitter le groupe. */}
+        <fieldset className="mouvement__sens" disabled={verrouille}>
+          <legend className="mouvement__legende">Sens de l'opération</legend>
+          <div className="mouvement__bascule">
+            {SENS.map((option) => (
+              <label
+                key={option.code}
+                className={`mouvement__choix mouvement__choix--${option.code}${
+                  sens === option.code ? ' mouvement__choix--actif' : ''
+                }`}
+              >
+                <input
+                  type="radio"
+                  name={`${identifiant}-sens`}
+                  value={option.code}
+                  checked={sens === option.code}
+                  onChange={() => setSens(option.code)}
+                  className="lecteur-ecran-seulement"
+                />
+                <span>{option.libelle}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        {creation ? (
+          <fieldset className="mouvement__creation" disabled={verrouille}>
+            <legend className="mouvement__legende">Nouvel actif</legend>
+
+            <div className="champ">
+              <label className="champ__label" htmlFor={`${identifiant}-classe`}>
+                Classe
+              </label>
+              <select
+                id={`${identifiant}-classe`}
+                className="champ__saisie"
+                value={nouvelActif.type}
+                onChange={(evenement) =>
+                  setNouvelActif({ ...nouvelActif, type: evenement.target.value })
+                }
+              >
+                {CLASSES_QUANTITE.map((classe) => (
+                  <option key={classe} value={classe}>
+                    {LIBELLES_CLASSE[classe]}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <Champ
+              label="Symbole"
+              valeur={nouvelActif.symbole}
+              onChange={(evenement) =>
+                setNouvelActif({ ...nouvelActif, symbole: evenement.target.value })
+              }
+              erreur={erreurs.symbole}
+              aide="Le code du marché, par exemple BTC, XAU ou USD."
+              obligatoire
+              maxLength={20}
+              autoComplete="off"
+            />
+
+            <Champ
+              label="Nom"
+              valeur={nouvelActif.nom}
+              onChange={(evenement) =>
+                setNouvelActif({ ...nouvelActif, nom: evenement.target.value })
+              }
+              erreur={erreurs.nom}
+              obligatoire
+              maxLength={100}
+              autoComplete="off"
+            />
+
+            <div className="mouvement__creation-actions">
+              {catalogue.length > 0 && (
+                <Bouton variante="secondaire" onClick={() => setCreation(false)}>
+                  Revenir à la liste
+                </Bouton>
+              )}
+              <Bouton onClick={ajouterActif} enCours={creationEnCours}>
+                Ajouter cet actif
+              </Bouton>
+            </div>
+          </fieldset>
+        ) : (
+          <div className="champ">
+            <label className="champ__label" htmlFor={`${identifiant}-actif`}>
+              Actif
+              <span className="champ__obligatoire" aria-hidden="true">
+                {' '}
+                *
+              </span>
+              <span className="lecteur-ecran-seulement"> (obligatoire)</span>
+            </label>
+            <select
+              id={`${identifiant}-actif`}
+              className={`champ__saisie${erreurs.actif ? ' champ__saisie--erreur' : ''}`}
+              value={actifId}
+              onChange={(evenement) => choisirActif(evenement.target.value)}
+              disabled={verrouille}
+              aria-invalid={erreurs.actif ? 'true' : undefined}
+            >
+              <option value="">Choisir un actif</option>
+              {catalogue.map((position) => (
+                <option key={position.id} value={position.id}>
+                  {position.nom} — {position.symbole} ({LIBELLES_CLASSE[position.type]})
+                </option>
+              ))}
+            </select>
+
+            <div className="mouvement__appoint">
+              {actif && <JetonClasse classe={actif.type} avecLibelle />}
+              <button
+                type="button"
+                className="mouvement__lien"
+                onClick={() => setCreation(true)}
+                disabled={verrouille}
+              >
+                Suivre un nouvel actif
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div className="mouvement__paire">
+          <div className="mouvement__quantite">
+            <Champ
+              label="Quantité"
+              valeur={quantite}
+              onChange={(evenement) => setQuantite(evenement.target.value)}
+              onBlur={() => marquerQuitte('quantite')}
+              erreur={depassement ?? erreurDe('quantite')}
+              obligatoire
+              inputMode="decimal"
+              autoComplete="off"
+              disabled={verrouille}
+            />
+            {/* Raccourci de vente totale : il évite de recopier à la main une quantité à
+                huit décimales, et garantit que la valeur envoyée est exactement celle que
+                le serveur a rendue. */}
+            {sens === 'vente' && quantiteDetenue !== null && !estNul(quantiteDetenue) && (
+              <button
+                type="button"
+                className="mouvement__lien"
+                onClick={() => setQuantite(quantiteDetenue)}
+                disabled={verrouille}
+              >
+                Tout vendre
+              </button>
+            )}
+          </div>
+
+          <Champ
+            label="Prix unitaire (€)"
+            valeur={prixUnitaire}
+            onChange={(evenement) => setPrixUnitaire(evenement.target.value)}
+            onBlur={() => marquerQuitte('prix_unitaire')}
+            erreur={erreurDe('prix_unitaire')}
+            obligatoire
+            inputMode="decimal"
+            autoComplete="off"
+            disabled={verrouille}
+          />
+        </div>
+
+        {/* Le cours du jour est une proposition et non une contrainte : le dire évite de
+            laisser croire que la valeur affichée est celle de l'opération passée que l'on
+            est en train de saisir. */}
+        {actif && (
+          <p className="mouvement__aide">
+            {actif.cours_eur ? (
+              <>
+                <span aria-hidden="true">ⓘ </span>
+                Cours du jour : <Montant valeur={actif.cours_eur} type="cours" />. Conservez-le pour
+                une opération du moment, corrigez-le pour une opération passée.
+              </>
+            ) : (
+              <>
+                <span aria-hidden="true">◐ </span>
+                Aucun cours n'est disponible pour {actif.symbole} : le prix unitaire n'a pas été
+                pré-rempli, saisissez celui de votre opération.
+              </>
+            )}
+          </p>
+        )}
+
+        <div className="mouvement__paire">
+          <Champ
+            label="Date de l'opération"
+            type="date"
+            valeur={date}
+            onChange={(evenement) => setDate(evenement.target.value)}
+            onBlur={() => marquerQuitte('date_transaction')}
+            erreur={erreurDe('date_transaction')}
+            obligatoire
+            max={aujourdhui()}
+            disabled={verrouille}
+          />
+
+          <Champ
+            label="Frais (€)"
+            valeur={frais}
+            onChange={(evenement) => setFrais(evenement.target.value)}
+            onBlur={() => marquerQuitte('frais')}
+            erreur={erreurDe('frais')}
+            aide="Facultatif. Les frais d'achat entrent dans le prix de revient."
+            inputMode="decimal"
+            autoComplete="off"
+            disabled={verrouille}
+          />
+        </div>
+
+        {/* Le récapitulatif est une région vivante : ses recalculs sont annoncés sans
+            interrompre la saisie en cours. */}
+        <section
+          className="mouvement__recapitulatif"
+          aria-live="polite"
+          aria-busy={recapitulatifEnCours || undefined}
+          aria-labelledby={`${identifiant}-recapitulatif`}
+        >
+          <h3 id={`${identifiant}-recapitulatif`} className="mouvement__intitule">
+            Effet de ce mouvement
+          </h3>
+
+          {erreurRecapitulatif ? (
+            <p className="mouvement__recapitulatif-absent">
+              L'effet de ce mouvement ne peut pas être calculé : {erreurRecapitulatif}
+            </p>
+          ) : recapitulatif ? (
+            <dl className="mouvement__effet">
+              <div>
+                <dt>Montant de l'opération</dt>
+                <dd>
+                  <Montant valeur={recapitulatif.montant} />
+                </dd>
+              </div>
+
+              {!estNul(recapitulatif.frais) && (
+                <div>
+                  <dt>Frais</dt>
+                  <dd>
+                    <Montant valeur={recapitulatif.frais} />
+                  </dd>
+                </div>
+              )}
+
+              <div>
+                <dt>Quantité détenue après</dt>
+                <dd>
+                  <Montant
+                    valeur={recapitulatif.quantite_detenue_apres}
+                    type="quantite"
+                    classe={actif?.type}
+                    symbole={actif?.symbole}
+                  />
+                </dd>
+              </div>
+
+              {recapitulatif.plus_value_realisee !== null && (
+                <div>
+                  <dt>Plus-value réalisée</dt>
+                  <dd>
+                    <Variation valeur={recapitulatif.plus_value_realisee} mode="absolue" />
+                  </dd>
+                </div>
+              )}
+
+              <div className="mouvement__effet-total">
+                <dt>Nouveau prix de revient</dt>
+                <dd>
+                  <Montant valeur={recapitulatif.pru_apres} type="cours" />
+                  {/* Une vente ne déplace pas le prix de revient : le dire vaut mieux
+                      qu'afficher « +0,00 », que l'utilisateur aurait à interpréter. */}
+                  {estNul(recapitulatif.effet_pru) ? (
+                    <span className="mouvement__inchange">inchangé</span>
+                  ) : (
+                    <Variation valeur={recapitulatif.effet_pru} mode="absolue" />
+                  )}
+                </dd>
+              </div>
+            </dl>
+          ) : recapitulatifEnCours ? (
+            <p className="mouvement__recapitulatif-absent">Calcul en cours…</p>
+          ) : (
+            <p className="mouvement__recapitulatif-absent">
+              Choisissez un actif, une quantité et un prix unitaire pour voir l'effet de ce
+              mouvement sur votre position.
+            </p>
+          )}
+        </section>
+
+        {messageServeur && <Message variante="erreur">{messageServeur}</Message>}
+
+        <div className="feuille__actions">
+          <Bouton variante="secondaire" onClick={surFermeture} desactive={verrouille}>
+            Annuler
+          </Bouton>
+          {/* La validation reste bloquée tant que l'effet du mouvement n'a pas pu être
+              calculé : enregistrer sans l'avoir vu retirerait à cet écran sa raison
+              d'être, et signifierait que le serveur n'a pas accepté la saisie. */}
+          <Bouton type="submit" enCours={envoi} desactive={!recapitulatif || verrouille}>
+            Enregistrer
+          </Bouton>
+        </div>
+      </form>
+    </Feuille>
+  );
+}

--- a/frontend/src/composants/__tests__/FeuilleMouvement.test.jsx
+++ b/frontend/src/composants/__tests__/FeuilleMouvement.test.jsx
@@ -1,0 +1,451 @@
+import { useState } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FeuilleMouvement from '../FeuilleMouvement';
+import * as contexte from '../../contexte/contexteAuthentification';
+import { api, ErreurApi } from '../../services/api';
+
+// La feuille de saisie est testée sur ce qui se casse en silence : le récapitulatif, qui
+// doit venir du serveur et non d'un calcul refait ici, le bornement de la vente, le
+// blocage de la validation, et le comportement de dialogue modal.
+//
+// Les réponses simulées reproduisent la forme exacte de celles du serveur, chaînes
+// comprises : une valeur inventée validerait un affichage faux.
+
+const POSITIONS = [
+  {
+    id: 1,
+    type: 'crypto',
+    symbole: 'BTC',
+    nom: 'Bitcoin',
+    cours_eur: '60801.20',
+    source_cours: 'coinbase',
+    quantite_detenue: '0.6',
+    pru: '56656.25',
+  },
+  {
+    id: 4,
+    type: 'metal',
+    symbole: 'XAU',
+    nom: 'Or',
+    cours_eur: '88.45',
+    source_cours: 'gold-api',
+    quantite_detenue: '120',
+    pru: '74.10',
+  },
+];
+
+const EFFET_ACHAT = {
+  sens: 'achat',
+  montant: '11780.00',
+  frais: '2.40',
+  quantite_detenue_avant: '0.6',
+  quantite_detenue_apres: '0.8',
+  pru_avant: '56656.25',
+  pru_apres: '57107.4',
+  effet_pru: '451.15',
+  plus_value_realisee: null,
+  cout_total_apres: '45685.92',
+};
+
+const EFFET_VENTE = {
+  sens: 'vente',
+  montant: '12700.00',
+  frais: '0',
+  quantite_detenue_avant: '0.6',
+  quantite_detenue_apres: '0.4',
+  pru_avant: '56656.25',
+  pru_apres: '56656.25',
+  effet_pru: '0',
+  plus_value_realisee: '1368.75',
+  cout_total_apres: '22662.50',
+};
+
+// La feuille est montée par un déclencheur, comme dans l'application : c'est la seule
+// façon de vérifier que le focus lui revient à la fermeture.
+function Harnais({ actifs = POSITIONS, surEnregistrement = () => {} }) {
+  const [ouverte, setOuverte] = useState(false);
+
+  return (
+    <>
+      <button type="button" onClick={() => setOuverte(true)}>
+        Nouveau mouvement
+      </button>
+      {ouverte && (
+        <FeuilleMouvement
+          actifs={actifs}
+          surFermeture={() => setOuverte(false)}
+          surEnregistrement={surEnregistrement}
+        />
+      )}
+    </>
+  );
+}
+
+async function ouvrir(proprietes) {
+  const utilisateur = userEvent.setup();
+  render(<Harnais {...proprietes} />);
+  await utilisateur.click(screen.getByRole('button', { name: 'Nouveau mouvement' }));
+  return utilisateur;
+}
+
+// Saisie complète d'un achat sur le bitcoin, jusqu'à l'apparition du récapitulatif.
+async function saisirAchat(utilisateur, { quantite = '0.2', prix = '58900', frais = '2.40' } = {}) {
+  await utilisateur.selectOptions(screen.getByLabelText(/^Actif/), '1');
+  await utilisateur.type(screen.getByLabelText(/^Quantité/), quantite);
+  await utilisateur.clear(screen.getByLabelText(/^Prix unitaire/));
+  await utilisateur.type(screen.getByLabelText(/^Prix unitaire/), prix);
+  await utilisateur.type(screen.getByLabelText(/^Frais/), frais);
+}
+
+beforeEach(() => {
+  vi.spyOn(contexte, 'useAuthentification').mockReturnValue({
+    jeton: 'jeton-de-test',
+    utilisateur: { pseudo: 'Camille' },
+    estConnecte: true,
+  });
+  vi.spyOn(api, 'simulerTransaction').mockResolvedValue(EFFET_ACHAT);
+  vi.spyOn(api, 'creerTransaction').mockResolvedValue({
+    id: 42,
+    actif_id: 1,
+    sens: 'achat',
+    quantite: '0.20000000',
+    prix_unitaire: '58900.00',
+    frais: '2.40',
+    date_transaction: '2026-08-25T10:00:00.000Z',
+    note: null,
+  });
+  vi.spyOn(api, 'creerActif').mockResolvedValue({
+    id: 9,
+    utilisateur_id: 2,
+    type: 'crypto',
+    symbole: 'SOL',
+    nom: 'Solana',
+    date_ajout: '2026-08-25T10:00:00.000Z',
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('forme et accessibilité', () => {
+  it('est un dialogue modal intitulé', async () => {
+    await ouvrir();
+
+    const dialogue = screen.getByRole('dialog');
+    expect(dialogue.getAttribute('aria-modal')).toBe('true');
+    expect(within(dialogue).getByRole('heading', { name: 'Nouveau mouvement' })).toBeTruthy();
+  });
+
+  it('place le focus dans la feuille à son ouverture', async () => {
+    await ouvrir();
+
+    expect(screen.getByRole('dialog').contains(document.activeElement)).toBe(true);
+  });
+
+  it('se ferme par Échap et rend le focus à son déclencheur', async () => {
+    const utilisateur = await ouvrir();
+
+    await utilisateur.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', { name: 'Nouveau mouvement' })
+    );
+  });
+
+  it('se ferme par le bouton de fermeture', async () => {
+    const utilisateur = await ouvrir();
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Fermer' }));
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  // Le sens est un groupe de boutons radio et non une paire de boutons : les flèches du
+  // clavier doivent passer d'une option à l'autre.
+  it('présente le sens en boutons radio, achat par défaut', async () => {
+    const utilisateur = await ouvrir();
+
+    const achat = screen.getByRole('radio', { name: 'Achat' });
+    const vente = screen.getByRole('radio', { name: 'Vente' });
+    expect(achat.checked).toBe(true);
+
+    achat.focus();
+    await utilisateur.keyboard('{ArrowRight}');
+    expect(vente.checked).toBe(true);
+  });
+
+  it('annonce les recalculs du récapitulatif sans interrompre la saisie', async () => {
+    await ouvrir();
+
+    const region = screen.getByRole('region', { name: /Effet de ce mouvement/ });
+    expect(region.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('déclare les champs numériques en saisie décimale', async () => {
+    await ouvrir();
+
+    expect(screen.getByLabelText(/^Quantité/).getAttribute('inputmode')).toBe('decimal');
+    expect(screen.getByLabelText(/^Prix unitaire/).getAttribute('inputmode')).toBe('decimal');
+  });
+});
+
+describe('récapitulatif', () => {
+  it("demande l'effet du mouvement au serveur plutôt que de le calculer", async () => {
+    const utilisateur = await ouvrir();
+    await saisirAchat(utilisateur);
+
+    await waitFor(() =>
+      expect(api.simulerTransaction).toHaveBeenCalledWith(
+        'jeton-de-test',
+        '1',
+        expect.objectContaining({
+          sens: 'achat',
+          quantite: '0.2',
+          prix_unitaire: '58900',
+          frais: '2.40',
+        })
+      )
+    );
+  });
+
+  it('affiche le nouveau prix de revient et son déplacement', async () => {
+    const utilisateur = await ouvrir();
+    await saisirAchat(utilisateur);
+
+    expect(await screen.findByText(/57\s?107,4/)).toBeTruthy();
+    expect(screen.getByText(/\+451,15/)).toBeTruthy();
+    expect(screen.getByText(/11\s?780/)).toBeTruthy();
+  });
+
+  it('nomme la plus-value dégagée par une vente et dit le prix de revient inchangé', async () => {
+    api.simulerTransaction.mockResolvedValue(EFFET_VENTE);
+    const utilisateur = await ouvrir();
+
+    await utilisateur.click(screen.getByRole('radio', { name: 'Vente' }));
+    await utilisateur.selectOptions(screen.getByLabelText(/^Actif/), '1');
+    await utilisateur.type(screen.getByLabelText(/^Quantité/), '0.2');
+
+    expect(await screen.findByText('Plus-value réalisée')).toBeTruthy();
+    expect(screen.getByText('inchangé')).toBeTruthy();
+  });
+
+  // Le prix unitaire est pré-rempli au cours du jour, avec une mention explicite : sans
+  // elle, la valeur proposée se lirait comme le prix de l'opération saisie.
+  it('propose le cours du jour et le dit', async () => {
+    const utilisateur = await ouvrir();
+
+    await utilisateur.selectOptions(screen.getByLabelText(/^Actif/), '1');
+
+    expect(screen.getByLabelText(/^Prix unitaire/).value).toBe('60801.20');
+    expect(screen.getByText(/Cours du jour/)).toBeTruthy();
+  });
+
+  it("explique l'absence de récapitulatif tant que la saisie est incomplète", async () => {
+    await ouvrir();
+
+    expect(screen.getByText(/pour voir l'effet de ce mouvement/)).toBeTruthy();
+    expect(api.simulerTransaction).not.toHaveBeenCalled();
+  });
+
+  it('signale un récapitulatif refusé par le serveur sans inventer de chiffres', async () => {
+    api.simulerTransaction.mockRejectedValue(
+      new ErreurApi('Quantité insuffisante : vous détenez 0.6 sur cet actif.', 400)
+    );
+    const utilisateur = await ouvrir();
+    await saisirAchat(utilisateur);
+
+    expect(await screen.findByText(/ne peut pas être calculé/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Enregistrer' }).disabled).toBe(true);
+  });
+});
+
+describe('validation', () => {
+  it("bloque l'enregistrement tant que l'effet du mouvement n'est pas connu", async () => {
+    await ouvrir();
+
+    expect(screen.getByRole('button', { name: 'Enregistrer' }).disabled).toBe(true);
+  });
+
+  it('refuse une quantité qui n\'est pas un nombre', async () => {
+    const utilisateur = await ouvrir();
+
+    await utilisateur.selectOptions(screen.getByLabelText(/^Actif/), '1');
+    await utilisateur.type(screen.getByLabelText(/^Quantité/), 'beaucoup');
+    await utilisateur.tab();
+
+    expect(screen.getByText(/La quantité doit être un nombre positif/)).toBeTruthy();
+    expect(api.simulerTransaction).not.toHaveBeenCalled();
+  });
+
+  it('refuse une quantité nulle', async () => {
+    const utilisateur = await ouvrir();
+
+    await utilisateur.selectOptions(screen.getByLabelText(/^Actif/), '1');
+    await utilisateur.type(screen.getByLabelText(/^Quantité/), '0');
+    await utilisateur.tab();
+
+    expect(screen.getByText('La quantité doit être supérieure à zéro.')).toBeTruthy();
+  });
+
+  it("interdit une date postérieure à aujourd'hui", async () => {
+    const utilisateur = await ouvrir();
+
+    const date = screen.getByLabelText(/^Date/);
+    // Le champ est borné au jour même, et pré-rempli à cette date.
+    expect(date.getAttribute('max')).toBe(date.value);
+
+    await utilisateur.clear(date);
+    await utilisateur.type(date, '2030-01-01');
+    await utilisateur.tab();
+
+    expect(screen.getByText(/ne peut pas être postérieure/)).toBeTruthy();
+  });
+
+  // La règle appartient au serveur ; l'interface l'annonce avant l'envoi, avec la
+  // quantité que le serveur a rendue.
+  it('borne la vente à la quantité détenue', async () => {
+    const utilisateur = await ouvrir();
+
+    await utilisateur.click(screen.getByRole('radio', { name: 'Vente' }));
+    await utilisateur.selectOptions(screen.getByLabelText(/^Actif/), '1');
+    await utilisateur.type(screen.getByLabelText(/^Quantité/), '0.9');
+
+    expect(screen.getByText(/Vous détenez 0,6 BTC/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Enregistrer' }).disabled).toBe(true);
+    expect(api.simulerTransaction).not.toHaveBeenCalled();
+  });
+
+  it('remplit la quantité exacte détenue par le raccourci de vente totale', async () => {
+    const utilisateur = await ouvrir();
+
+    await utilisateur.click(screen.getByRole('radio', { name: 'Vente' }));
+    await utilisateur.selectOptions(screen.getByLabelText(/^Actif/), '1');
+    await utilisateur.click(screen.getByRole('button', { name: 'Tout vendre' }));
+
+    expect(screen.getByLabelText(/^Quantité/).value).toBe('0.6');
+  });
+
+  it('accepte une quantité saisie avec une virgule', async () => {
+    const utilisateur = await ouvrir();
+
+    await utilisateur.selectOptions(screen.getByLabelText(/^Actif/), '1');
+    await utilisateur.type(screen.getByLabelText(/^Quantité/), '0,2');
+
+    await waitFor(() =>
+      expect(api.simulerTransaction).toHaveBeenCalledWith(
+        'jeton-de-test',
+        '1',
+        expect.objectContaining({ quantite: '0.2' })
+      )
+    );
+  });
+});
+
+describe('enregistrement', () => {
+  it('envoie le mouvement puis rend la main à l\'écran d\'origine', async () => {
+    const surEnregistrement = vi.fn();
+    const utilisateur = await ouvrir({ surEnregistrement });
+    await saisirAchat(utilisateur);
+    await screen.findByText(/57\s?107,4/);
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Enregistrer' }));
+
+    expect(api.creerTransaction).toHaveBeenCalledWith(
+      'jeton-de-test',
+      '1',
+      expect.objectContaining({ sens: 'achat', quantite: '0.2', prix_unitaire: '58900' })
+    );
+    await waitFor(() => expect(surEnregistrement).toHaveBeenCalled());
+    // L'espace qui précède le symbole est une espace insécable, posée par le module de
+    // formatage : le motif ne présume pas de sa nature.
+    expect(surEnregistrement.mock.calls[0][0].resume).toMatch(/Achat de 0,2\sBTC enregistré/);
+  });
+
+  // Les messages de validation du serveur se posent sur les champs concernés, jamais en
+  // bloc au-dessus du formulaire.
+  it('replace les erreurs de validation du serveur sur leurs champs', async () => {
+    api.creerTransaction.mockRejectedValue(
+      new ErreurApi('Données invalides.', 400, [
+        { champ: 'quantite', message: 'La valeur doit être strictement positive.' },
+      ])
+    );
+    const utilisateur = await ouvrir();
+    await saisirAchat(utilisateur);
+    await screen.findByText(/57\s?107,4/);
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Enregistrer' }));
+
+    expect(
+      await screen.findByText('La valeur doit être strictement positive.')
+    ).toBeTruthy();
+  });
+
+  it('affiche le message du serveur lorsqu\'aucun champ n\'est nommé', async () => {
+    api.creerTransaction.mockRejectedValue(
+      new ErreurApi('Quantité insuffisante : vous détenez 0.6 sur cet actif.', 400)
+    );
+    const utilisateur = await ouvrir();
+    await saisirAchat(utilisateur);
+    await screen.findByText(/57\s?107,4/);
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Enregistrer' }));
+
+    expect(await screen.findByText(/Quantité insuffisante/)).toBeTruthy();
+  });
+
+  it('reste ouverte et ne prévient pas l\'écran d\'origine quand l\'envoi échoue', async () => {
+    const surEnregistrement = vi.fn();
+    api.creerTransaction.mockRejectedValue(new ErreurApi('Le serveur est injoignable.', 0));
+    const utilisateur = await ouvrir({ surEnregistrement });
+    await saisirAchat(utilisateur);
+    await screen.findByText(/57\s?107,4/);
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Enregistrer' }));
+
+    expect(await screen.findByText(/injoignable/)).toBeTruthy();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(surEnregistrement).not.toHaveBeenCalled();
+  });
+});
+
+describe('portefeuille vide', () => {
+  // Sans création possible ici, un compte neuf ne pourrait enregistrer aucun mouvement :
+  // le sélecteur serait vide et le parcours de premier lancement s'arrêterait là.
+  it('ouvre directement sur la création lorsque aucun actif n\'est suivi', async () => {
+    await ouvrir({ actifs: [] });
+
+    expect(screen.queryByLabelText(/^Actif/)).toBeNull();
+    expect(screen.getByRole('button', { name: 'Ajouter cet actif' })).toBeTruthy();
+  });
+
+  it('crée l\'actif puis le sélectionne pour la saisie', async () => {
+    const utilisateur = await ouvrir({ actifs: [] });
+
+    await utilisateur.type(screen.getByLabelText(/^Symbole/), 'SOL');
+    await utilisateur.type(screen.getByLabelText(/^Nom/), 'Solana');
+    await utilisateur.click(screen.getByRole('button', { name: 'Ajouter cet actif' }));
+
+    expect(api.creerActif).toHaveBeenCalledWith('jeton-de-test', {
+      type: 'crypto',
+      symbole: 'SOL',
+      nom: 'Solana',
+    });
+    expect((await screen.findByLabelText(/^Actif/)).value).toBe('9');
+  });
+
+  it('signale un symbole déjà suivi sur le champ qui le porte', async () => {
+    api.creerActif.mockRejectedValue(new ErreurApi('Le symbole SOL est déjà suivi.', 409));
+    const utilisateur = await ouvrir({ actifs: [] });
+
+    await utilisateur.type(screen.getByLabelText(/^Symbole/), 'SOL');
+    await utilisateur.type(screen.getByLabelText(/^Nom/), 'Solana');
+    await utilisateur.click(screen.getByRole('button', { name: 'Ajouter cet actif' }));
+
+    expect(await screen.findByText(/déjà suivi/)).toBeTruthy();
+  });
+});

--- a/frontend/src/hooks/useMouvement.js
+++ b/frontend/src/hooks/useMouvement.js
@@ -1,0 +1,49 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+// Ouverture de la feuille de saisie d'un mouvement, portée par l'adresse de l'écran
+// d'origine.
+//
+// La saisie n'est pas une page : elle se superpose à l'écran d'où elle est demandée, qui
+// reste visible derrière elle. Elle ne peut donc pas avoir de route à elle. Mais elle ne
+// peut pas non plus n'être qu'un état de composant : un rechargement la ferait
+// disparaître, et l'adresse ne décrirait plus ce qui est affiché.
+//
+// Un paramètre de requête répond aux deux : `?mouvement=nouveau` ouvre la feuille sans
+// actif présélectionné, `?mouvement=12` l'ouvre sur la position 12. C'est la même
+// convention que les filtres et le tri de l'écran des positions.
+//
+// L'ouverture et la fermeture remplacent l'entrée d'historique au lieu d'en empiler une
+// nouvelle : le bouton de retour du navigateur quitte alors l'écran, comme on l'attend,
+// plutôt que de rejouer l'ouverture et la fermeture de la feuille.
+
+export const PARAMETRE_MOUVEMENT = 'mouvement';
+export const MOUVEMENT_NOUVEAU = 'nouveau';
+
+export function useMouvement() {
+  const [parametres, setParametres] = useSearchParams();
+  const ouvert = parametres.get(PARAMETRE_MOUVEMENT);
+
+  const ouvrir = useCallback(
+    (actifId) => {
+      const suivants = new URLSearchParams(parametres);
+      suivants.set(PARAMETRE_MOUVEMENT, actifId ? String(actifId) : MOUVEMENT_NOUVEAU);
+      setParametres(suivants, { replace: true });
+    },
+    [parametres, setParametres]
+  );
+
+  const fermer = useCallback(() => {
+    const suivants = new URLSearchParams(parametres);
+    suivants.delete(PARAMETRE_MOUVEMENT);
+    setParametres(suivants, { replace: true });
+  }, [parametres, setParametres]);
+
+  return {
+    ouvert: ouvert !== null,
+    // Un identifiant d'actif, ou null lorsque la feuille s'ouvre sans présélection.
+    actifInitialId: ouvert === MOUVEMENT_NOUVEAU ? null : ouvert,
+    ouvrir,
+    fermer,
+  };
+}

--- a/frontend/src/pages/DetailPosition.jsx
+++ b/frontend/src/pages/DetailPosition.jsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useAuthentification } from '../contexte/contexteAuthentification';
+import { useMouvement } from '../hooks/useMouvement';
 import { api, ErreurApi } from '../services/api';
 import { convertir } from '../utils/conversion';
 import { sensVariation } from '../utils/formatage';
@@ -15,6 +16,7 @@ import SelecteurPeriode from '../composants/SelecteurPeriode';
 import FriseMouvements from '../composants/FriseMouvements';
 import BarreProgression from '../composants/BarreProgression';
 import Confirmation from '../composants/Confirmation';
+import FeuilleMouvement from '../composants/FeuilleMouvement';
 import Bouton from '../composants/Bouton';
 import Squelette from '../composants/Squelette';
 import MessageErreur from '../composants/MessageErreur';
@@ -83,6 +85,9 @@ export default function DetailPosition() {
   const [periode, setPeriode] = useState(PERIODE_PAR_DEFAUT);
   const [aSupprimer, setASupprimer] = useState(null);
   const [suppressionEnCours, setSuppressionEnCours] = useState(false);
+  const [confirmation, setConfirmation] = useState(null);
+
+  const mouvement = useMouvement();
 
   const [devise, setDevise] = useState(() => lirePreference(CLE_DEVISE, 'EUR'));
   const [masque, setMasque] = useState(() => lirePreference(CLE_MASQUAGE, 'non') === 'oui');
@@ -279,6 +284,8 @@ export default function DetailPosition() {
         <MessageErreur nature={natureDeLErreur(erreur)} surAction={charger} />
       )}
 
+      {confirmation && <Message>{confirmation}</Message>}
+
       {sansCours && (
         <Message variante="avertissement">
           Aucun cours disponible pour {position.symbole} : cette position n'est pas valorisée.
@@ -448,7 +455,9 @@ export default function DetailPosition() {
       </Carte>
 
       <div className="detail__actions">
-        <Bouton variante="secondaire" onClick={() => naviguer('/mouvement')}>
+        {/* La feuille s'ouvre déjà réglée sur cette position : elle est la seule que
+            l'écran connaisse, et le sélecteur n'aurait rien d'autre à proposer. */}
+        <Bouton variante="secondaire" onClick={() => mouvement.ouvrir(position.id)}>
           Nouveau mouvement
         </Bouton>
         <Bouton variante="danger" onClick={() => setASupprimer({ type: 'position' })}>
@@ -481,6 +490,23 @@ export default function DetailPosition() {
           enCours={suppressionEnCours}
           surConfirmation={confirmerSuppression}
           surAnnulation={() => setASupprimer(null)}
+        />
+      )}
+
+      {/* L'écran de détail ne connaît qu'une position : la feuille reçoit celle-ci et
+          elle seule, avec son cours et sa quantité détenue, sans requête de plus. Les
+          montants transmis sont ceux du serveur, en euros, et non ceux convertis pour
+          l'affichage : la saisie se fait dans la devise de référence. */}
+      {mouvement.ouvert && (
+        <FeuilleMouvement
+          actifs={[position]}
+          actifInitialId={position.id}
+          surFermeture={mouvement.fermer}
+          surEnregistrement={({ resume }) => {
+            mouvement.fermer();
+            setConfirmation(resume);
+            charger();
+          }}
         />
       )}
     </div>

--- a/frontend/src/pages/Patrimoine.jsx
+++ b/frontend/src/pages/Patrimoine.jsx
@@ -1,10 +1,13 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuthentification } from '../contexte/contexteAuthentification';
+import { useMouvement } from '../hooks/useMouvement';
 import { api, ErreurApi } from '../services/api';
 import { convertir } from '../utils/conversion';
 import { sensVariation } from '../utils/formatage';
+import Bouton from '../composants/Bouton';
 import Carte from '../composants/Carte';
+import FeuilleMouvement from '../composants/FeuilleMouvement';
 import Montant from '../composants/Montant';
 import Variation from '../composants/Variation';
 import SelecteurPeriode from '../composants/SelecteurPeriode';
@@ -72,6 +75,9 @@ export default function Patrimoine() {
   const [periode, setPeriode] = useState(PERIODE_PAR_DEFAUT);
   const [erreur, setErreur] = useState(null);
   const [chargement, setChargement] = useState(true);
+  const [confirmation, setConfirmation] = useState(null);
+
+  const mouvement = useMouvement();
 
   const [devise, setDevise] = useState(() => lirePreference(CLE_DEVISE, 'EUR'));
   const [masque, setMasque] = useState(() => lirePreference(CLE_MASQUAGE, 'non') === 'oui');
@@ -135,8 +141,27 @@ export default function Patrimoine() {
   const sansCours = portefeuille?.cours_indisponibles ?? [];
   const seuilsFranchis = portefeuille?.alertes_declenchees ?? [];
 
+  // Le mouvement enregistré change le patrimoine, le prix de revient et les plus-values :
+  // c'est le serveur qui les recalcule, l'écran se recharge plutôt que d'ajuster ses
+  // chiffres de son côté.
+  function apresEnregistrement({ resume }) {
+    mouvement.fermer();
+    setConfirmation(resume);
+    charger(periode);
+  }
+
+  const feuille = mouvement.ouvert && (
+    <FeuilleMouvement
+      actifs={portefeuille?.actifs ?? []}
+      actifInitialId={mouvement.actifInitialId}
+      surFermeture={mouvement.fermer}
+      surEnregistrement={apresEnregistrement}
+    />
+  );
+
   const outils = (
     <div className="patrimoine__outils">
+      <Bouton onClick={() => mouvement.ouvrir()}>+ Mouvement</Bouton>
       <BasculeDevise
         devise={devise}
         indisponible={!taux}
@@ -219,8 +244,9 @@ export default function Patrimoine() {
               : "Votre portefeuille ne contient aucune position. Enregistrez un achat pour voir apparaître votre patrimoine et son évolution."
           }
           libelleAction="Ajouter votre première position"
-          surAction={() => naviguer('/mouvement')}
+          surAction={() => mouvement.ouvrir()}
         />
+        {feuille}
       </div>
     );
   }
@@ -243,6 +269,10 @@ export default function Patrimoine() {
           className="patrimoine__incident"
         />
       )}
+
+      {/* Confirmation brève après un enregistrement. Elle n'est pas une alerte : elle
+          confirme ce qui vient d'être demandé, sans interrompre. */}
+      {confirmation && <Message>{confirmation}</Message>}
 
       {enRepli.length > 0 && (
         <Message variante="avertissement">
@@ -385,6 +415,8 @@ export default function Patrimoine() {
           </ul>
         </Carte>
       )}
+
+      {feuille}
     </div>
   );
 }

--- a/frontend/src/pages/Positions.jsx
+++ b/frontend/src/pages/Positions.jsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuthentification } from '../contexte/contexteAuthentification';
+import { useMouvement } from '../hooks/useMouvement';
 import { api, ErreurApi } from '../services/api';
 import { convertir } from '../utils/conversion';
 import { comparerDecimales, CLASSES_QUANTITE } from '../utils/formatage';
 import Bouton from '../composants/Bouton';
+import FeuilleMouvement from '../composants/FeuilleMouvement';
 import TableauPositions from '../composants/TableauPositions';
 import FiltresClasse from '../composants/FiltresClasse';
 import BasculeDevise from '../composants/BasculeDevise';
@@ -78,6 +80,9 @@ export default function Positions() {
   const [portefeuille, setPortefeuille] = useState(null);
   const [erreur, setErreur] = useState(null);
   const [chargement, setChargement] = useState(true);
+  const [confirmation, setConfirmation] = useState(null);
+
+  const mouvement = useMouvement();
 
   const [devise, setDevise] = useState(() => lirePreference(CLE_DEVISE, 'EUR'));
   const [masque, setMasque] = useState(() => lirePreference(CLE_MASQUAGE, 'non') === 'oui');
@@ -187,8 +192,29 @@ export default function Positions() {
     setParametres(suivants, { replace: true });
   }
 
+  // Le mouvement change la position, son prix de revient et sa valorisation : l'écran se
+  // recharge, le serveur restant seul à recalculer.
+  function apresEnregistrement({ resume }) {
+    mouvement.fermer();
+    setConfirmation(resume);
+    charger();
+  }
+
+  // La feuille reçoit les positions telles que le serveur les a rendues, en euros, et
+  // non celles converties pour l'affichage : la saisie se fait dans la devise de
+  // référence, et un prix pré-rempli en dollars serait enregistré comme des euros.
+  const feuille = mouvement.ouvert && (
+    <FeuilleMouvement
+      actifs={portefeuille?.actifs ?? []}
+      actifInitialId={mouvement.actifInitialId}
+      surFermeture={mouvement.fermer}
+      surEnregistrement={apresEnregistrement}
+    />
+  );
+
   const outils = (
     <div className="positions__outils">
+      <Bouton onClick={() => mouvement.ouvrir()}>+ Mouvement</Bouton>
       <BasculeDevise
         devise={devise}
         indisponible={!taux}
@@ -250,8 +276,9 @@ export default function Positions() {
           titre="Aucune position"
           explication="Votre portefeuille ne contient aucune position. Enregistrez un achat pour la voir apparaître ici."
           libelleAction="Ajouter une position"
-          surAction={() => naviguer('/mouvement')}
+          surAction={() => mouvement.ouvrir()}
         />
+        {feuille}
       </div>
     );
   }
@@ -271,6 +298,8 @@ export default function Positions() {
       {erreur && (
         <MessageErreur nature={natureDeLErreur(erreur)} surAction={charger} />
       )}
+
+      {confirmation && <Message>{confirmation}</Message>}
 
       {enRepli.length > 0 && (
         <Message variante="avertissement">
@@ -339,6 +368,8 @@ export default function Positions() {
           surTri={changerTri}
         />
       )}
+
+      {feuille}
     </div>
   );
 }

--- a/frontend/src/pages/__tests__/DetailPosition.test.jsx
+++ b/frontend/src/pages/__tests__/DetailPosition.test.jsx
@@ -13,6 +13,10 @@ import { api, ErreurApi } from '../../services/api';
 // Les mouvements sont ceux que le serveur renvoie, déjà enrichis : aucune de ces valeurs
 // n'est recalculée par l'interface, et le jeu d'essai reproduit donc la forme exacte de
 // la réponse plutôt qu'une forme inventée.
+//
+// Les chiffres sont ceux que le moteur produit réellement sur ces trois mouvements :
+// (0,5 x 54 000 + 15 + 0,3 x 61 000 + 10) / 0,8 donne un prix de revient de 56 656,25,
+// et la vente de 0,2 à 63 500 dégage 1 360,75 une fois ses 8 de frais déduits.
 
 const MOUVEMENTS = [
   {
@@ -40,8 +44,8 @@ const MOUVEMENTS = [
     note: 'Renforcement',
     montant: '18300.00',
     pru_avant: '54030',
-    pru_apres: '56636.25',
-    effet_pru: '2606.25',
+    pru_apres: '56656.25',
+    effet_pru: '2626.25',
     quantite_apres: '0.8',
     plus_value_realisee: null,
   },
@@ -54,11 +58,11 @@ const MOUVEMENTS = [
     date_transaction: '2026-08-03T10:00:00.000Z',
     note: 'Prise de bénéfice partielle',
     montant: '12700.00',
-    pru_avant: '56636.25',
-    pru_apres: '56636.25',
+    pru_avant: '56656.25',
+    pru_apres: '56656.25',
     effet_pru: '0',
     quantite_apres: '0.6',
-    plus_value_realisee: '1364.75',
+    plus_value_realisee: '1360.75',
   },
 ];
 
@@ -73,12 +77,12 @@ const DETAIL = {
   source_cours: 'coinbase',
   horodatage_cours: '2026-08-23T08:00:00.000Z',
   quantite_detenue: '0.6',
-  pru: '56636.25',
-  cout_total: '33981.75',
+  pru: '56656.25',
+  cout_total: '33993.75',
   valeur: '36480.72',
-  plus_value_latente: '2498.97',
-  plus_value_realisee: '1364.75',
-  pourcentage_variation: '7.35',
+  plus_value_latente: '2486.97',
+  plus_value_realisee: '1360.75',
+  pourcentage_variation: '7.32',
   transactions: MOUVEMENTS,
   historique: { points: [], performances: {} },
   taux_affichage: {
@@ -437,3 +441,71 @@ describe('graphe de cours', () => {
     expect(plages.getAllByRole('tab')).toHaveLength(5);
   });
 });
+
+describe('saisie d’un mouvement', () => {
+  // La fiche ne connaît qu'une position : la feuille s'ouvre déjà réglée sur elle, le
+  // sélecteur n'ayant rien d'autre à proposer.
+  it('ouvre la feuille déjà réglée sur la position consultée', async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Nouveau mouvement' }));
+
+    expect(screen.getByRole('dialog', { name: 'Nouveau mouvement' })).toBeTruthy();
+    expect(screen.getByLabelText(/^Actif/).value).toBe('1');
+    // Le cours de la fiche est proposé comme prix unitaire, sans requête de plus.
+    expect(screen.getByLabelText(/^Prix unitaire/).value).toBe('60801.20');
+  });
+
+  // La quantité détenue vient du serveur : la feuille la relaie, elle ne la recalcule pas.
+  it('borne la vente à la quantité que le serveur a rendue', async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Nouveau mouvement' }));
+    await utilisateur.click(screen.getByRole('radio', { name: 'Vente' }));
+    await utilisateur.click(screen.getByRole('button', { name: 'Tout vendre' }));
+
+    expect(screen.getByLabelText(/^Quantité/).value).toBe('0.6');
+  });
+
+  it('recharge la fiche après un enregistrement', async () => {
+    vi.spyOn(api, 'simulerTransaction').mockResolvedValue({
+      sens: 'achat',
+      montant: '6080.12',
+      frais: '0',
+      quantite_detenue_avant: '0.6',
+      quantite_detenue_apres: '0.7',
+      pru_avant: '56656.25',
+      pru_apres: '57249.06',
+      effet_pru: '592.81',
+      plus_value_realisee: null,
+      cout_total_apres: '40074.34',
+    });
+    vi.spyOn(api, 'creerTransaction').mockResolvedValue({
+      id: 60,
+      actif_id: 1,
+      sens: 'achat',
+      quantite: '0.10000000',
+      prix_unitaire: '60801.20',
+      frais: '0',
+      date_transaction: '2026-08-25T10:00:00.000Z',
+      note: null,
+    });
+
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Nouveau mouvement' }));
+    await utilisateur.type(screen.getByLabelText(/^Quantité/), '0.1');
+    await screen.findByText(/57\s?249,06/);
+    await utilisateur.click(screen.getByRole('button', { name: 'Enregistrer' }));
+
+    expect(await screen.findByText(/Achat de 0,1\sBTC enregistré/)).toBeTruthy();
+    expect(api.actif).toHaveBeenCalledTimes(2);
+  });
+});
+

--- a/frontend/src/pages/__tests__/Patrimoine.test.jsx
+++ b/frontend/src/pages/__tests__/Patrimoine.test.jsx
@@ -367,3 +367,79 @@ describe('accessibilité', () => {
     expect(courbe.getAttribute('aria-label')).toMatch(/2026-08-09/);
   });
 });
+
+describe('saisie d’un mouvement', () => {
+  const EFFET = {
+    sens: 'achat',
+    montant: '1000.00',
+    frais: '0',
+    quantite_detenue_avant: '0.5',
+    quantite_detenue_apres: '0.6',
+    pru_avant: '9000',
+    pru_apres: '9100',
+    effet_pru: '100',
+    plus_value_realisee: null,
+    cout_total_apres: '5460.00',
+  };
+
+  // La saisie n'est jamais une page : la feuille se pose par-dessus le patrimoine, qui
+  // reste affiché derrière elle.
+  it("ouvre la feuille depuis l'en-tête sans quitter l'écran", async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByText(/12.480,65/);
+
+    await utilisateur.click(screen.getByRole('button', { name: '+ Mouvement' }));
+
+    expect(screen.getByRole('dialog', { name: 'Nouveau mouvement' })).toBeTruthy();
+    expect(screen.getByText('Valeur totale')).toBeTruthy();
+  });
+
+  // Sans cette porte d'entrée, un compte neuf n'aurait aucun moyen d'enregistrer son
+  // premier mouvement : c'est le premier pas du parcours de découverte.
+  it("ouvre la feuille depuis l'état vide", async () => {
+    const utilisateur = userEvent.setup();
+    api.portefeuille.mockResolvedValue({ ...PORTEFEUILLE, actifs: [], repartition: [] });
+    rendre();
+
+    await utilisateur.click(
+      await screen.findByRole('button', { name: 'Ajouter votre première position' })
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Nouveau mouvement' })).toBeTruthy();
+  });
+
+  // Le mouvement change le patrimoine, le prix de revient et les plus-values : c'est le
+  // serveur qui les recalcule, l'écran se recharge plutôt que d'ajuster ses chiffres.
+  it('recharge le patrimoine et confirme après un enregistrement', async () => {
+    vi.spyOn(api, 'simulerTransaction').mockResolvedValue(EFFET);
+    vi.spyOn(api, 'creerTransaction').mockResolvedValue({
+      id: 51,
+      actif_id: 1,
+      sens: 'achat',
+      quantite: '0.10000000',
+      prix_unitaire: '10000.00',
+      frais: '0',
+      date_transaction: '2026-08-25T10:00:00.000Z',
+      note: null,
+    });
+
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByText(/12.480,65/);
+    const chargements = api.portefeuille.mock.calls.length;
+
+    await utilisateur.click(screen.getByRole('button', { name: '+ Mouvement' }));
+    await utilisateur.selectOptions(screen.getByLabelText(/^Actif/), '1');
+    await utilisateur.type(screen.getByLabelText(/^Quantité/), '0.1');
+    await utilisateur.type(screen.getByLabelText(/^Prix unitaire/), '10000');
+
+    // L'enregistrement n'est possible qu'une fois l'effet du mouvement obtenu.
+    await screen.findByText(/9\s?100/);
+    await utilisateur.click(screen.getByRole('button', { name: 'Enregistrer' }));
+
+    expect(await screen.findByText(/Achat de 0,1\sBTC enregistré/)).toBeTruthy();
+    expect(screen.queryByRole('dialog')).toBeNull();
+    await waitFor(() => expect(api.portefeuille.mock.calls.length).toBeGreaterThan(chargements));
+  });
+});

--- a/frontend/src/pages/__tests__/Positions.test.jsx
+++ b/frontend/src/pages/__tests__/Positions.test.jsx
@@ -408,3 +408,53 @@ describe('tendance sur trente jours', () => {
     expect(within(menu).queryByText(/30 jours/)).toBeNull();
   });
 });
+
+describe('saisie d’un mouvement', () => {
+  it("ouvre la feuille par-dessus la liste et l'inscrit dans l'adresse", async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('table');
+
+    await utilisateur.click(screen.getByRole('button', { name: '+ Mouvement' }));
+
+    expect(screen.getByRole('dialog', { name: 'Nouveau mouvement' })).toBeTruthy();
+    expect(adresse.search).toContain('mouvement=nouveau');
+  });
+
+  it("referme la feuille et retire le paramètre de l'adresse", async () => {
+    const utilisateur = userEvent.setup();
+    rendre('/positions?mouvement=nouveau');
+    await screen.findByRole('dialog');
+
+    await utilisateur.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(adresse.search).not.toContain('mouvement');
+  });
+
+  it('conserve les filtres en vigueur pendant la saisie', async () => {
+    const utilisateur = userEvent.setup();
+    rendre('/positions?classes=crypto');
+    await screen.findByRole('table');
+
+    await utilisateur.click(screen.getByRole('button', { name: '+ Mouvement' }));
+
+    expect(adresse.search).toContain('classes=crypto');
+    expect(adresse.search).toContain('mouvement=nouveau');
+  });
+
+  // La bascule euro-dollar ne change que l'affichage : la saisie, elle, se fait dans la
+  // devise de référence. Transmettre à la feuille des montants convertis enregistrerait
+  // des dollars dans une colonne d'euros.
+  it('propose un prix en euros même lorsque la liste est affichée en dollars', async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('table');
+
+    await utilisateur.click(screen.getByLabelText('Afficher les montants en dollars'));
+    await utilisateur.click(screen.getByRole('button', { name: '+ Mouvement' }));
+    await utilisateur.selectOptions(screen.getByLabelText(/^Actif/), '1');
+
+    expect(screen.getByLabelText(/^Prix unitaire/).value).toBe('54890.12');
+  });
+});

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -100,7 +100,20 @@ export const api = {
   // ressource appartenant à un autre compte répond 404, jamais 403 (D52) : l'appelant
   // ne peut pas distinguer l'inexistant de ce qui ne lui appartient pas.
   actif: (jeton, id) => requete(`/actifs/${id}`, { jeton }),
+  creerActif: (jeton, donnees) => requete('/actifs', { methode: 'POST', corps: donnees, jeton }),
   supprimerActif: (jeton, id) => requete(`/actifs/${id}`, { methode: 'DELETE', jeton }),
+  creerTransaction: (jeton, actifId, donnees) =>
+    requete(`/actifs/${actifId}/transactions`, { methode: 'POST', corps: donnees, jeton }),
+  // Effet d'un mouvement avant son enregistrement : nouveau prix de revient, quantité
+  // détenue après, plus-value dégagée par une vente. Rien n'est écrit. Ces valeurs sont
+  // des états métier et viennent donc du moteur du serveur, jamais d'un calcul refait
+  // ici (D69).
+  simulerTransaction: (jeton, actifId, donnees) =>
+    requete(`/actifs/${actifId}/transactions/simulation`, {
+      methode: 'POST',
+      corps: donnees,
+      jeton,
+    }),
   supprimerTransaction: (jeton, actifId, transactionId) =>
     requete(`/actifs/${actifId}/transactions/${transactionId}`, { methode: 'DELETE', jeton }),
   alertes: (jeton) => requete('/alertes', { jeton }),


### PR DESCRIPTION
## Description

Lot E5 — Mouvement. Saisie d'un achat ou d'une vente en feuille glissante sur mobile et en dialogue centré sur desktop, jamais en page : la feuille se pose sur l'écran d'origine, qui reste visible derrière elle.

Le récapitulatif recalculé en direct est le coeur de cet écran. Il annonce le montant de l'opération, la quantité détenue après, le nouveau prix de revient avec son déplacement, et pour une vente la plus-value dégagée. Aucun de ces chiffres n'est calculé par l'interface : une route de simulation rejoue le déroulé du moteur sans rien écrire, et l'interface affiche ce qu'elle reçoit (D69). Le prix de revient est une moyenne pondérée sur toute l'histoire de la position ; une seconde implémentation dans React aurait fini par diverger de celle du serveur.

Côté serveur, `POST /api/actifs/:id/transactions/simulation` reprend le corps, les contrôles et le cloisonnement de la création. Le mouvement hypothétique est inséré à sa date dans l'historique avant que le déroulé ne soit rejoué : une saisie rétroactive donne donc le même prix de revient que si elle avait été saisie à sa date. La règle de vente s'applique avant tout calcul. Le service de transaction reçoit désormais ses modèles en paramètre, comme ceux du portefeuille et de l'authentification, et devient testable sans base.

Côté interface, la vente est bornée à la quantité détenue rendue par le serveur, avec un raccourci « tout vendre » qui reprend la valeur exacte ; le prix unitaire est pré-rempli au cours du jour, avec la mention qui dit qu'il reste modifiable ; la date est bornée au jour même. La validation reste bloquée tant que l'effet du mouvement n'a pas été obtenu. La création d'un actif se fait dans la même feuille, en une étape préalable : sans elle, un portefeuille vide ne permettrait aucune première saisie.

La feuille est un dialogue modal : le focus y entre, n'en sort plus par la tabulation, revient à son déclencheur à la fermeture, et Échap referme sauf pendant un enregistrement. Le sens est un groupe de boutons radio, le récapitulatif une région `aria-live="polite"`, les champs numériques portent `inputmode="decimal"`.

Son ouverture est portée par le paramètre `?mouvement` de l'écran d'origine, comme les filtres de la liste des positions : elle survit à un rechargement et l'adresse décrit ce qui est affiché. Les trois écrans déjà livrés y mènent, et la route `/mouvement`, jusqu'ici sans destination, ouvre la feuille par-dessus le patrimoine.

## Vérifications

Contrat contrôlé contre une réponse réelle du serveur, sur le compte de démonstration : simulation d'un achat et d'une vente sur la position BTC, vente supérieure à la quantité détenue (400 avec le message du serveur), quantité négative et date future (400 avec les champs nommés), clé inconnue dans le corps (400), position d'un autre compte demandée par l'administrateur (404, jamais 403), appel sans jeton (401). Le prix de revient recalculé à la main sur la position réelle rend exactement la valeur du serveur, 57 220,1875 après l'achat simulé.

Le jeu d'essai de l'écran de détail est aligné au passage sur l'arithmétique réelle du moteur, que la base confirme : 56 656,25 de prix de revient sur ces trois mouvements, et non 56 636,25. Aucune assertion n'en dépendait.

218 tests back, 204 tests front, lint muet, build sans avertissement.

## Issue liée

Closes #115
Closes #116

Couvre également l'intention de l'issue de backlog #35 (formulaire d'ajout de transaction).

## Liste de contrôle

- [x] Le code respecte l'architecture du projet (routes → middlewares → controllers → services → models)
- [x] Les entrées utilisateur sont validées côté serveur
- [x] Les requêtes SQL sont préparées (pas de concaténation de chaînes)
- [x] La vérification de propriété est appliquée sur les ressources concernées
- [x] Aucun secret ni clé d'API n'est présent dans le diff
- [x] Les tests existants passent, et de nouveaux tests couvrent le changement si pertinent
- [x] La documentation concernée est à jour (README, docs/, commentaires)
- [x] Le message des commits respecte `docs/convention-commits.md`