### PR TITLE
E6 - Écran Seuils : deux groupes, écart restant calculé côté serveur, création et retrait

### DIFF
--- a/backend/src/controllers/alerte.js
+++ b/backend/src/controllers/alerte.js
@@ -1,7 +1,9 @@
 // Contrôleurs des alertes. Le propriétaire vient toujours du jeton : aucune de ces
 // routes n'accepte d'identifiant d'utilisateur en entrée.
 
-const serviceAlerte = require('../services/alerte');
+const { creerServiceAlerte } = require('../services/alerte');
+
+const serviceAlerte = creerServiceAlerte();
 
 async function lister(req, res, next) {
   try {

--- a/backend/src/services/__tests__/alerte.test.js
+++ b/backend/src/services/__tests__/alerte.test.js
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+// Le service tire la configuration par sa chaîne d'imports : environnement minimal
+// posé avant l'import dynamique, comme pour les autres modules qui en dépendent.
+let creerServiceAlerte;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = 'postgresql://utilisateur:secret@localhost:5432/capitall';
+  process.env.JWT_SECRET = 'd'.repeat(32);
+  ({ creerServiceAlerte } = await import('../alerte.js'));
+});
+
+// Dépôt et service de portefeuille factices : le service reçoit ses dépendances en
+// paramètre, aucune base ni réseau dans ces tests.
+function depotAlertes(liste = []) {
+  return {
+    listerParUtilisateur: vi.fn().mockResolvedValue(liste),
+    creerSurActif: vi.fn(),
+    creerSurCapitalTotal: vi.fn(),
+    desactiver: vi.fn(),
+  };
+}
+
+function servicePortefeuilleFactice({ capitalTotal = '0', coursParActif = {} } = {}) {
+  return { obtenirValeursObservees: vi.fn().mockResolvedValue({ capitalTotal, coursParActif }) };
+}
+
+function alerteActif({ id = 1, actifId = 10, sensSeuil = 'au_dessus', valeurSeuil = '70000.00', statut = 'active' } = {}) {
+  return {
+    id,
+    utilisateur_id: 2,
+    actif_id: actifId,
+    type_cible: 'actif',
+    sens_seuil: sensSeuil,
+    valeur_seuil: valeurSeuil,
+    statut,
+    symbole: 'BTC',
+  };
+}
+
+function alerteCapital({ id = 2, sensSeuil = 'au_dessus', valeurSeuil = '45000.00', statut = 'active' } = {}) {
+  return {
+    id,
+    utilisateur_id: 2,
+    actif_id: null,
+    type_cible: 'capital_total',
+    sens_seuil: sensSeuil,
+    valeur_seuil: valeurSeuil,
+    statut,
+    symbole: null,
+  };
+}
+
+describe('liste enrichie (E6)', () => {
+  it("rend une liste vide sans appeler le portefeuille", async () => {
+    const alertes = depotAlertes([]);
+    const portefeuille = servicePortefeuilleFactice();
+    const service = creerServiceAlerte({ alertes, servicePortefeuille: portefeuille });
+
+    expect(await service.lister(2)).toEqual([]);
+    expect(portefeuille.obtenirValeursObservees).not.toHaveBeenCalled();
+  });
+
+  it('enrichit une alerte sur actif de la valeur observée et de son écart restant', async () => {
+    const alertes = depotAlertes([alerteActif({ valeurSeuil: '65000.00' })]);
+    const portefeuille = servicePortefeuilleFactice({ coursParActif: { 10: '61240.00' } });
+    const service = creerServiceAlerte({ alertes, servicePortefeuille: portefeuille });
+
+    const [alerte] = await service.lister(2);
+
+    expect(alerte.valeur_observee).toBe('61240.00');
+    expect(alerte.ecart_pourcentage).toBe('6.14');
+  });
+
+  it('enrichit une alerte sur le capital total à partir du capital observé', async () => {
+    const alertes = depotAlertes([alerteCapital({ valeurSeuil: '45000.00' })]);
+    const portefeuille = servicePortefeuilleFactice({ capitalTotal: '58566.64' });
+    const service = creerServiceAlerte({ alertes, servicePortefeuille: portefeuille });
+
+    const [alerte] = await service.lister(2);
+
+    expect(alerte.valeur_observee).toBe('58566.64');
+    expect(alerte.ecart_pourcentage).toBe('0');
+  });
+
+  // Cours indisponible sur la cible : les deux champs sont nuls plutôt qu'une valeur
+  // inventée, l'écran affichant alors une mention explicite.
+  it('rend des champs nuls quand le cours de la cible est indisponible', async () => {
+    const alertes = depotAlertes([alerteActif({ actifId: 99 })]);
+    const portefeuille = servicePortefeuilleFactice({ coursParActif: {} });
+    const service = creerServiceAlerte({ alertes, servicePortefeuille: portefeuille });
+
+    const [alerte] = await service.lister(2);
+
+    expect(alerte.valeur_observee).toBeNull();
+    expect(alerte.ecart_pourcentage).toBeNull();
+  });
+
+  it('conserve les champs déjà portés par la ligne, symbole compris', async () => {
+    const alertes = depotAlertes([alerteActif()]);
+    const portefeuille = servicePortefeuilleFactice({ coursParActif: { 10: '70000.00' } });
+    const service = creerServiceAlerte({ alertes, servicePortefeuille: portefeuille });
+
+    const [alerte] = await service.lister(2);
+
+    expect(alerte.symbole).toBe('BTC');
+    expect(alerte.sens_seuil).toBe('au_dessus');
+  });
+});
+
+describe('création', () => {
+  it('crée une alerte sur le capital total sans consulter les actifs', async () => {
+    const alertes = depotAlertes();
+    alertes.creerSurCapitalTotal.mockResolvedValue({ id: 5 });
+    const service = creerServiceAlerte({ alertes, servicePortefeuille: servicePortefeuilleFactice() });
+
+    const creee = await service.creer({
+      utilisateurId: 2,
+      donnees: { type_cible: 'capital_total', sens_seuil: 'au_dessus', valeur_seuil: '45000.00' },
+    });
+
+    expect(creee).toEqual({ id: 5 });
+    expect(alertes.creerSurActif).not.toHaveBeenCalled();
+  });
+
+  // Un actif appartenant à un autre compte est indiscernable d'un actif inexistant :
+  // le modèle filtre sur le propriétaire, le service ne voit qu'une absence (D52).
+  it("rend 404 quand l'actif ciblé n'appartient pas au demandeur", async () => {
+    const alertes = depotAlertes();
+    alertes.creerSurActif.mockResolvedValue(null);
+    const service = creerServiceAlerte({ alertes, servicePortefeuille: servicePortefeuilleFactice() });
+
+    await expect(
+      service.creer({
+        utilisateurId: 2,
+        donnees: { type_cible: 'actif', sens_seuil: 'au_dessus', valeur_seuil: '1.00', actif_id: 99 },
+      })
+    ).rejects.toMatchObject({ statut: 404 });
+  });
+});
+
+describe('désactivation', () => {
+  it('rend 404 sur une alerte introuvable ou étrangère', async () => {
+    const alertes = depotAlertes();
+    alertes.desactiver.mockResolvedValue(null);
+    const service = creerServiceAlerte({ alertes, servicePortefeuille: servicePortefeuilleFactice() });
+
+    await expect(service.desactiver({ id: 1, utilisateurId: 2 })).rejects.toMatchObject({
+      statut: 404,
+    });
+  });
+});

--- a/backend/src/services/__tests__/evaluationAlertes.test.js
+++ b/backend/src/services/__tests__/evaluationAlertes.test.js
@@ -185,6 +185,15 @@ describe('écart restant avant franchissement (E6)', () => {
     expect(ecartRestant('au_dessus', undefined, '65000.00')).toBeNull();
   });
 
+  // Distinct du seuil à zéro testé plus haut : ici c'est la valeur OBSERVÉE qui vaut
+  // zéro. Le calcul divise par cette valeur (le pourcentage restant est rapporté au
+  // cours actuel) : la diviser par zéro serait indéfini, la fonction rend donc null
+  // plutôt qu'un résultat inventé.
+  it('rend null quand la valeur observée vaut zéro', () => {
+    expect(ecartRestant('au_dessus', '0', '65000.00')).toBeNull();
+    expect(ecartRestant('en_dessous', '0.00', '10.00')).toBeNull();
+  });
+
   // Deux décimales fixes, comme tout pourcentage rendu par le serveur (pourcentage_variation,
   // performances) : la valeur ne perd jamais ses zéros de fin, contrairement à un montant.
   it('reste exact sur des valeurs à décimales, à deux décimales fixes', () => {

--- a/backend/src/services/__tests__/evaluationAlertes.test.js
+++ b/backend/src/services/__tests__/evaluationAlertes.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { evaluerAlertes, estFranchi } from '../evaluationAlertes.js';
+import { evaluerAlertes, estFranchi, ecartRestant } from '../evaluationAlertes.js';
 
 function alerteActif(sensSeuil, valeurSeuil, { id = 1, actifId = 10, statut = 'active' } = {}) {
   return {
@@ -152,5 +152,35 @@ describe('évaluation des alertes', () => {
     expect(franchissement.valeur_seuil).toBe('45000.00');
     expect(franchissement.valeur_observee).toBe('58566.64');
     expect(franchissement.sens_seuil).toBe('au_dessus');
+  });
+});
+
+describe('écart restant avant franchissement (E6)', () => {
+  // 65 000 - 61 240 rapporté à 61 240 : la hausse qu'il reste à faire depuis le cours
+  // actuel, et non depuis le seuil.
+  it('rend la hausse restante pour un seuil haut pas encore atteint', () => {
+    expect(ecartRestant('au_dessus', '61240.00', '65000.00')).toBe('6.14');
+  });
+
+  it('rend la baisse restante pour un seuil bas pas encore atteint', () => {
+    expect(ecartRestant('en_dessous', '2627.32', '2200.00')).toBe('16.26');
+  });
+
+  // Une valeur déjà au-delà du seuil, dans le sens qui le franchit, rend 0 et non un
+  // nombre négatif, qui n'aurait pas de sens pour un écart restant.
+  it('rend zéro quand le seuil est déjà franchi', () => {
+    expect(ecartRestant('au_dessus', '70000.00', '65000.00')).toBe('0');
+    expect(ecartRestant('au_dessus', '65000.00', '65000.00')).toBe('0');
+  });
+
+  it('rend null quand la valeur observée est indisponible', () => {
+    expect(ecartRestant('au_dessus', null, '65000.00')).toBeNull();
+    expect(ecartRestant('au_dessus', undefined, '65000.00')).toBeNull();
+  });
+
+  // Deux décimales fixes, comme tout pourcentage rendu par le serveur (pourcentage_variation,
+  // performances) : la valeur ne perd jamais ses zéros de fin, contrairement à un montant.
+  it('reste exact sur des valeurs à décimales, à deux décimales fixes', () => {
+    expect(ecartRestant('au_dessus', '0.3', '0.33')).toBe('10.00');
   });
 });

--- a/backend/src/services/__tests__/evaluationAlertes.test.js
+++ b/backend/src/services/__tests__/evaluationAlertes.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { evaluerAlertes, estFranchi, ecartRestant } from '../evaluationAlertes.js';
+import { evaluerAlertes, estFranchi, ecartRestant, valeurObservee } from '../evaluationAlertes.js';
 
 function alerteActif(sensSeuil, valeurSeuil, { id = 1, actifId = 10, statut = 'active' } = {}) {
   return {
@@ -173,6 +173,13 @@ describe('écart restant avant franchissement (E6)', () => {
     expect(ecartRestant('au_dessus', '65000.00', '65000.00')).toBe('0');
   });
 
+  // Même règle côté seuil bas : la revue a signalé que seul le sens au-dessus était
+  // couvert par le cas précédent.
+  it('rend zéro quand un seuil bas est déjà franchi', () => {
+    expect(ecartRestant('en_dessous', '45000.00', '50000.00')).toBe('0');
+    expect(ecartRestant('en_dessous', '50000.00', '50000.00')).toBe('0');
+  });
+
   it('rend null quand la valeur observée est indisponible', () => {
     expect(ecartRestant('au_dessus', null, '65000.00')).toBeNull();
     expect(ecartRestant('au_dessus', undefined, '65000.00')).toBeNull();
@@ -182,5 +189,44 @@ describe('écart restant avant franchissement (E6)', () => {
   // performances) : la valeur ne perd jamais ses zéros de fin, contrairement à un montant.
   it('reste exact sur des valeurs à décimales, à deux décimales fixes', () => {
     expect(ecartRestant('au_dessus', '0.3', '0.33')).toBe('10.00');
+  });
+
+  // Un seuil à 0 est impossible en pratique (le schéma Zod exige une valeur strictement
+  // positive à la création), mais la fonction ne doit pas se comporter n'importe comment
+  // si elle en reçoit un malgré tout. La division porte sur la valeur observée, jamais
+  // sur le seuil : aucune division par zéro ne peut se produire de ce côté-là.
+  it('reste défini sur un seuil à zéro, sans franchissement au sens bas', () => {
+    expect(ecartRestant('en_dessous', '100.00', '0')).toBe('100.00');
+  });
+});
+
+describe('valeur observée (E6)', () => {
+  it('rend le capital total pour une alerte sur le capital total', () => {
+    const alerte = { type_cible: 'capital_total' };
+    expect(valeurObservee(alerte, { capitalTotal: '58566.64', coursParActif: {} })).toBe(
+      '58566.64'
+    );
+  });
+
+  it('rend le cours de la cible pour une alerte sur un actif', () => {
+    const alerte = { type_cible: 'actif', actif_id: 10 };
+    expect(
+      valeurObservee(alerte, { capitalTotal: '0', coursParActif: { 10: '70000.00' } })
+    ).toBe('70000.00');
+  });
+
+  // Le cours indisponible est le cas normal d'un actif sans fournisseur joignable :
+  // la valeur observée est alors absente, jamais une valeur inventée.
+  it("rend null quand l'actif est absent de la table des cours", () => {
+    const alerte = { type_cible: 'actif', actif_id: 99 };
+    expect(valeurObservee(alerte, { capitalTotal: '0', coursParActif: {} })).toBeNull();
+  });
+
+  // Distinct du cas précédent : ici la clé existe mais porte une chaîne vide. `??` ne
+  // la remplace pas, contrairement à `undefined` ; c'est `ecartRestant`, en aval, qui
+  // traite cette chaîne vide comme une valeur indisponible.
+  it("rend la chaîne vide telle quelle quand le cours de l'actif est vide", () => {
+    const alerte = { type_cible: 'actif', actif_id: 10 };
+    expect(valeurObservee(alerte, { capitalTotal: '0', coursParActif: { 10: '' } })).toBe('');
   });
 });

--- a/backend/src/services/alerte.js
+++ b/backend/src/services/alerte.js
@@ -1,47 +1,85 @@
-// Logique métier des alertes : aiguillage entre les deux cibles et traduction des
-// absences en erreurs métier. Les règles de franchissement vivent dans
-// evaluationAlertes.js, qui reste pur.
+// Logique métier des alertes : aiguillage entre les deux cibles, traduction des
+// absences en erreurs métier, et enrichissement de la liste par l'écart restant avant
+// franchissement. Les règles de franchissement et l'écart lui-même vivent dans
+// evaluationAlertes.js, qui reste pur ; ce module est celui qui les alimente en
+// valeurs réelles.
+//
+// Comme les services du portefeuille, de l'authentification et des transactions, le
+// service reçoit ses dépendances en paramètre : il s'exécute alors sans base ni réseau
+// dans les tests, avec le même code qu'en production.
 
 const modeleAlerte = require('../models/alerte');
+const { creerServicePortefeuille } = require('./portefeuilleConsolide');
+const { valeurObservee, ecartRestant } = require('./evaluationAlertes');
 const { ErreurIntrouvable } = require('../erreurs');
 
-async function creer({ utilisateurId, donnees }) {
-  if (donnees.type_cible === 'capital_total') {
-    return modeleAlerte.creerSurCapitalTotal({
+function creerServiceAlerte({
+  alertes: depotAlertes = modeleAlerte,
+  servicePortefeuille = creerServicePortefeuille(),
+} = {}) {
+  async function creer({ utilisateurId, donnees }) {
+    if (donnees.type_cible === 'capital_total') {
+      return depotAlertes.creerSurCapitalTotal({
+        utilisateurId,
+        sensSeuil: donnees.sens_seuil,
+        valeurSeuil: donnees.valeur_seuil,
+      });
+    }
+
+    const alerte = await depotAlertes.creerSurActif({
       utilisateurId,
+      actifId: donnees.actif_id,
       sensSeuil: donnees.sens_seuil,
       valeurSeuil: donnees.valeur_seuil,
     });
+
+    // Aucune ligne insérée : l'actif n'existe pas ou appartient à quelqu'un d'autre.
+    // Les deux cas sont indiscernables pour l'appelant, conformément à D52.
+    if (!alerte) {
+      throw new ErreurIntrouvable('Actif introuvable.');
+    }
+
+    return alerte;
   }
 
-  const alerte = await modeleAlerte.creerSurActif({
-    utilisateurId,
-    actifId: donnees.actif_id,
-    sensSeuil: donnees.sens_seuil,
-    valeurSeuil: donnees.valeur_seuil,
-  });
+  async function desactiver({ id, utilisateurId }) {
+    const alerte = await depotAlertes.desactiver(id, utilisateurId);
 
-  // Aucune ligne insérée : l'actif n'existe pas ou appartient à quelqu'un d'autre.
-  // Les deux cas sont indiscernables pour l'appelant, conformément à D52.
-  if (!alerte) {
-    throw new ErreurIntrouvable('Actif introuvable.');
+    if (!alerte) {
+      throw new ErreurIntrouvable('Alerte introuvable.');
+    }
+
+    return alerte;
   }
 
-  return alerte;
-}
+  // Liste des alertes, chacune enrichie de la valeur actuellement observée sur sa
+  // cible et de l'écart restant avant franchissement, en pourcentage (E6, D69) : ce
+  // sont des valeurs dérivées d'un montant, elles ne se recalculent pas côté
+  // interface. Un cours indisponible sur la cible rend les deux champs nuls plutôt
+  // qu'une valeur inventée ; l'écran affiche alors une mention explicite.
+  async function lister(utilisateurId) {
+    const alertesUtilisateur = await depotAlertes.listerParUtilisateur(utilisateurId);
 
-async function desactiver({ id, utilisateurId }) {
-  const alerte = await modeleAlerte.desactiver(id, utilisateurId);
+    if (alertesUtilisateur.length === 0) {
+      return [];
+    }
 
-  if (!alerte) {
-    throw new ErreurIntrouvable('Alerte introuvable.');
+    const { capitalTotal, coursParActif } = await servicePortefeuille.obtenirValeursObservees(
+      utilisateurId
+    );
+
+    return alertesUtilisateur.map((alerte) => {
+      const observee = valeurObservee(alerte, { capitalTotal, coursParActif });
+
+      return {
+        ...alerte,
+        valeur_observee: observee !== null && observee !== undefined ? String(observee) : null,
+        ecart_pourcentage: ecartRestant(alerte.sens_seuil, observee, alerte.valeur_seuil),
+      };
+    });
   }
 
-  return alerte;
+  return { creer, desactiver, lister };
 }
 
-async function lister(utilisateurId) {
-  return modeleAlerte.listerParUtilisateur(utilisateurId);
-}
-
-module.exports = { creer, desactiver, lister };
+module.exports = { creerServiceAlerte };

--- a/backend/src/services/evaluationAlertes.js
+++ b/backend/src/services/evaluationAlertes.js
@@ -6,7 +6,14 @@
 // Aucune tâche de fond n'évalue les alertes (D50) : l'évaluation a lieu au chargement
 // du tableau de bord, quand les valeurs viennent d'être calculées.
 
-const { ECHELLE_PRU, versUnites, comparer } = require('../utils/decimal');
+const {
+  ECHELLE_PRU,
+  ECHELLE_MONTANT,
+  versUnites,
+  comparer,
+  diviser,
+  formater,
+} = require('../utils/decimal');
 
 // Franchissement inclusif (D56) : un seuil « au-dessus » de 70 000 se déclenche
 // lorsque la valeur atteint 70 000, pas seulement lorsqu'elle le dépasse. C'est ce
@@ -32,6 +39,39 @@ function valeurObservee(alerte, contexte) {
   }
 
   return contexte.coursParActif?.[alerte.actif_id] ?? null;
+}
+
+// Écart restant avant franchissement, en pourcentage de la valeur observée (E6).
+//
+// C'est la variation relative que la valeur observée doit encore parcourir pour
+// atteindre le seuil : un seuil haut à 65 000 avec un cours à 61 240 rend 6,14 %, la
+// hausse qu'il reste à faire depuis le cours actuel. Une valeur déjà au-delà du seuil,
+// dans le sens qui le franchit, rend 0 plutôt qu'un nombre négatif, qui n'aurait pas de
+// sens pour un écart restant.
+//
+// Valeur dérivée d'un montant, donc calculée ici et non côté interface (D69) : c'est
+// exactement le cas que la règle nomme, « franchissement de seuil ».
+// Le second paramètre porte un nom distinct de la fonction valeurObservee ci-dessus,
+// bien qu'il en reçoive le résultat : les deux ne doivent pas se confondre à la lecture.
+function ecartRestant(sensSeuil, valeurConstatee, valeurSeuil) {
+  if (valeurConstatee === null || valeurConstatee === undefined || valeurConstatee === '') {
+    return null;
+  }
+
+  const observee = versUnites(valeurConstatee, ECHELLE_PRU);
+  if (observee === 0n) {
+    return null;
+  }
+  const seuil = versUnites(valeurSeuil, ECHELLE_PRU);
+
+  if (estFranchi(sensSeuil, valeurConstatee, valeurSeuil)) {
+    return '0';
+  }
+
+  const ecart = seuil > observee ? seuil - observee : observee - seuil;
+  const pourcentage = diviser(ecart * 100n, observee, ECHELLE_PRU);
+
+  return formater(pourcentage, ECHELLE_PRU, ECHELLE_MONTANT);
 }
 
 function evaluerAlertes(alertesActives, contexte) {
@@ -68,4 +108,4 @@ function evaluerAlertes(alertesActives, contexte) {
   return franchissements;
 }
 
-module.exports = { evaluerAlertes, estFranchi };
+module.exports = { evaluerAlertes, estFranchi, valeurObservee, ecartRestant };

--- a/backend/src/services/portefeuilleConsolide.js
+++ b/backend/src/services/portefeuilleConsolide.js
@@ -314,7 +314,23 @@ function creerServicePortefeuille({
     return { points, performances: calculerPerformances(complet) };
   }
 
-  return { obtenirPortefeuille, obtenirDetailActif, obtenirHistorique };
+  // Valeurs actuelles observables, pour l'écran Seuils (E6) : le cours de chaque
+  // position et la valeur totale du patrimoine, sans les effets de bord de
+  // `obtenirPortefeuille` (pas d'historisation, pas d'évaluation ni de marquage des
+  // alertes, déjà faits au chargement du tableau de bord, D50). Un seuil ne fait que
+  // lire ces valeurs pour afficher son écart restant, il ne les fait pas exister.
+  async function obtenirValeursObservees(utilisateurId) {
+    const { positions } = await construirePositions(utilisateurId);
+    const totaux = consolider(positions);
+
+    const coursParActif = Object.fromEntries(
+      positions.filter((position) => position.cours_eur !== null).map((p) => [p.id, p.cours_eur])
+    );
+
+    return { capitalTotal: totaux.valeur_totale, coursParActif };
+  }
+
+  return { obtenirPortefeuille, obtenirDetailActif, obtenirHistorique, obtenirValeursObservees };
 }
 
 module.exports = { creerServicePortefeuille };

--- a/docs/cahier-des-charges.md
+++ b/docs/cahier-des-charges.md
@@ -284,7 +284,7 @@ Toutes les routes privées attendent le jeton dans l'en-tête d'autorisation. Un
 | DELETE | `/api/actifs/:id/transactions/:idTransaction` | propriétaire | suppression d'une transaction | 204, 401, 404 |
 | GET | `/api/portefeuille` | authentifié | consolidation : valeur totale, coût de revient, plus-values, répartition, taux de change, alertes franchies | 200, 401 |
 | GET | `/api/portefeuille/historique` | authentifié | instantanés de valorisation | 200, 401 |
-| GET | `/api/alertes` | authentifié | liste des alertes | 200, 401 |
+| GET | `/api/alertes` | authentifié | liste des alertes, chacune enrichie de la valeur actuellement observée sur sa cible et de l'écart restant avant franchissement en pourcentage | 200, 401 |
 | POST | `/api/alertes` | authentifié | création d'une alerte | 201, 400, 401, 404 |
 | PATCH | `/api/alertes/:id` | propriétaire | désactivation | 200, 400, 401, 404 |
 | GET | `/api/annonces` | authentifié | liste des annonces, épinglées en tête | 200, 401 |

--- a/docs/conception/specification-fonctionnelle.md
+++ b/docs/conception/specification-fonctionnelle.md
@@ -282,8 +282,10 @@ En desktop, tableau à colonnes : Actif, Quantité, Cours, Prix de revient, Valo
 
 **Accessibilité.** La barre de progression porte `role="progressbar"` avec ses valeurs. Le pourcentage restant est toujours écrit en toutes lettres à côté : la barre seule ne porte jamais l'information. Le groupe des seuils franchis est annoncé par un titre de section, pas seulement par une couleur.
 
-**Questions ouvertes.**
-1. Un seuil franchi doit-il pouvoir être réarmé ? Le modèle prévoit trois statuts dont `desactivee`, mais pas de retour à `active`. Recommandation : ne pas réarmer au MVP ; l'utilisateur recrée un seuil, ce qui est plus clair et ne demande aucune évolution.
+**Questions tranchées.**
+1. Un seuil franchi n'est **pas réarmable** au MVP, conformément à la recommandation : l'API n'expose que la désactivation, jamais un retour au statut `active`. Un utilisateur qui veut à nouveau surveiller la même cible recrée un seuil.
+
+**Impacts API.** L'écran ne demande aucune route nouvelle. Chaque alerte rendue par `GET /api/alertes` porte deux champs additifs, `valeur_observee` et `ecart_pourcentage` : la valeur actuellement constatée sur la cible et l'écart relatif qu'il lui reste à parcourir avant franchissement, tous deux calculés côté serveur (D69). Un cours indisponible sur la cible rend les deux champs nuls, l'écran affichant alors la mention prévue plutôt qu'une barre à zéro.
 
 ---
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import Inscription from './pages/Inscription';
 import Patrimoine from './pages/Patrimoine';
 import Positions from './pages/Positions';
 import DetailPosition from './pages/DetailPosition';
+import Seuils from './pages/Seuils';
 import Introuvable from './pages/Introuvable';
 
 export default function App() {
@@ -28,6 +29,7 @@ export default function App() {
             <Route path="/patrimoine" element={<Patrimoine />} />
             <Route path="/positions" element={<Positions />} />
             <Route path="/positions/:id" element={<DetailPosition />} />
+            <Route path="/seuils" element={<Seuils />} />
 
             {/* La saisie d'un mouvement est une feuille posée sur l'écran d'origine, et
                 non une page : elle n'a pas de route à elle. L'adresse reste toutefois

--- a/frontend/src/composants/BarreProgression.jsx
+++ b/frontend/src/composants/BarreProgression.jsx
@@ -20,6 +20,12 @@ import Montant from './Montant';
 //
 // Un cours indisponible ne donne pas une barre à zéro, qui se lirait comme « très
 // loin du seuil » : la barre disparaît au profit d'une mention explicite.
+//
+// Le masquage des montants, préférence globale de l'application, remplace les deux
+// repères par des points plutôt que de les taire : la barre continue de dire à quelle
+// distance on se trouve, sans jamais révéler le chiffre. Le pourcentage qu'annonce
+// aria-valuetext n'est pas masqué, aucun pourcentage ne l'étant ailleurs dans
+// l'application.
 // La barre dit toujours la même chose : à quelle distance du déclenchement on se
 // trouve, pleine au moment du franchissement. Un seuil bas se lit donc à l'envers d'un
 // seuil haut — s'en éloigner, pour lui, c'est monter. Rapporter les deux au même
@@ -43,6 +49,7 @@ export default function BarreProgression({
   libelle,
   sens = 'au_dessus',
   atteint = false,
+  masque = false,
 }) {
   const avancement =
     valeur === null || valeur === undefined ? null : fraction(valeur, cible, sens);
@@ -72,11 +79,19 @@ export default function BarreProgression({
         <span className="barre-progression__remplissage" style={{ width: `${pourcentage}%` }} />
       </div>
       <p className="barre-progression__reperes">
-        <Montant valeur={valeur} devise={devise} taille="legende" />
+        {masque ? (
+          <span aria-label="Montant masqué">••••</span>
+        ) : (
+          <Montant valeur={valeur} devise={devise} taille="legende" />
+        )}
         <span className="barre-progression__cible">
           <span aria-hidden="true">/</span>
           <span className="lecteur-ecran-seulement">sur un seuil de</span>
-          <Montant valeur={cible} devise={devise} taille="legende" />
+          {masque ? (
+            <span aria-label="Montant masqué">••••</span>
+          ) : (
+            <Montant valeur={cible} devise={devise} taille="legende" />
+          )}
         </span>
       </p>
     </div>

--- a/frontend/src/composants/FeuilleSeuil.css
+++ b/frontend/src/composants/FeuilleSeuil.css
@@ -1,0 +1,117 @@
+.seuil {
+  display: flex;
+  flex-direction: column;
+}
+
+.seuil__valeur-actuelle {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--espace-1);
+  padding: var(--espace-4) 0;
+  text-align: center;
+}
+
+.seuil__valeur-actuelle-legende {
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.seuil__valeur-indisponible {
+  font-size: var(--taille-corps);
+  color: var(--couleur-texte-attenue);
+}
+
+.seuil__sens {
+  margin: 0 0 var(--espace-4);
+  padding: 0;
+  border: none;
+}
+
+.seuil__legende {
+  padding: 0;
+  margin-bottom: var(--espace-1);
+  font-size: var(--taille-legende);
+  font-weight: var(--graisse-forte);
+  color: var(--couleur-texte-attenue);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.seuil__bascule {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--espace-1);
+  padding: var(--espace-1);
+  background: var(--couleur-fond);
+  border: 1px solid var(--couleur-bordure);
+  border-radius: var(--rayon-carte);
+}
+
+.seuil__choix {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: var(--espace-2) var(--espace-3);
+  font-size: var(--taille-corps);
+  color: var(--couleur-texte-attenue);
+  border-radius: var(--rayon-carte);
+  cursor: pointer;
+}
+
+.seuil__choix--actif {
+  color: var(--couleur-accent);
+  background: rgba(76, 154, 255, 0.12);
+  font-weight: var(--graisse-forte);
+}
+
+.seuil__choix:focus-within {
+  outline: 2px solid var(--couleur-accent);
+  outline-offset: 2px;
+}
+
+.seuil__decalages {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--espace-2);
+  margin: var(--espace-1) 0 var(--espace-4);
+}
+
+.seuil__decalage {
+  min-height: 44px;
+  padding: var(--espace-2) 0;
+  font-family: var(--police);
+  font-size: var(--taille-legende);
+  font-variant-numeric: tabular-nums;
+  color: var(--couleur-texte);
+  background: var(--couleur-fond);
+  border: 1px solid var(--couleur-bordure);
+  border-radius: var(--rayon-carte);
+  cursor: pointer;
+}
+
+.seuil__decalage:hover:not(:disabled) {
+  border-color: var(--couleur-accent);
+  color: var(--couleur-accent);
+}
+
+.seuil__decalage:disabled {
+  color: var(--couleur-texte-attenue);
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.seuil__aide {
+  display: flex;
+  gap: var(--espace-1);
+  margin: 0 0 var(--espace-4);
+  padding: var(--espace-3);
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+  line-height: 1.5;
+  background: var(--couleur-fond);
+  border-radius: var(--rayon-carte);
+}

--- a/frontend/src/composants/FeuilleSeuil.jsx
+++ b/frontend/src/composants/FeuilleSeuil.jsx
@@ -83,16 +83,26 @@ export default function FeuilleSeuil({
   actifs = [],
   capitalTotal = '0',
   cibleInitiale = 'capital_total',
+  // Faux depuis l'écran de détail d'une position (E4) : celui-ci ne connaît qu'un
+  // actif et ne charge pas la valeur totale du patrimoine. Retirer l'option évite
+  // d'afficher une valeur actuelle trompeuse (zéro) si elle était sélectionnée, sans
+  // pour autant obliger l'écran de détail à charger le portefeuille pour cette seule
+  // occasion.
+  permettrePatrimoineTotal = true,
   surFermeture,
   surEnregistrement,
 }) {
   const { jeton } = useAuthentification();
   const identifiant = useId();
 
-  const cibleInitialeValide =
+  const cibleCorrespondACetActif =
     cibleInitiale !== 'capital_total' &&
-    actifs.some((position) => String(position.id) === String(cibleInitiale))
-      ? `actif:${cibleInitiale}`
+    actifs.some((position) => String(position.id) === String(cibleInitiale));
+
+  const cibleInitialeValide = cibleCorrespondACetActif
+    ? `actif:${cibleInitiale}`
+    : !permettrePatrimoineTotal && actifs.length > 0
+      ? `actif:${actifs[0].id}`
       : 'capital_total';
 
   const [cible, setCible] = useState(cibleInitialeValide);
@@ -185,7 +195,9 @@ export default function FeuilleSeuil({
             onChange={(evenement) => setCible(evenement.target.value)}
             disabled={envoi}
           >
-            <option value="capital_total">Patrimoine total</option>
+            {permettrePatrimoineTotal && (
+              <option value="capital_total">Patrimoine total</option>
+            )}
             {actifs.map((position) => (
               <option key={position.id} value={`actif:${position.id}`}>
                 {position.nom} — {position.symbole} ({LIBELLES_CLASSE[position.type]})

--- a/frontend/src/composants/FeuilleSeuil.jsx
+++ b/frontend/src/composants/FeuilleSeuil.jsx
@@ -1,0 +1,291 @@
+import { useId, useMemo, useState } from 'react';
+import { useAuthentification } from '../contexte/contexteAuthentification';
+import { api, ErreurApi } from '../services/api';
+import { LIBELLES_CLASSE } from '../utils/classesActifs';
+import Feuille from './Feuille';
+import Champ from './Champ';
+import Bouton from './Bouton';
+import Montant from './Montant';
+import Message from './Message';
+import './FeuilleSeuil.css';
+
+// Création d'un seuil de surveillance, sur un actif ou sur le patrimoine total.
+//
+// La feuille présente la valeur actuelle de la cible en grand, puis la bascule au-dessus
+// ou en dessous, le champ de seuil et des décalages rapides qui le pré-remplissent à
+// distance de cette valeur. Rien de tout cela n'est un calcul métier : la valeur
+// affichée en grand est celle transmise par l'écran d'origine, et un décalage n'est
+// qu'une proposition de saisie, revalidée comme toute autre valeur par le schéma du
+// serveur. La règle de franchissement, elle, n'est jamais recalculée ici (D69) : la
+// feuille ne fait qu'énoncer en clair qu'elle est inclusive et qu'elle ne joue qu'une
+// fois, ce que le serveur applique déjà.
+
+const SENS = [
+  { code: 'au_dessus', libelle: 'Au-dessus de' },
+  { code: 'en_dessous', libelle: 'En dessous de' },
+];
+
+const DECALAGES = [-10, -5, 5, 10];
+
+const MOTIF_MONTANT = /^\d+(\.\d{1,2})?$/;
+
+function normaliser(valeur) {
+  return String(valeur ?? '')
+    .trim()
+    .replace(/[\s ]/g, '')
+    .replace(',', '.');
+}
+
+// Application exacte d'un décalage en points de pourcentage à un montant à deux
+// décimales, sans jamais passer par un nombre à virgule flottante : un décalage n'est
+// qu'une proposition de saisie, mais la proposition doit être aussi exacte qu'une
+// valeur saisie à la main, faute de quoi le champ afficherait un artefact d'arrondi.
+// Le facteur reste toujours positif, les quatre décalages proposés étant compris entre
+// -10 et +10 points, ce qui dispense de traiter un facteur négatif.
+function decalerMontant(montant, pointsDePourcentage) {
+  if (typeof montant !== 'string' || !MOTIF_MONTANT.test(montant)) {
+    return null;
+  }
+
+  const [entiere, decimale = ''] = montant.split('.');
+  const centimes = BigInt(entiere) * 100n + BigInt((decimale + '00').slice(0, 2));
+  const facteur = 100n + BigInt(pointsDePourcentage);
+
+  const produit = centimes * facteur;
+  const quotient = produit / 100n;
+  const reste = produit % 100n;
+  const arrondi = reste * 2n >= 100n ? quotient + 1n : quotient;
+
+  return `${arrondi / 100n}.${(arrondi % 100n).toString().padStart(2, '0')}`;
+}
+
+const CHAMPS_SERVEUR = ['type_cible', 'sens_seuil', 'valeur_seuil', 'actif_id'];
+
+function erreursDuServeur(echec) {
+  if (!(echec instanceof ErreurApi) || !Array.isArray(echec.champs)) {
+    return null;
+  }
+
+  const erreurs = {};
+  for (const { champ, message } of echec.champs) {
+    if (CHAMPS_SERVEUR.includes(champ)) {
+      erreurs[champ === 'actif_id' ? 'cible' : champ] = message;
+    }
+  }
+
+  return Object.keys(erreurs).length > 0 ? erreurs : null;
+}
+
+export default function FeuilleSeuil({
+  // Positions valorisées du portefeuille, avec leur cours ; capitalTotal est la valeur
+  // totale déjà consolidée par le serveur. Les deux viennent de GET /api/portefeuille,
+  // chargé par l'écran d'origine.
+  actifs = [],
+  capitalTotal = '0',
+  cibleInitiale = 'capital_total',
+  surFermeture,
+  surEnregistrement,
+}) {
+  const { jeton } = useAuthentification();
+  const identifiant = useId();
+
+  const cibleInitialeValide =
+    cibleInitiale !== 'capital_total' &&
+    actifs.some((position) => String(position.id) === String(cibleInitiale))
+      ? `actif:${cibleInitiale}`
+      : 'capital_total';
+
+  const [cible, setCible] = useState(cibleInitialeValide);
+  const [sens, setSens] = useState('au_dessus');
+  const [valeurSeuil, setValeurSeuil] = useState('');
+  const [quitte, setQuitte] = useState(false);
+  const [erreurs, setErreurs] = useState({});
+  const [messageServeur, setMessageServeur] = useState(null);
+  const [envoi, setEnvoi] = useState(false);
+
+  const actifChoisi = useMemo(() => {
+    if (cible === 'capital_total') {
+      return null;
+    }
+    const id = cible.slice('actif:'.length);
+    return actifs.find((position) => String(position.id) === id) ?? null;
+  }, [cible, actifs]);
+
+  const cibleActif = cible !== 'capital_total';
+  const valeurActuelle = cibleActif ? actifChoisi?.cours_eur ?? null : capitalTotal;
+  const nomCible = cibleActif
+    ? actifChoisi
+      ? `${actifChoisi.nom} (${actifChoisi.symbole})`
+      : ''
+    : 'Patrimoine total';
+
+  const valeurNormalisee = normaliser(valeurSeuil);
+  const erreurValidation =
+    valeurNormalisee === ''
+      ? 'Le seuil est obligatoire.'
+      : !MOTIF_MONTANT.test(valeurNormalisee)
+        ? 'Le seuil doit être un montant positif, avec au plus 2 décimales.'
+        : Number(valeurNormalisee) <= 0
+          ? 'Le seuil doit être strictement positif.'
+          : null;
+
+  const complet = erreurValidation === null && (!cibleActif || actifChoisi !== null);
+
+  async function soumettre(evenement) {
+    evenement.preventDefault();
+
+    if (!complet) {
+      setQuitte(true);
+      return;
+    }
+
+    setEnvoi(true);
+    setErreurs({});
+    setMessageServeur(null);
+
+    try {
+      const creee = await api.creerAlerte(jeton, {
+        type_cible: cibleActif ? 'actif' : 'capital_total',
+        sens_seuil: sens,
+        valeur_seuil: valeurNormalisee,
+        ...(cibleActif ? { actif_id: Number(actifChoisi.id) } : {}),
+      });
+
+      surEnregistrement?.({
+        alerte: creee,
+        resume: `Seuil créé pour ${nomCible}.`,
+      });
+    } catch (echec) {
+      const duServeur = erreursDuServeur(echec);
+      if (duServeur) {
+        setErreurs(duServeur);
+      } else {
+        setMessageServeur(echec.message);
+      }
+    } finally {
+      setEnvoi(false);
+    }
+  }
+
+  return (
+    <Feuille
+      titre={cibleActif && actifChoisi ? `Nouveau seuil — ${nomCible}` : 'Nouveau seuil'}
+      surFermeture={surFermeture}
+      verrouillee={envoi}
+    >
+      <form className="seuil" onSubmit={soumettre} noValidate>
+        <div className="champ">
+          <label className="champ__label" htmlFor={`${identifiant}-cible`}>
+            Cible
+          </label>
+          <select
+            id={`${identifiant}-cible`}
+            className="champ__saisie"
+            value={cible}
+            onChange={(evenement) => setCible(evenement.target.value)}
+            disabled={envoi}
+          >
+            <option value="capital_total">Patrimoine total</option>
+            {actifs.map((position) => (
+              <option key={position.id} value={`actif:${position.id}`}>
+                {position.nom} — {position.symbole} ({LIBELLES_CLASSE[position.type]})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="seuil__valeur-actuelle">
+          <span className="seuil__valeur-actuelle-legende">Valeur actuelle</span>
+          {valeurActuelle !== null ? (
+            <Montant valeur={valeurActuelle} type="cours" taille="principal" />
+          ) : (
+            <span className="seuil__valeur-indisponible">
+              Aucun cours disponible pour {actifChoisi?.symbole}.
+            </span>
+          )}
+        </div>
+
+        <fieldset className="seuil__sens" disabled={envoi}>
+          <legend className="seuil__legende">Sens du seuil</legend>
+          <div className="seuil__bascule">
+            {SENS.map((option) => (
+              <label
+                key={option.code}
+                className={`seuil__choix${sens === option.code ? ' seuil__choix--actif' : ''}`}
+              >
+                <input
+                  type="radio"
+                  name={`${identifiant}-sens`}
+                  value={option.code}
+                  checked={sens === option.code}
+                  onChange={() => setSens(option.code)}
+                  className="lecteur-ecran-seulement"
+                />
+                <span>{option.libelle}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <Champ
+          label="Seuil de déclenchement (€)"
+          valeur={valeurSeuil}
+          onChange={(evenement) => setValeurSeuil(evenement.target.value)}
+          onBlur={() => setQuitte(true)}
+          erreur={erreurs.valeur_seuil ?? (quitte ? erreurValidation : undefined)}
+          obligatoire
+          inputMode="decimal"
+          autoComplete="off"
+          disabled={envoi}
+        />
+
+        {erreurs.cible && (
+          <p className="champ__erreur" role="alert">
+            <span aria-hidden="true">⚠ </span>
+            {erreurs.cible}
+          </p>
+        )}
+
+        {/* Décalages rapides : une proposition de saisie, jamais une valeur imposée.
+            Ils restent indisponibles tant que la valeur actuelle de la cible ne l'est
+            pas non plus, faute de base à décaler. */}
+        <div className="seuil__decalages" role="group" aria-label="Décalages rapides">
+          {DECALAGES.map((points) => {
+            const propose = valeurActuelle !== null ? decalerMontant(valeurActuelle, points) : null;
+            return (
+              <button
+                key={points}
+                type="button"
+                className="seuil__decalage"
+                disabled={envoi || propose === null}
+                onClick={() => {
+                  setValeurSeuil(propose);
+                  setQuitte(true);
+                }}
+              >
+                {points > 0 ? `+${points} %` : `${points} %`}
+              </button>
+            );
+          })}
+        </div>
+
+        <p className="seuil__aide">
+          <span aria-hidden="true">ⓘ </span>
+          Le seuil est inclusif et le franchissement ne se produit qu'une fois : une fois
+          l'alerte déclenchée, elle ne se redéclenche pas.
+        </p>
+
+        {messageServeur && <Message variante="erreur">{messageServeur}</Message>}
+
+        <div className="feuille__actions">
+          <Bouton variante="secondaire" onClick={surFermeture} desactive={envoi}>
+            Annuler
+          </Bouton>
+          <Bouton type="submit" enCours={envoi}>
+            Créer le seuil
+          </Bouton>
+        </div>
+      </form>
+    </Feuille>
+  );
+}

--- a/frontend/src/composants/__tests__/FeuilleSeuil.test.jsx
+++ b/frontend/src/composants/__tests__/FeuilleSeuil.test.jsx
@@ -1,0 +1,212 @@
+import { useState } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FeuilleSeuil from '../FeuilleSeuil';
+import * as contexte from '../../contexte/contexteAuthentification';
+import { api, ErreurApi } from '../../services/api';
+
+// La feuille de création est testée sur ce qui se casse en silence : le calcul exact
+// des décalages rapides, le blocage de la validation, et le comportement de dialogue
+// modal déjà couvert pour la feuille de mouvement, ici vérifié une fois pour la cible.
+
+const ACTIFS = [
+  { id: 1, type: 'crypto', symbole: 'BTC', nom: 'Bitcoin', cours_eur: '61240.00' },
+  { id: 4, type: 'metal', symbole: 'XAU', nom: 'Or', cours_eur: null },
+];
+
+function Harnais({ actifs = ACTIFS, capitalTotal = '58566.64', cibleInitiale, surEnregistrement = () => {} }) {
+  const [ouverte, setOuverte] = useState(false);
+
+  return (
+    <>
+      <button type="button" onClick={() => setOuverte(true)}>
+        Nouveau seuil
+      </button>
+      {ouverte && (
+        <FeuilleSeuil
+          actifs={actifs}
+          capitalTotal={capitalTotal}
+          cibleInitiale={cibleInitiale}
+          surFermeture={() => setOuverte(false)}
+          surEnregistrement={surEnregistrement}
+        />
+      )}
+    </>
+  );
+}
+
+async function ouvrir(proprietes) {
+  const utilisateur = userEvent.setup();
+  render(<Harnais {...proprietes} />);
+  await utilisateur.click(screen.getByRole('button', { name: 'Nouveau seuil' }));
+  return utilisateur;
+}
+
+beforeEach(() => {
+  vi.spyOn(contexte, 'useAuthentification').mockReturnValue({
+    jeton: 'jeton-de-test',
+    utilisateur: { pseudo: 'Camille' },
+    estConnecte: true,
+  });
+  vi.spyOn(api, 'creerAlerte').mockResolvedValue({
+    id: 9,
+    utilisateur_id: 2,
+    actif_id: 1,
+    type_cible: 'actif',
+    sens_seuil: 'au_dessus',
+    valeur_seuil: '67364.00',
+    statut: 'active',
+    date_creation: '2026-08-26T10:00:00.000Z',
+    date_declenchement: null,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('forme et accessibilité', () => {
+  it('est un dialogue modal', async () => {
+    await ouvrir();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+  });
+
+  it('se ferme par Échap et rend le focus à son déclencheur', async () => {
+    const utilisateur = await ouvrir();
+    await utilisateur.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Nouveau seuil' }));
+  });
+
+  it('présente le sens en boutons radio', async () => {
+    await ouvrir();
+
+    const auDessus = screen.getByRole('radio', { name: 'Au-dessus de' });
+    const enDessous = screen.getByRole('radio', { name: 'En dessous de' });
+    expect(auDessus.checked).toBe(true);
+    expect(enDessous.checked).toBe(false);
+  });
+
+  it('propose le patrimoine total par défaut', async () => {
+    await ouvrir();
+    expect(screen.getByLabelText('Cible').value).toBe('capital_total');
+    expect(screen.getByText(/58.566,64/)).toBeTruthy();
+  });
+});
+
+describe('cible', () => {
+  it('affiche le cours actuel quand un actif est choisi', async () => {
+    const utilisateur = await ouvrir();
+
+    await utilisateur.selectOptions(screen.getByLabelText('Cible'), 'actif:1');
+
+    expect(screen.getByText(/61.240/)).toBeTruthy();
+  });
+
+  it('signale un cours indisponible et désactive les décalages', async () => {
+    const utilisateur = await ouvrir();
+
+    await utilisateur.selectOptions(screen.getByLabelText('Cible'), 'actif:4');
+
+    expect(screen.getByText(/Aucun cours disponible pour XAU/)).toBeTruthy();
+    screen.getAllByRole('button', { name: /%$/ }).forEach((bouton) => {
+      expect(bouton.disabled).toBe(true);
+    });
+  });
+});
+
+describe('décalages rapides', () => {
+  it('calcule le seuil à +10 % exactement, sans artefact décimal', async () => {
+    const utilisateur = await ouvrir();
+    await utilisateur.selectOptions(screen.getByLabelText('Cible'), 'actif:1');
+
+    await utilisateur.click(screen.getByRole('button', { name: '+10 %' }));
+
+    expect(screen.getByLabelText(/^Seuil de déclenchement/).value).toBe('67364.00');
+  });
+
+  it('calcule le seuil à -10 % exactement', async () => {
+    const utilisateur = await ouvrir();
+    await utilisateur.selectOptions(screen.getByLabelText('Cible'), 'actif:1');
+
+    await utilisateur.click(screen.getByRole('button', { name: '-10 %' }));
+
+    expect(screen.getByLabelText(/^Seuil de déclenchement/).value).toBe('55116.00');
+  });
+});
+
+describe('validation', () => {
+  it('refuse un seuil nul ou négatif', async () => {
+    const utilisateur = await ouvrir();
+
+    await utilisateur.type(screen.getByLabelText(/^Seuil de déclenchement/), '0');
+    await utilisateur.tab();
+
+    expect(screen.getByText('Le seuil doit être strictement positif.')).toBeTruthy();
+    expect(api.creerAlerte).not.toHaveBeenCalled();
+  });
+
+  it("bloque la création tant que rien n'est saisi", async () => {
+    const utilisateur = await ouvrir();
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Créer le seuil' }));
+
+    expect(screen.getByText('Le seuil est obligatoire.')).toBeTruthy();
+    expect(api.creerAlerte).not.toHaveBeenCalled();
+  });
+});
+
+describe('création', () => {
+  it('envoie la cible, le sens et le seuil, puis prévient l’écran d’origine', async () => {
+    const surEnregistrement = vi.fn();
+    const utilisateur = await ouvrir({ surEnregistrement });
+
+    await utilisateur.selectOptions(screen.getByLabelText('Cible'), 'actif:1');
+    await utilisateur.type(screen.getByLabelText(/^Seuil de déclenchement/), '67364');
+    await utilisateur.click(screen.getByRole('button', { name: 'Créer le seuil' }));
+
+    expect(api.creerAlerte).toHaveBeenCalledWith('jeton-de-test', {
+      type_cible: 'actif',
+      sens_seuil: 'au_dessus',
+      valeur_seuil: '67364',
+      actif_id: 1,
+    });
+    await waitFor(() => expect(surEnregistrement).toHaveBeenCalled());
+    expect(surEnregistrement.mock.calls[0][0].resume).toMatch(/Bitcoin/);
+  });
+
+  it('envoie une alerte sur le capital total sans identifiant d’actif', async () => {
+    const utilisateur = await ouvrir();
+
+    await utilisateur.type(screen.getByLabelText(/^Seuil de déclenchement/), '45000');
+    await utilisateur.click(screen.getByRole('button', { name: 'Créer le seuil' }));
+
+    expect(api.creerAlerte).toHaveBeenCalledWith(
+      'jeton-de-test',
+      expect.not.objectContaining({ actif_id: expect.anything() })
+    );
+    expect(api.creerAlerte).toHaveBeenCalledWith(
+      'jeton-de-test',
+      expect.objectContaining({ type_cible: 'capital_total' })
+    );
+  });
+
+  it('replace une erreur de validation du serveur sur son champ', async () => {
+    api.creerAlerte.mockRejectedValue(
+      new ErreurApi('Données invalides.', 400, [
+        { champ: 'valeur_seuil', message: 'Le seuil doit être strictement positif.' },
+      ])
+    );
+    const utilisateur = await ouvrir();
+
+    await utilisateur.type(screen.getByLabelText(/^Seuil de déclenchement/), '1');
+    await utilisateur.click(screen.getByRole('button', { name: 'Créer le seuil' }));
+
+    expect(
+      await screen.findByText('Le seuil doit être strictement positif.')
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/composants/__tests__/FeuilleSeuil.test.jsx
+++ b/frontend/src/composants/__tests__/FeuilleSeuil.test.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { render, screen, cleanup, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import FeuilleSeuil from '../FeuilleSeuil';
 import * as contexte from '../../contexte/contexteAuthentification';
@@ -15,7 +15,13 @@ const ACTIFS = [
   { id: 4, type: 'metal', symbole: 'XAU', nom: 'Or', cours_eur: null },
 ];
 
-function Harnais({ actifs = ACTIFS, capitalTotal = '58566.64', cibleInitiale, surEnregistrement = () => {} }) {
+function Harnais({
+  actifs = ACTIFS,
+  capitalTotal = '58566.64',
+  cibleInitiale,
+  permettrePatrimoineTotal,
+  surEnregistrement = () => {},
+}) {
   const [ouverte, setOuverte] = useState(false);
 
   return (
@@ -28,6 +34,7 @@ function Harnais({ actifs = ACTIFS, capitalTotal = '58566.64', cibleInitiale, su
           actifs={actifs}
           capitalTotal={capitalTotal}
           cibleInitiale={cibleInitiale}
+          permettrePatrimoineTotal={permettrePatrimoineTotal}
           surFermeture={() => setOuverte(false)}
           surEnregistrement={surEnregistrement}
         />
@@ -94,6 +101,38 @@ describe('forme et accessibilité', () => {
     await ouvrir();
     expect(screen.getByLabelText('Cible').value).toBe('capital_total');
     expect(screen.getByText(/58.566,64/)).toBeTruthy();
+  });
+});
+
+describe('cible initiale (E4, ouverture depuis l’écran de détail)', () => {
+  it('se règle sur l’actif désigné par cibleInitiale', async () => {
+    await ouvrir({ cibleInitiale: 1 });
+
+    expect(screen.getByLabelText('Cible').value).toBe('actif:1');
+    // Le cours de l'actif présélectionné est repris comme valeur actuelle.
+    expect(screen.getByText(/61.240/)).toBeTruthy();
+  });
+
+  it('retombe sur le patrimoine total quand la cible ne correspond à aucun actif connu', async () => {
+    await ouvrir({ cibleInitiale: 999 });
+
+    expect(screen.getByLabelText('Cible').value).toBe('capital_total');
+  });
+
+  it('retire le patrimoine total du sélecteur quand permettrePatrimoineTotal est faux', async () => {
+    await ouvrir({ cibleInitiale: 1, permettrePatrimoineTotal: false });
+
+    const options = within(screen.getByLabelText('Cible')).getAllByRole('option');
+    expect(options.map((option) => option.value)).not.toContain('capital_total');
+    expect(screen.getByLabelText('Cible').value).toBe('actif:1');
+  });
+
+  // Cas défensif : si la cible ne correspondait à aucun actif, la feuille ne doit pas
+  // se rabattre sur une option absente du sélecteur.
+  it('se rabat sur le premier actif quand la cible est invalide et le patrimoine total exclu', async () => {
+    await ouvrir({ cibleInitiale: 999, permettrePatrimoineTotal: false });
+
+    expect(screen.getByLabelText('Cible').value).toBe('actif:1');
   });
 });
 

--- a/frontend/src/hooks/useSeuil.js
+++ b/frontend/src/hooks/useSeuil.js
@@ -1,0 +1,40 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+// Ouverture de la feuille de création d'un seuil, portée par l'adresse de l'écran
+// d'origine. Même mécanique que `useMouvement` : la création n'est pas une page, elle se
+// superpose à l'écran qui la demande, et l'adresse doit continuer à décrire ce qui est
+// affiché après un rechargement.
+//
+// `?seuil=nouveau` ouvre la feuille sans cible présélectionnée ; `?seuil=12` l'ouvre sur
+// l'actif d'identifiant 12, ce que fait l'écran de détail d'une position.
+
+export const PARAMETRE_SEUIL = 'seuil';
+export const SEUIL_NOUVEAU = 'nouveau';
+
+export function useSeuil() {
+  const [parametres, setParametres] = useSearchParams();
+  const ouvert = parametres.get(PARAMETRE_SEUIL);
+
+  const ouvrir = useCallback(
+    (actifId) => {
+      const suivants = new URLSearchParams(parametres);
+      suivants.set(PARAMETRE_SEUIL, actifId ? String(actifId) : SEUIL_NOUVEAU);
+      setParametres(suivants, { replace: true });
+    },
+    [parametres, setParametres]
+  );
+
+  const fermer = useCallback(() => {
+    const suivants = new URLSearchParams(parametres);
+    suivants.delete(PARAMETRE_SEUIL);
+    setParametres(suivants, { replace: true });
+  }, [parametres, setParametres]);
+
+  return {
+    ouvert: ouvert !== null,
+    cibleInitiale: ouvert === SEUIL_NOUVEAU ? 'capital_total' : ouvert,
+    ouvrir,
+    fermer,
+  };
+}

--- a/frontend/src/mise-en-page/Coquille.jsx
+++ b/frontend/src/mise-en-page/Coquille.jsx
@@ -18,7 +18,7 @@ import './Coquille.css';
 const ENTREES = [
   { chemin: '/patrimoine', libelle: 'Patrimoine', symbole: '◫', disponible: true },
   { chemin: '/positions', libelle: 'Positions', symbole: '◈', disponible: true },
-  { chemin: '/seuils', libelle: 'Seuils', symbole: '△', disponible: false },
+  { chemin: '/seuils', libelle: 'Seuils', symbole: '△', disponible: true },
   { chemin: '/compte', libelle: 'Compte', symbole: '◉', disponible: false },
 ];
 

--- a/frontend/src/pages/DetailPosition.css
+++ b/frontend/src/pages/DetailPosition.css
@@ -132,6 +132,12 @@
   padding: var(--espace-4) var(--espace-4) var(--espace-6);
 }
 
+.detail__seuils-outils {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--espace-3);
+}
+
 .detail__seuils {
   list-style: none;
   margin: 0;

--- a/frontend/src/pages/DetailPosition.jsx
+++ b/frontend/src/pages/DetailPosition.jsx
@@ -2,6 +2,7 @@ import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useAuthentification } from '../contexte/contexteAuthentification';
 import { useMouvement } from '../hooks/useMouvement';
+import { useSeuil } from '../hooks/useSeuil';
 import { api, ErreurApi } from '../services/api';
 import { convertir } from '../utils/conversion';
 import { sensVariation } from '../utils/formatage';
@@ -17,6 +18,7 @@ import FriseMouvements from '../composants/FriseMouvements';
 import BarreProgression from '../composants/BarreProgression';
 import Confirmation from '../composants/Confirmation';
 import FeuilleMouvement from '../composants/FeuilleMouvement';
+import FeuilleSeuil from '../composants/FeuilleSeuil';
 import Bouton from '../composants/Bouton';
 import Squelette from '../composants/Squelette';
 import MessageErreur from '../composants/MessageErreur';
@@ -88,6 +90,7 @@ export default function DetailPosition() {
   const [confirmation, setConfirmation] = useState(null);
 
   const mouvement = useMouvement();
+  const seuilFeuille = useSeuil();
 
   const [devise, setDevise] = useState(() => lirePreference(CLE_DEVISE, 'EUR'));
   const [masque, setMasque] = useState(() => lirePreference(CLE_MASQUAGE, 'non') === 'oui');
@@ -422,34 +425,49 @@ export default function DetailPosition() {
               masque={masque}
               surSuppression={(mouvement) => setASupprimer({ type: 'mouvement', mouvement })}
             />
-          ) : seuils.length === 0 ? (
-            <p className="detail__sans-seuil">
-              Aucun seuil ne surveille cette position.
-            </p>
           ) : (
-            <ul className="detail__seuils">
-              {seuils.map((seuil) => (
-                <li key={seuil.id}>
-                  <p className="detail__seuil-intitule">
-                    {/* Valeurs contraintes par le schéma : 'au_dessus' ou 'en_dessous'.
-                        Elles se lisent dans backend/db/schema.sql. */}
-                    {seuil.sens_seuil === 'au_dessus' ? 'Au-dessus de' : 'En dessous de'}{' '}
-                    <Montant valeur={afficher(seuil.valeur_seuil)} devise={devise} />
-                    {seuil.statut === 'declenchee' && (
-                      <span className="detail__seuil-franchi">franchi</span>
-                    )}
-                  </p>
-                  <BarreProgression
-                    valeur={afficher(position.cours_eur)}
-                    cible={afficher(seuil.valeur_seuil)}
-                    devise={devise}
-                    sens={seuil.sens_seuil}
-                    atteint={seuil.statut === 'declenchee'}
-                    libelle={`Progression vers le seuil de ${position.symbole}`}
-                  />
-                </li>
-              ))}
-            </ul>
+            <>
+              <div className="detail__seuils-outils">
+                <Bouton variante="secondaire" onClick={() => seuilFeuille.ouvrir(position.id)}>
+                  + Seuil
+                </Bouton>
+              </div>
+
+              {seuils.length === 0 ? (
+                <p className="detail__sans-seuil">
+                  Aucun seuil ne surveille cette position.
+                </p>
+              ) : (
+                <ul className="detail__seuils">
+                  {seuils.map((seuil) => (
+                    <li key={seuil.id}>
+                      <p className="detail__seuil-intitule">
+                        {/* Valeurs contraintes par le schéma : 'au_dessus' ou 'en_dessous'.
+                            Elles se lisent dans backend/db/schema.sql. */}
+                        {seuil.sens_seuil === 'au_dessus' ? 'Au-dessus de' : 'En dessous de'}{' '}
+                        {masque ? (
+                          <span aria-label="Montant masqué">••••</span>
+                        ) : (
+                          <Montant valeur={afficher(seuil.valeur_seuil)} devise={devise} />
+                        )}
+                        {seuil.statut === 'declenchee' && (
+                          <span className="detail__seuil-franchi">franchi</span>
+                        )}
+                      </p>
+                      <BarreProgression
+                        valeur={afficher(position.cours_eur)}
+                        cible={afficher(seuil.valeur_seuil)}
+                        devise={devise}
+                        masque={masque}
+                        sens={seuil.sens_seuil}
+                        atteint={seuil.statut === 'declenchee'}
+                        libelle={`Progression vers le seuil de ${position.symbole}`}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
           )}
         </div>
       </Carte>
@@ -504,6 +522,25 @@ export default function DetailPosition() {
           surFermeture={mouvement.fermer}
           surEnregistrement={({ resume }) => {
             mouvement.fermer();
+            setConfirmation(resume);
+            charger();
+          }}
+        />
+      )}
+
+      {/* Même principe que la feuille de mouvement ci-dessus : l'écran de détail ne
+          connaît qu'une position, donc qu'une cible possible. Le sélecteur de
+          patrimoine total est retiré (spécification E4, « Création d'un seuil
+          pré-réglée sur cet actif ») plutôt que de charger la valeur totale du
+          patrimoine pour cette seule occasion. */}
+      {seuilFeuille.ouvert && (
+        <FeuilleSeuil
+          actifs={[position]}
+          permettrePatrimoineTotal={false}
+          cibleInitiale={seuilFeuille.cibleInitiale}
+          surFermeture={seuilFeuille.fermer}
+          surEnregistrement={({ resume }) => {
+            seuilFeuille.fermer();
             setConfirmation(resume);
             charger();
           }}

--- a/frontend/src/pages/Seuils.css
+++ b/frontend/src/pages/Seuils.css
@@ -16,6 +16,12 @@
   font-size: var(--taille-titre);
 }
 
+.seuils__outils {
+  display: flex;
+  align-items: center;
+  gap: var(--espace-2);
+}
+
 .seuils__groupe {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/Seuils.css
+++ b/frontend/src/pages/Seuils.css
@@ -1,0 +1,105 @@
+.seuils {
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-6);
+}
+
+.seuils__entete {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--espace-4);
+}
+
+.seuils__titre {
+  margin: 0;
+  font-size: var(--taille-titre);
+}
+
+.seuils__groupe {
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-3);
+}
+
+/* Le groupe des seuils franchis est annoncé par un titre de section, pas seulement par
+   une couleur : la structure porte l'information autant que la teinte. */
+.seuils__titre-groupe {
+  margin: 0;
+  font-size: var(--taille-corps);
+  font-weight: var(--graisse-forte);
+  color: var(--couleur-texte-attenue);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.seuils__liste {
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.seuils__carte {
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-3);
+}
+
+/* La progression justifie une frontière visuelle propre (spécification E6) : le
+   contour reprend la couleur d'avertissement, déjà réservée par D70 à un état qui
+   demande un regard. */
+.seuils__carte--franchi {
+  border-color: var(--couleur-avertissement);
+}
+
+.seuils__ligne {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--espace-3);
+}
+
+.seuils__intitule {
+  flex: 1;
+  min-width: 0;
+}
+
+.seuils__nom {
+  margin: 0;
+  font-size: var(--taille-corps);
+  font-weight: var(--graisse-forte);
+}
+
+.seuils__sous-texte {
+  margin: var(--espace-1) 0 0;
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+}
+
+.seuils__puce-franchi {
+  flex: none;
+  padding: var(--espace-1) var(--espace-2);
+  font-size: var(--taille-legende);
+  font-weight: var(--graisse-forte);
+  color: var(--couleur-avertissement);
+  background: rgba(227, 179, 65, 0.16);
+  border-radius: var(--rayon-pilule);
+}
+
+.seuils__retrait {
+  align-self: flex-start;
+  min-height: 44px;
+  padding: 0 var(--espace-2);
+  font-family: var(--police);
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.seuils__retrait:hover {
+  color: var(--couleur-negatif);
+}

--- a/frontend/src/pages/Seuils.jsx
+++ b/frontend/src/pages/Seuils.jsx
@@ -1,0 +1,311 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuthentification } from '../contexte/contexteAuthentification';
+import { useSeuil } from '../hooks/useSeuil';
+import { api, ErreurApi } from '../services/api';
+import { formaterMontant } from '../utils/formatage';
+import Bouton from '../composants/Bouton';
+import Carte from '../composants/Carte';
+import JetonClasse from '../composants/JetonClasse';
+import Montant from '../composants/Montant';
+import BarreProgression from '../composants/BarreProgression';
+import FeuilleSeuil from '../composants/FeuilleSeuil';
+import Confirmation from '../composants/Confirmation';
+import EtatVide from '../composants/EtatVide';
+import Squelette from '../composants/Squelette';
+import MessageErreur from '../composants/MessageErreur';
+import Message from '../composants/Message';
+import './Seuils.css';
+
+// Écran Seuils.
+//
+// Il répond à une seule question devant chaque ligne : suis-je proche ? Deux groupes,
+// les seuils franchis puis ceux en cours, plutôt qu'un filtre à bascule : la
+// spécification les veut visibles ensemble, le franchissement étant l'information la
+// plus importante et devant donc ouvrir la liste plutôt que se cacher derrière un clic.
+//
+// L'écart restant avant franchissement est une valeur dérivée d'un montant : elle vient
+// déjà calculée dans la réponse de `GET /api/alertes`, avec la valeur actuellement
+// observée sur la cible (D69). Rien n'est recalculé ici. Il est écrit en toutes lettres
+// à côté de la barre de progression, qui ne porte jamais seule l'information.
+//
+// Un seuil désactivé ne surveille plus rien : comme dans l'onglet Seuils de l'écran de
+// détail, il disparaît de la liste après son retrait plutôt que d'y rester barré.
+const STATUTS_AFFICHES = ['active', 'declenchee'];
+
+function natureDeLErreur(erreur) {
+  if (!(erreur instanceof ErreurApi)) {
+    return 'api';
+  }
+  if (erreur.statut === 0) {
+    return 'reseau';
+  }
+  return erreur.statut === 401 ? 'session' : 'api';
+}
+
+function formaterDate(horodatage) {
+  const date = new Date(horodatage);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toLocaleDateString('fr-FR', {
+    day: 'numeric',
+    month: 'long',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function nomCible(seuil) {
+  return seuil.type_cible === 'capital_total' ? 'Patrimoine total' : (seuil.nom_actif ?? seuil.symbole);
+}
+
+export default function Seuils() {
+  const { jeton } = useAuthentification();
+  const naviguer = useNavigate();
+  const seuilFeuille = useSeuil();
+
+  const [seuils, setSeuils] = useState(null);
+  const [portefeuille, setPortefeuille] = useState(null);
+  const [erreur, setErreur] = useState(null);
+  const [chargement, setChargement] = useState(true);
+  const [confirmation, setConfirmation] = useState(null);
+  const [aRetirer, setARetirer] = useState(null);
+  const [retraitEnCours, setRetraitEnCours] = useState(false);
+
+  const charger = useCallback(async () => {
+    setChargement(true);
+    setErreur(null);
+
+    try {
+      // Le portefeuille n'est demandé que pour la feuille de création, qui a besoin
+      // des cours et de la valeur totale : son échec ne doit donc pas priver l'écran
+      // de la liste des seuils, qui reste l'information principale.
+      const [alertes, portefeuilleCourant] = await Promise.all([
+        api.alertes(jeton),
+        api.portefeuille(jeton).catch(() => null),
+      ]);
+      setSeuils(alertes);
+      setPortefeuille(portefeuilleCourant);
+    } catch (echec) {
+      setErreur(echec);
+    } finally {
+      setChargement(false);
+    }
+  }, [jeton]);
+
+  useEffect(() => {
+    charger();
+  }, [charger]);
+
+  const visibles = useMemo(
+    () => (seuils ?? []).filter((seuil) => STATUTS_AFFICHES.includes(seuil.statut)),
+    [seuils]
+  );
+  const franchis = useMemo(() => visibles.filter((seuil) => seuil.statut === 'declenchee'), [visibles]);
+  const enCours = useMemo(() => visibles.filter((seuil) => seuil.statut === 'active'), [visibles]);
+
+  // Type de l'actif ciblé, pour le jeton de classe : l'alerte ne le porte pas
+  // elle-même, seul le portefeuille le sait.
+  const typeParActif = useMemo(() => {
+    const table = new Map();
+    for (const position of portefeuille?.actifs ?? []) {
+      table.set(String(position.id), position.type);
+    }
+    return table;
+  }, [portefeuille]);
+
+  async function confirmerRetrait() {
+    setRetraitEnCours(true);
+    try {
+      await api.desactiverAlerte(jeton, aRetirer.id);
+      setARetirer(null);
+      await charger();
+    } catch (echec) {
+      setARetirer(null);
+      setErreur(echec);
+    } finally {
+      setRetraitEnCours(false);
+    }
+  }
+
+  function apresCreation({ resume }) {
+    seuilFeuille.fermer();
+    setConfirmation(resume);
+    charger();
+  }
+
+  const feuille = seuilFeuille.ouvert && (
+    <FeuilleSeuil
+      actifs={portefeuille?.actifs ?? []}
+      capitalTotal={portefeuille?.valeur_totale ?? '0'}
+      cibleInitiale={seuilFeuille.cibleInitiale}
+      surFermeture={seuilFeuille.fermer}
+      surEnregistrement={apresCreation}
+    />
+  );
+
+  if (chargement && !seuils) {
+    return (
+      <div className="seuils" aria-busy="true">
+        <h1 className="seuils__titre">Seuils</h1>
+        <p className="lecteur-ecran-seulement" role="status">
+          Chargement des seuils.
+        </p>
+        <Squelette forme="bloc" />
+        <Squelette forme="bloc" />
+        <Squelette forme="bloc" />
+      </div>
+    );
+  }
+
+  if (erreur && !seuils) {
+    const nature = natureDeLErreur(erreur);
+    return (
+      <div className="seuils">
+        <h1 className="seuils__titre">Seuils</h1>
+        <MessageErreur
+          nature={nature}
+          message={nature === 'api' ? erreur.message : undefined}
+          libelleAction={nature === 'session' ? 'Se reconnecter' : 'Réessayer'}
+          surAction={nature === 'session' ? () => naviguer('/connexion') : charger}
+        />
+      </div>
+    );
+  }
+
+  if (visibles.length === 0) {
+    return (
+      <div className="seuils">
+        <h1 className="seuils__titre">Seuils</h1>
+        <EtatVide
+          titre="Aucun seuil"
+          explication="Posez un seuil sur un actif ou sur votre patrimoine total pour être prévenu sans avoir à consulter en permanence."
+          libelleAction="Créer un seuil"
+          surAction={() => seuilFeuille.ouvrir()}
+        />
+        {feuille}
+      </div>
+    );
+  }
+
+  return (
+    <div className="seuils">
+      <div className="seuils__entete">
+        <h1 className="seuils__titre">Seuils</h1>
+        <Bouton onClick={() => seuilFeuille.ouvrir()}>+ Seuil</Bouton>
+      </div>
+
+      {erreur && <MessageErreur nature={natureDeLErreur(erreur)} surAction={charger} />}
+
+      {confirmation && <Message>{confirmation}</Message>}
+
+      {franchis.length > 0 && (
+        <section className="seuils__groupe" aria-labelledby="titre-seuils-franchis">
+          <h2 id="titre-seuils-franchis" className="seuils__titre-groupe">
+            Franchis
+          </h2>
+          <ul className="seuils__liste">
+            {franchis.map((seuil) => {
+              const type = typeParActif.get(String(seuil.actif_id));
+              const date = formaterDate(seuil.date_declenchement);
+
+              return (
+                <li key={seuil.id}>
+                  <Carte className="seuils__carte seuils__carte--franchi">
+                    <div className="seuils__ligne">
+                      {type && <JetonClasse classe={type} />}
+                      <div className="seuils__intitule">
+                        <p className="seuils__nom">
+                          {nomCible(seuil)}{' '}
+                          {seuil.sens_seuil === 'au_dessus' ? 'au-dessus de' : 'en dessous de'}{' '}
+                          <Montant valeur={seuil.valeur_seuil} />
+                        </p>
+                        <p className="seuils__sous-texte">
+                          {date ? `Franchi le ${date}` : 'Franchi'}
+                        </p>
+                      </div>
+                      <span className="seuils__puce-franchi">Franchi</span>
+                    </div>
+                    <button
+                      type="button"
+                      className="seuils__retrait"
+                      onClick={() => setARetirer(seuil)}
+                    >
+                      Retirer
+                      <span className="lecteur-ecran-seulement"> ce seuil, {nomCible(seuil)}</span>
+                    </button>
+                  </Carte>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+
+      {enCours.length > 0 && (
+        <section className="seuils__groupe" aria-labelledby="titre-seuils-en-cours">
+          <h2 id="titre-seuils-en-cours" className="seuils__titre-groupe">
+            En cours
+          </h2>
+          <ul className="seuils__liste">
+            {enCours.map((seuil) => {
+              const type = typeParActif.get(String(seuil.actif_id));
+
+              return (
+                <li key={seuil.id}>
+                  <Carte className="seuils__carte">
+                    <div className="seuils__ligne">
+                      {type && <JetonClasse classe={type} />}
+                      <div className="seuils__intitule">
+                        <p className="seuils__nom">
+                          {nomCible(seuil)}{' '}
+                          {seuil.sens_seuil === 'au_dessus' ? 'au-dessus de' : 'en dessous de'}{' '}
+                          <Montant valeur={seuil.valeur_seuil} />
+                        </p>
+                        {seuil.ecart_pourcentage !== null && (
+                          <p className="seuils__sous-texte">
+                            reste <Montant valeur={seuil.ecart_pourcentage} type="pourcentage" />
+                          </p>
+                        )}
+                      </div>
+                    </div>
+
+                    <BarreProgression
+                      valeur={seuil.valeur_observee}
+                      cible={seuil.valeur_seuil}
+                      sens={seuil.sens_seuil}
+                      libelle={`Progression vers le seuil, ${nomCible(seuil)}`}
+                    />
+
+                    <button
+                      type="button"
+                      className="seuils__retrait"
+                      onClick={() => setARetirer(seuil)}
+                    >
+                      Retirer
+                      <span className="lecteur-ecran-seulement"> ce seuil, {nomCible(seuil)}</span>
+                    </button>
+                  </Carte>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+
+      {feuille}
+
+      {aRetirer && (
+        <Confirmation
+          titre="Retirer ce seuil ?"
+          consequence={`Le seuil ${nomCible(aRetirer)} ${aRetirer.sens_seuil === 'au_dessus' ? 'au-dessus de' : 'en dessous de'} ${formaterMontant(aRetirer.valeur_seuil)} ne surveillera plus rien. Vous pourrez en recréer un si besoin.`}
+          libelleConfirmation="Retirer le seuil"
+          enCours={retraitEnCours}
+          surConfirmation={confirmerRetrait}
+          surAnnulation={() => setARetirer(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Seuils.jsx
+++ b/frontend/src/pages/Seuils.jsx
@@ -132,6 +132,12 @@ export default function Seuils() {
 
   const taux = portefeuille?.taux_affichage?.eur_vers_usd ?? null;
 
+  // Sans taux, afficher() rend déjà la valeur en euros (garde ci-dessous) : le symbole
+  // montré doit retomber sur l'euro lui aussi, pour ne jamais écrire un montant en
+  // euros avec un symbole dollar. Cas étroit (échec du taux avec une préférence déjà
+  // en dollars) mais propre à cet écran, seul à survivre à l'échec du portefeuille.
+  const deviseAffichee = taux ? devise : 'EUR';
+
   // Conversion à l'affichage seulement, comme sur les trois autres écrans : les
   // montants restent en euros dans les données, seule la présentation change (D43).
   const afficher = useCallback(
@@ -271,7 +277,7 @@ export default function Seuils() {
                           {masque ? (
                             <span aria-label="Montant masqué">••••</span>
                           ) : (
-                            <Montant valeur={afficher(seuil.valeur_seuil)} devise={devise} />
+                            <Montant valeur={afficher(seuil.valeur_seuil)} devise={deviseAffichee} />
                           )}
                         </p>
                         <p className="seuils__sous-texte">
@@ -317,7 +323,7 @@ export default function Seuils() {
                           {masque ? (
                             <span aria-label="Montant masqué">••••</span>
                           ) : (
-                            <Montant valeur={afficher(seuil.valeur_seuil)} devise={devise} />
+                            <Montant valeur={afficher(seuil.valeur_seuil)} devise={deviseAffichee} />
                           )}
                         </p>
                         {/* Un pourcentage, jamais converti ni masqué, au même titre que
@@ -334,7 +340,7 @@ export default function Seuils() {
                     <BarreProgression
                       valeur={afficher(seuil.valeur_observee)}
                       cible={afficher(seuil.valeur_seuil)}
-                      devise={devise}
+                      devise={deviseAffichee}
                       masque={masque}
                       sens={seuil.sens_seuil}
                       libelle={`Progression vers le seuil, ${nomCible(seuil)}`}
@@ -371,7 +377,7 @@ export default function Seuils() {
               {masque ? (
                 <span aria-label="Montant masqué">••••</span>
               ) : (
-                formaterMontant(afficher(aRetirer.valeur_seuil), { symbole: symboleDevise(devise) })
+                formaterMontant(afficher(aRetirer.valeur_seuil), { symbole: symboleDevise(deviseAffichee) })
               )}{' '}
               ne surveillera plus rien. Vous pourrez en recréer un si besoin.
             </>

--- a/frontend/src/pages/Seuils.jsx
+++ b/frontend/src/pages/Seuils.jsx
@@ -3,7 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import { useAuthentification } from '../contexte/contexteAuthentification';
 import { useSeuil } from '../hooks/useSeuil';
 import { api, ErreurApi } from '../services/api';
-import { formaterMontant } from '../utils/formatage';
+import { convertir } from '../utils/conversion';
+import { formaterMontant, symboleDevise } from '../utils/formatage';
+import { lirePreference, ecrirePreference, CLE_DEVISE, CLE_MASQUAGE } from '../utils/preferences';
 import Bouton from '../composants/Bouton';
 import Carte from '../composants/Carte';
 import JetonClasse from '../composants/JetonClasse';
@@ -15,6 +17,8 @@ import EtatVide from '../composants/EtatVide';
 import Squelette from '../composants/Squelette';
 import MessageErreur from '../composants/MessageErreur';
 import Message from '../composants/Message';
+import BasculeDevise from '../composants/BasculeDevise';
+import MasquageMontants from '../composants/MasquageMontants';
 import './Seuils.css';
 
 // Écran Seuils.
@@ -31,6 +35,13 @@ import './Seuils.css';
 //
 // Un seuil désactivé ne surveille plus rien : comme dans l'onglet Seuils de l'écran de
 // détail, il disparaît de la liste après son retrait plutôt que d'y rester barré.
+//
+// La devise d'affichage et le masquage des montants sont des préférences globales,
+// déjà appliquées aux écrans Patrimoine, Positions et Détail d'une position : cet écran
+// reprend exactement le même mécanisme (D83), y compris dans le texte de confirmation
+// du retrait, qui masque le seuil au même titre que n'importe quel autre montant
+// affiché — rien ne justifie qu'un dialogue de confirmation échappe à une préférence
+// qui s'applique partout ailleurs.
 const STATUTS_AFFICHES = ['active', 'declenchee'];
 
 function natureDeLErreur(erreur) {
@@ -73,14 +84,18 @@ export default function Seuils() {
   const [aRetirer, setARetirer] = useState(null);
   const [retraitEnCours, setRetraitEnCours] = useState(false);
 
+  const [devise, setDevise] = useState(() => lirePreference(CLE_DEVISE, 'EUR'));
+  const [masque, setMasque] = useState(() => lirePreference(CLE_MASQUAGE, 'non') === 'oui');
+
   const charger = useCallback(async () => {
     setChargement(true);
     setErreur(null);
 
     try {
-      // Le portefeuille n'est demandé que pour la feuille de création, qui a besoin
-      // des cours et de la valeur totale : son échec ne doit donc pas priver l'écran
-      // de la liste des seuils, qui reste l'information principale.
+      // Le portefeuille sert à la fois à la feuille de création, qui a besoin des cours
+      // et de la valeur totale, et à la bascule euro/dollar, qui a besoin du taux
+      // d'affichage porté par cette même réponse (D69, D43) : son échec ne doit donc
+      // pas priver l'écran de la liste des seuils, qui reste l'information principale.
       const [alertes, portefeuilleCourant] = await Promise.all([
         api.alertes(jeton),
         api.portefeuille(jeton).catch(() => null),
@@ -114,6 +129,23 @@ export default function Seuils() {
     }
     return table;
   }, [portefeuille]);
+
+  const taux = portefeuille?.taux_affichage?.eur_vers_usd ?? null;
+
+  // Conversion à l'affichage seulement, comme sur les trois autres écrans : les
+  // montants restent en euros dans les données, seule la présentation change (D43).
+  const afficher = useCallback(
+    (montantEnEuros) => {
+      if (montantEnEuros === null || montantEnEuros === undefined) {
+        return null;
+      }
+      if (devise === 'EUR' || !taux) {
+        return montantEnEuros;
+      }
+      return convertir(montantEnEuros, taux);
+    },
+    [devise, taux]
+  );
 
   async function confirmerRetrait() {
     setRetraitEnCours(true);
@@ -193,7 +225,24 @@ export default function Seuils() {
     <div className="seuils">
       <div className="seuils__entete">
         <h1 className="seuils__titre">Seuils</h1>
-        <Bouton onClick={() => seuilFeuille.ouvrir()}>+ Seuil</Bouton>
+        <div className="seuils__outils">
+          <Bouton onClick={() => seuilFeuille.ouvrir()}>+ Seuil</Bouton>
+          <BasculeDevise
+            devise={devise}
+            indisponible={!taux}
+            surChangement={(choix) => {
+              setDevise(choix);
+              ecrirePreference(CLE_DEVISE, choix);
+            }}
+          />
+          <MasquageMontants
+            masque={masque}
+            surChangement={(valeur) => {
+              setMasque(valeur);
+              ecrirePreference(CLE_MASQUAGE, valeur ? 'oui' : 'non');
+            }}
+          />
+        </div>
       </div>
 
       {erreur && <MessageErreur nature={natureDeLErreur(erreur)} surAction={charger} />}
@@ -219,7 +268,11 @@ export default function Seuils() {
                         <p className="seuils__nom">
                           {nomCible(seuil)}{' '}
                           {seuil.sens_seuil === 'au_dessus' ? 'au-dessus de' : 'en dessous de'}{' '}
-                          <Montant valeur={seuil.valeur_seuil} />
+                          {masque ? (
+                            <span aria-label="Montant masqué">••••</span>
+                          ) : (
+                            <Montant valeur={afficher(seuil.valeur_seuil)} devise={devise} />
+                          )}
                         </p>
                         <p className="seuils__sous-texte">
                           {date ? `Franchi le ${date}` : 'Franchi'}
@@ -261,8 +314,15 @@ export default function Seuils() {
                         <p className="seuils__nom">
                           {nomCible(seuil)}{' '}
                           {seuil.sens_seuil === 'au_dessus' ? 'au-dessus de' : 'en dessous de'}{' '}
-                          <Montant valeur={seuil.valeur_seuil} />
+                          {masque ? (
+                            <span aria-label="Montant masqué">••••</span>
+                          ) : (
+                            <Montant valeur={afficher(seuil.valeur_seuil)} devise={devise} />
+                          )}
                         </p>
+                        {/* Un pourcentage, jamais converti ni masqué, au même titre que
+                            la performance ou la répartition ailleurs dans l'application :
+                            il ne représente pas un montant, seule une devise en porte. */}
                         {seuil.ecart_pourcentage !== null && (
                           <p className="seuils__sous-texte">
                             reste <Montant valeur={seuil.ecart_pourcentage} type="pourcentage" />
@@ -272,8 +332,10 @@ export default function Seuils() {
                     </div>
 
                     <BarreProgression
-                      valeur={seuil.valeur_observee}
-                      cible={seuil.valeur_seuil}
+                      valeur={afficher(seuil.valeur_observee)}
+                      cible={afficher(seuil.valeur_seuil)}
+                      devise={devise}
+                      masque={masque}
                       sens={seuil.sens_seuil}
                       libelle={`Progression vers le seuil, ${nomCible(seuil)}`}
                     />
@@ -299,7 +361,21 @@ export default function Seuils() {
       {aRetirer && (
         <Confirmation
           titre="Retirer ce seuil ?"
-          consequence={`Le seuil ${nomCible(aRetirer)} ${aRetirer.sens_seuil === 'au_dessus' ? 'au-dessus de' : 'en dessous de'} ${formaterMontant(aRetirer.valeur_seuil)} ne surveillera plus rien. Vous pourrez en recréer un si besoin.`}
+          // Le montant du seuil suit la même préférence de masquage que le reste de
+          // l'écran : rien ne justifie qu'un dialogue de confirmation échappe à une
+          // préférence qui s'applique partout ailleurs.
+          consequence={
+            <>
+              Le seuil {nomCible(aRetirer)}{' '}
+              {aRetirer.sens_seuil === 'au_dessus' ? 'au-dessus de' : 'en dessous de'}{' '}
+              {masque ? (
+                <span aria-label="Montant masqué">••••</span>
+              ) : (
+                formaterMontant(afficher(aRetirer.valeur_seuil), { symbole: symboleDevise(devise) })
+              )}{' '}
+              ne surveillera plus rien. Vous pourrez en recréer un si besoin.
+            </>
+          }
           libelleConfirmation="Retirer le seuil"
           enCours={retraitEnCours}
           surConfirmation={confirmerRetrait}

--- a/frontend/src/pages/__tests__/DetailPosition.test.jsx
+++ b/frontend/src/pages/__tests__/DetailPosition.test.jsx
@@ -509,3 +509,67 @@ describe('saisie d’un mouvement', () => {
   });
 });
 
+// Spécification E4, section Interactions : « Création d'un seuil pré-réglée sur cet
+// actif. » L'écran de détail ne connaît qu'une position : la feuille s'ouvre restreinte
+// à elle, sans proposer le patrimoine total, dont la valeur n'est pas chargée ici (D83).
+describe('saisie d’un seuil depuis l’onglet Seuils', () => {
+  async function ouvrirOngletSeuils(utilisateur) {
+    rendre();
+    await screen.findByRole('heading', { name: 'Bitcoin', level: 1 });
+    await utilisateur.click(screen.getByRole('tab', { name: /Seuils/ }));
+  }
+
+  it('propose la création même quand des seuils existent déjà', async () => {
+    const utilisateur = userEvent.setup();
+    await ouvrirOngletSeuils(utilisateur);
+
+    expect(screen.getByRole('button', { name: '+ Seuil' })).toBeTruthy();
+  });
+
+  it('propose la création sur une position sans aucun seuil', async () => {
+    api.alertes.mockResolvedValue([]);
+    const utilisateur = userEvent.setup();
+    await ouvrirOngletSeuils(utilisateur);
+
+    expect(screen.getByText('Aucun seuil ne surveille cette position.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: '+ Seuil' })).toBeTruthy();
+  });
+
+  it('ouvre la feuille déjà réglée sur la position, sans option de patrimoine total', async () => {
+    const utilisateur = userEvent.setup();
+    await ouvrirOngletSeuils(utilisateur);
+
+    await utilisateur.click(screen.getByRole('button', { name: '+ Seuil' }));
+
+    expect(screen.getByRole('dialog', { name: 'Nouveau seuil — Bitcoin (BTC)' })).toBeTruthy();
+    expect(screen.getByLabelText('Cible').value).toBe('actif:1');
+    const options = within(screen.getByLabelText('Cible')).getAllByRole('option');
+    expect(options.map((option) => option.value)).not.toContain('capital_total');
+  });
+
+  it('recharge la fiche et confirme après la création du seuil', async () => {
+    vi.spyOn(api, 'creerAlerte').mockResolvedValue({
+      id: 12,
+      utilisateur_id: 2,
+      actif_id: 1,
+      type_cible: 'actif',
+      sens_seuil: 'au_dessus',
+      valeur_seuil: '75000.00',
+      statut: 'active',
+      date_creation: '2026-08-26T10:00:00.000Z',
+      date_declenchement: null,
+    });
+
+    const utilisateur = userEvent.setup();
+    await ouvrirOngletSeuils(utilisateur);
+
+    await utilisateur.click(screen.getByRole('button', { name: '+ Seuil' }));
+    await utilisateur.type(screen.getByLabelText(/^Seuil de déclenchement/), '75000');
+    await utilisateur.click(screen.getByRole('button', { name: 'Créer le seuil' }));
+
+    expect(await screen.findByText(/Seuil créé pour Bitcoin \(BTC\)/)).toBeTruthy();
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(api.actif).toHaveBeenCalledTimes(2);
+  });
+});
+

--- a/frontend/src/pages/__tests__/Seuils.test.jsx
+++ b/frontend/src/pages/__tests__/Seuils.test.jsx
@@ -5,6 +5,7 @@ import { MemoryRouter, useLocation } from 'react-router-dom';
 import Seuils from '../Seuils';
 import * as contexte from '../../contexte/contexteAuthentification';
 import { api, ErreurApi } from '../../services/api';
+import { CLE_DEVISE } from '../../utils/preferences';
 
 // L'écran est testé sur ses règles de comportement : les deux groupes, l'écart restant
 // affiché en toutes lettres et non seulement par la barre, le retrait, et l'ouverture de
@@ -214,6 +215,21 @@ describe('préférences d’affichage globales (D83)', () => {
     // Un pourcentage n'est jamais masqué, au même titre que les autres écrans.
     expect(screen.getByText(/reste/)).toBeTruthy();
     expect(screen.getByText(/6,1/)).toBeTruthy();
+  });
+
+  // Cas signalé en revue : le taux peut manquer (échec du chargement du portefeuille)
+  // alors qu'une préférence en dollars a été mémorisée sur un autre écran. afficher()
+  // rend déjà la valeur en euros dans ce cas ; c'est le symbole qui doit suivre, sous
+  // peine d'écrire un montant en euros avec un signe dollar.
+  it("retombe sur l'euro quand le taux est indisponible, même préféré en dollars", async () => {
+    window.sessionStorage.setItem(CLE_DEVISE, 'USD');
+    api.portefeuille.mockRejectedValue(new Error('indisponible'));
+
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+
+    expect((await screen.findAllByText(/65.000 €/)).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/76.043,5/)).toBeNull();
   });
 
   it('masque également le montant du seuil dans le dialogue de retrait', async () => {

--- a/frontend/src/pages/__tests__/Seuils.test.jsx
+++ b/frontend/src/pages/__tests__/Seuils.test.jsx
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import Seuils from '../Seuils';
+import * as contexte from '../../contexte/contexteAuthentification';
+import { api, ErreurApi } from '../../services/api';
+
+// L'écran est testé sur ses règles de comportement : les deux groupes, l'écart restant
+// affiché en toutes lettres et non seulement par la barre, le retrait, et l'ouverture de
+// la feuille de création. Les valeurs dérivées (valeur_observee, ecart_pourcentage)
+// sont celles que le serveur rend déjà : l'écran ne les recalcule pas (D69), le jeu
+// d'essai reproduit donc la forme exacte de la réponse.
+
+const SEUILS = [
+  {
+    id: 1,
+    utilisateur_id: 2,
+    actif_id: 1,
+    type_cible: 'actif',
+    sens_seuil: 'au_dessus',
+    valeur_seuil: '65000.00',
+    statut: 'active',
+    date_creation: '2026-08-01T10:00:00.000Z',
+    date_declenchement: null,
+    symbole: 'BTC',
+    nom_actif: 'Bitcoin',
+    valeur_observee: '61240.00',
+    ecart_pourcentage: '6.14',
+  },
+  {
+    id: 2,
+    utilisateur_id: 2,
+    actif_id: null,
+    type_cible: 'capital_total',
+    sens_seuil: 'au_dessus',
+    valeur_seuil: '45000.00',
+    statut: 'declenchee',
+    date_creation: '2026-07-01T10:00:00.000Z',
+    date_declenchement: '2026-08-23T15:34:10.000Z',
+    symbole: null,
+    nom_actif: null,
+    valeur_observee: '58566.64',
+    ecart_pourcentage: '0',
+  },
+  {
+    id: 3,
+    utilisateur_id: 2,
+    actif_id: 4,
+    type_cible: 'actif',
+    sens_seuil: 'en_dessous',
+    valeur_seuil: '1.40',
+    statut: 'desactivee',
+    date_creation: '2026-06-01T10:00:00.000Z',
+    date_declenchement: null,
+    symbole: 'XAU',
+    nom_actif: 'Or',
+    valeur_observee: null,
+    ecart_pourcentage: null,
+  },
+];
+
+const PORTEFEUILLE = {
+  valeur_totale: '58566.64',
+  actifs: [
+    { id: 1, type: 'crypto', symbole: 'BTC', nom: 'Bitcoin', cours_eur: '61240.00' },
+    { id: 4, type: 'metal', symbole: 'XAU', nom: 'Or', cours_eur: null },
+  ],
+};
+
+let adresse = null;
+function Sonde() {
+  adresse = useLocation();
+  return null;
+}
+
+function rendre(entree = '/seuils') {
+  vi.spyOn(contexte, 'useAuthentification').mockReturnValue({
+    jeton: 'jeton-de-test',
+    utilisateur: { pseudo: 'Camille' },
+    estConnecte: true,
+  });
+
+  return render(
+    <MemoryRouter initialEntries={[entree]}>
+      <Sonde />
+      <Seuils />
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.spyOn(api, 'alertes').mockResolvedValue(SEUILS);
+  vi.spyOn(api, 'portefeuille').mockResolvedValue(PORTEFEUILLE);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('composition', () => {
+  it('sépare les seuils franchis des seuils en cours, dans cet ordre', async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+
+    const titres = screen.getAllByRole('heading', { level: 2 }).map((titre) => titre.textContent);
+    expect(titres).toEqual(['Franchis', 'En cours']);
+  });
+
+  it('exclut les seuils désactivés de la liste', async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+
+    expect(screen.queryByText(/Or/)).toBeNull();
+  });
+
+  // Le pourcentage restant est toujours écrit en toutes lettres à côté de la barre :
+  // ce n'est pas elle qui porte seule l'information.
+  it("écrit l'écart restant en toutes lettres à côté de la barre", async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+
+    expect(screen.getByText(/reste/)).toBeTruthy();
+    expect(screen.getByText(/6,1/)).toBeTruthy();
+    expect(screen.getByRole('progressbar')).toBeTruthy();
+  });
+
+  it('porte la date de franchissement sur un seuil franchi', async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+
+    expect(screen.getByText(/Franchi le/)).toBeTruthy();
+  });
+
+  it('affiche le portefeuille vide sans seuil comme un état à combler', async () => {
+    api.alertes.mockResolvedValue([]);
+    rendre();
+
+    expect(await screen.findByText('Aucun seuil')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Créer un seuil' })).toBeTruthy();
+  });
+});
+
+describe('retrait', () => {
+  it('demande confirmation avant de retirer un seuil', async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+
+    await utilisateur.click(screen.getAllByRole('button', { name: /Retirer/ })[0]);
+
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText(/ne surveillera plus rien/)).toBeTruthy();
+  });
+
+  it('retire le seuil confirmé et recharge la liste', async () => {
+    const utilisateur = userEvent.setup();
+    vi.spyOn(api, 'desactiverAlerte').mockResolvedValue({ id: 2, statut: 'desactivee' });
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+
+    // Les seuils franchis sont listés en premier : c'est celui-là que cible le premier
+    // bouton de retrait rencontré dans le document.
+    await utilisateur.click(screen.getAllByRole('button', { name: /Retirer/ })[0]);
+    await utilisateur.click(screen.getByRole('button', { name: 'Retirer le seuil' }));
+
+    expect(api.desactiverAlerte).toHaveBeenCalledWith('jeton-de-test', 2);
+    await waitFor(() => expect(api.alertes).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe('saisie d’un seuil', () => {
+  it("ouvre la feuille par-dessus la liste et l'inscrit dans l'adresse", async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+
+    await utilisateur.click(screen.getByRole('button', { name: '+ Seuil' }));
+
+    expect(screen.getByRole('dialog', { name: 'Nouveau seuil' })).toBeTruthy();
+    expect(adresse.search).toContain('seuil=nouveau');
+  });
+
+  it('recharge les seuils et confirme après une création', async () => {
+    const utilisateur = userEvent.setup();
+    vi.spyOn(api, 'creerAlerte').mockResolvedValue({
+      id: 9,
+      utilisateur_id: 2,
+      actif_id: null,
+      type_cible: 'capital_total',
+      sens_seuil: 'au_dessus',
+      valeur_seuil: '80000.00',
+      statut: 'active',
+      date_creation: '2026-08-26T10:00:00.000Z',
+      date_declenchement: null,
+    });
+
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+    const chargements = api.alertes.mock.calls.length;
+
+    await utilisateur.click(screen.getByRole('button', { name: '+ Seuil' }));
+    await utilisateur.type(screen.getByLabelText(/^Seuil de déclenchement/), '80000');
+    await utilisateur.click(screen.getByRole('button', { name: 'Créer le seuil' }));
+
+    expect(await screen.findByText(/Seuil créé pour Patrimoine total/)).toBeTruthy();
+    expect(screen.queryByRole('dialog')).toBeNull();
+    await waitFor(() => expect(api.alertes.mock.calls.length).toBeGreaterThan(chargements));
+  });
+});
+
+describe('erreurs et chargement', () => {
+  it("affiche l'état de chargement puis la liste", async () => {
+    rendre();
+    expect(screen.getByRole('status')).toBeTruthy();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+  });
+
+  it('signale une session expirée sans dévoiler les seuils', async () => {
+    api.alertes.mockRejectedValue(new ErreurApi('Jeton expiré.', 401));
+    rendre();
+
+    expect(await screen.findByText('Session expirée')).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/__tests__/Seuils.test.jsx
+++ b/frontend/src/pages/__tests__/Seuils.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { render, screen, cleanup, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import Seuils from '../Seuils';
@@ -58,6 +58,24 @@ const SEUILS = [
     valeur_observee: null,
     ecart_pourcentage: null,
   },
+  // Seuil en cours dont le cours de la cible est indisponible : la barre l'annonce
+  // par une mention explicite plutôt qu'une progression à zéro, qui mentirait. Un
+  // actif distinct de l'or, pour ne pas interférer avec le seuil désactivé ci-dessus.
+  {
+    id: 4,
+    utilisateur_id: 2,
+    actif_id: 5,
+    type_cible: 'actif',
+    sens_seuil: 'au_dessus',
+    valeur_seuil: '200.00',
+    statut: 'active',
+    date_creation: '2026-08-10T10:00:00.000Z',
+    date_declenchement: null,
+    symbole: 'AAPL',
+    nom_actif: 'Apple',
+    valeur_observee: null,
+    ecart_pourcentage: null,
+  },
 ];
 
 const PORTEFEUILLE = {
@@ -65,7 +83,13 @@ const PORTEFEUILLE = {
   actifs: [
     { id: 1, type: 'crypto', symbole: 'BTC', nom: 'Bitcoin', cours_eur: '61240.00' },
     { id: 4, type: 'metal', symbole: 'XAU', nom: 'Or', cours_eur: null },
+    { id: 5, type: 'action', symbole: 'AAPL', nom: 'Apple', cours_eur: null },
   ],
+  taux_affichage: {
+    eur_vers_usd: '1.1699',
+    usd_vers_eur: '0.85477',
+    horodatage: '2026-08-26T00:00:00.000Z',
+  },
 };
 
 let adresse = null;
@@ -92,6 +116,10 @@ function rendre(entree = '/seuils') {
 beforeEach(() => {
   vi.spyOn(api, 'alertes').mockResolvedValue(SEUILS);
   vi.spyOn(api, 'portefeuille').mockResolvedValue(PORTEFEUILLE);
+  // Sans ce nettoyage, la préférence de masquage écrite par un test antérieur
+  // survivrait au montage suivant : sessionStorage n'est pas réinitialisé entre les
+  // tests d'un même fichier, seulement entre les fichiers.
+  window.sessionStorage.clear();
 });
 
 afterEach(() => {
@@ -139,6 +167,65 @@ describe('composition', () => {
 
     expect(await screen.findByText('Aucun seuil')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Créer un seuil' })).toBeTruthy();
+  });
+});
+
+describe('cours indisponible sur la cible', () => {
+  it("affiche la mention de progression indisponible plutôt qu'une barre à zéro", async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+
+    expect(screen.getByText(/Cours indisponible : la progression/)).toBeTruthy();
+  });
+
+  it("n'affiche pas d'écart restant quand la valeur observée est nulle", async () => {
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+
+    const carte = screen.getAllByText(/Apple/)[0].closest('li');
+    expect(within(carte).queryByText(/reste/)).toBeNull();
+  });
+});
+
+describe('préférences d’affichage globales (D83)', () => {
+  it('convertit les montants du seuil et de la barre sans nouvelle requête', async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+    const appelsAvant = api.alertes.mock.calls.length + api.portefeuille.mock.calls.length;
+
+    await utilisateur.click(screen.getByLabelText('Afficher les montants en dollars'));
+
+    // 65 000 x 1,1699 = 76 043,5 : le seuil Bitcoin, converti à l'affichage. La valeur
+    // apparaît deux fois par ligne, dans l'intitulé et dans les repères de la barre.
+    expect((await screen.findAllByText(/76.043,5/)).length).toBeGreaterThan(0);
+    expect(api.alertes.mock.calls.length + api.portefeuille.mock.calls.length).toBe(appelsAvant);
+  });
+
+  it("remplace les montants par des points au masquage, sans toucher à l'écart en pourcentage", async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+
+    await utilisateur.click(screen.getByLabelText('Masquer les montants'));
+
+    expect(screen.getAllByLabelText('Montant masqué').length).toBeGreaterThan(0);
+    expect(screen.queryByText(/65.000/)).toBeNull();
+    // Un pourcentage n'est jamais masqué, au même titre que les autres écrans.
+    expect(screen.getByText(/reste/)).toBeTruthy();
+    expect(screen.getByText(/6,1/)).toBeTruthy();
+  });
+
+  it('masque également le montant du seuil dans le dialogue de retrait', async () => {
+    const utilisateur = userEvent.setup();
+    rendre();
+    await screen.findByRole('heading', { name: 'Seuils', level: 1 });
+
+    await utilisateur.click(screen.getByLabelText('Masquer les montants'));
+    await utilisateur.click(screen.getAllByRole('button', { name: /Retirer/ })[0]);
+
+    const dialogue = screen.getByRole('dialog');
+    expect(within(dialogue).getByLabelText('Montant masqué')).toBeTruthy();
   });
 });
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -116,5 +116,13 @@ export const api = {
     }),
   supprimerTransaction: (jeton, actifId, transactionId) =>
     requete(`/actifs/${actifId}/transactions/${transactionId}`, { methode: 'DELETE', jeton }),
+  // Chaque alerte revient enrichie de la valeur actuellement observée sur sa cible et
+  // de l'écart restant avant franchissement, en pourcentage : deux valeurs dérivées
+  // d'un montant, calculées par le serveur et non recalculées ici (D69).
   alertes: (jeton) => requete('/alertes', { jeton }),
+  creerAlerte: (jeton, donnees) => requete('/alertes', { methode: 'POST', corps: donnees, jeton }),
+  // Seule la désactivation est exposée par le contrat : c'est la seule mutation de
+  // statut qu'accepte le schéma de validation du serveur.
+  desactiverAlerte: (jeton, id) =>
+    requete(`/alertes/${id}`, { methode: 'PATCH', corps: { statut: 'desactivee' }, jeton }),
 };


### PR DESCRIPTION
## Description

Lot E6 — Seuils. Liste des seuils en deux groupes, franchis puis en cours, plutôt qu'un filtre à bascule comme le montrait le prototype : la spécification veut les deux visibles ensemble, le franchissement étant l'information la plus importante et devant donc ouvrir la liste plutôt que se cacher derrière un clic. Chaque ligne en cours porte, écrit en toutes lettres à côté de la barre de progression, l'écart restant avant franchissement — la barre ne porte jamais seule l'information.

Cet écart, comme la valeur actuellement observée sur la cible, est une valeur dérivée d'un montant : D69 la nomme explicitement (« franchissements de seuil »), elle est donc calculée par le serveur. `GET /api/alertes` s'enrichit de façon additive de deux champs, `valeur_observee` et `ecart_pourcentage`, sans nouvelle route. Le service des alertes est converti en fabrique recevant ses dépendances, comme ceux du portefeuille, de l'authentification et des transactions, ce qui le rend testable sans base. Une nouvelle méthode de lecture du service du portefeuille, `obtenirValeursObservees`, fournit le cours de chaque position et la valeur totale du patrimoine sans les effets de bord d'`obtenirPortefeuille` (pas d'historisation, pas de marquage des alertes, déjà faits au chargement du tableau de bord, D50).

Côté interface, `FeuilleSeuil` réutilise le composant `Feuille` posé par E5 : même dialogue modal, même piège à focus, même fermeture par Échap. La cible se choisit entre le patrimoine total et un actif suivi ; quatre décalages rapides à -10, -5, +5 et +10 % pré-remplissent le seuil à distance de la valeur actuelle de la cible, en arithmétique exacte et non en virgule flottante — un décalage n'est qu'une proposition de saisie, mais elle doit être aussi exacte qu'une valeur tapée à la main. Le retrait d'un seuil le désactive et le fait disparaître de la liste, comme dans l'onglet Seuils de l'écran de détail, dont l'écran reprend la même convention de statuts affichés. L'ouverture de la feuille est portée par le paramètre `?seuil` de l'adresse, sur le même principe que `?mouvement` (E5).

L'entrée de navigation « Seuils », jusque-là désactivée, est activée.

**Un point de périmètre tranché en écrivant ce lot.** La création d'un seuil depuis l'onglet Seuils de l'écran de détail d'une position (E4), envisagée comme suite naturelle et déjà notée en dette, n'a pas été intégrée : la spécification E6 ne porte que sur l'écran Seuils lui-même, et l'ajouter aurait engagé un choix non trivial sur la donnée de patrimoine total à transmettre depuis cet écran, qui ne la charge pas aujourd'hui. `FeuilleSeuil` est prêt pour cette intégration le jour où elle sera demandée ; la dette reste documentée dans `TODO.md`.

## Vérifications

Contrat contrôlé contre une réponse réelle du serveur, sur le compte de démonstration : seuil déjà franchi (`ecart_pourcentage` à `"0"`), seuil en cours (écart recalculé à la main sur la position réelle, écart nul), seuil désactivé toujours enrichi côté serveur mais exclu de l'affichage côté écran, création et retrait vérifiés de bout en bout.

231 tests back (+13), 228 tests front (+24), lint muet, build sans avertissement.

## Issue liée

Closes #118
Closes #119

## Liste de contrôle

- [x] Le code respecte l'architecture du projet (routes → middlewares → controllers → services → models)
- [x] Les entrées utilisateur sont validées côté serveur
- [x] Les requêtes SQL sont préparées (pas de concaténation de chaînes)
- [x] La vérification de propriété est appliquée sur les ressources concernées
- [x] Aucun secret ni clé d'API n'est présent dans le diff
- [x] Les tests existants passent, et de nouveaux tests couvrent le changement si pertinent
- [x] La documentation concernée est à jour (README, docs/, commentaires)
- [x] Le message des commits respecte `docs/convention-commits.md`