### PR TITLE
E7 - Écran Compte, gestion du compte et export CSV des mouvements

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -6,6 +6,7 @@ const routeurAuthentification = require('./routes/authentification');
 const routeurActif = require('./routes/actif');
 const routeurPortefeuille = require('./routes/portefeuille');
 const routeurAlerte = require('./routes/alerte');
+const routeurCompte = require('./routes/compte');
 const gestionErreurs = require('./middlewares/gestionErreurs');
 
 const app = express();
@@ -18,6 +19,10 @@ app.use(
   cors({
     origin: config.origineAutorisee,
     allowedHeaders: ['Content-Type', 'Authorization'],
+    // L'export des mouvements transmet le nom du fichier par Content-Disposition. Ce
+    // n'est pas un en-tête exposé par défaut : sans cette ligne, l'interface ne
+    // pourrait pas le lire le jour où elle ne serait plus servie sous la même origine.
+    exposedHeaders: ['Content-Disposition'],
   })
 );
 app.use(express.json());
@@ -30,6 +35,7 @@ app.use('/api/auth', routeurAuthentification);
 app.use('/api/actifs', routeurActif);
 app.use('/api/portefeuille', routeurPortefeuille);
 app.use('/api/alertes', routeurAlerte);
+app.use('/api/compte', routeurCompte);
 
 // Toujours en dernier : Express n'y passe que si une route a appelé next(erreur).
 app.use(gestionErreurs);

--- a/backend/src/controllers/compte.js
+++ b/backend/src/controllers/compte.js
@@ -1,0 +1,51 @@
+// Contrôleurs de la gestion du compte. Le propriétaire est toujours le porteur du
+// jeton, jamais un identifiant reçu du client : aucune de ces routes n'accepte de
+// paramètre désignant un utilisateur, il n'y a donc rien à contrôler de ce côté.
+
+const serviceCompte = require('../services/compte');
+
+async function changerMotDePasse(req, res, next) {
+  try {
+    await serviceCompte.changerMotDePasse({
+      utilisateurId: req.utilisateur.id,
+      ancienMotDePasse: req.body.ancienMotDePasse,
+      nouveauMotDePasse: req.body.nouveauMotDePasse,
+    });
+    res.status(204).end();
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+async function supprimer(req, res, next) {
+  try {
+    await serviceCompte.supprimer({ utilisateurId: req.utilisateur.id });
+    res.status(204).end();
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+// Marque d'ordre des octets. Sans elle, un tableur sous Windows ouvre le fichier dans
+// l'encodage local et abîme les caractères accentués des noms de classe d'actif.
+const BOM = '﻿';
+
+// Seule route du back-end à ne pas répondre en JSON : elle produit un fichier, pas une
+// ressource à consommer par l'interface.
+async function exporterMouvements(req, res, next) {
+  try {
+    const { nomFichier, contenu } = await serviceCompte.exporterMouvements({
+      utilisateurId: req.utilisateur.id,
+    });
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${nomFichier}"`);
+    // Le nom du fichier est construit par le serveur à partir d'une date : il ne peut
+    // porter aucun caractère saisi par l'utilisateur, et rien n'est à échapper ici.
+    res.send(BOM + contenu);
+  } catch (erreur) {
+    next(erreur);
+  }
+}
+
+module.exports = { changerMotDePasse, supprimer, exporterMouvements };

--- a/backend/src/controllers/compte.js
+++ b/backend/src/controllers/compte.js
@@ -19,7 +19,10 @@ async function changerMotDePasse(req, res, next) {
 
 async function supprimer(req, res, next) {
   try {
-    await serviceCompte.supprimer({ utilisateurId: req.utilisateur.id });
+    await serviceCompte.supprimer({
+      utilisateurId: req.utilisateur.id,
+      motDePasse: req.body.motDePasse,
+    });
     res.status(204).end();
   } catch (erreur) {
     next(erreur);

--- a/backend/src/erreurs.js
+++ b/backend/src/erreurs.js
@@ -11,9 +11,16 @@ class ErreurMetier extends Error {
 }
 
 // Règle de gestion non respectée, au-delà de la simple forme des données.
+//
+// Le second paramètre, facultatif, rattache l'erreur à un ou plusieurs champs du
+// formulaire, au format exact que produit déjà le middleware de validation :
+// [{ champ, message }]. Il sert aux règles qu'un schéma ne peut pas trancher seul
+// parce qu'elles demandent la base — un ancien mot de passe à comparer, par exemple.
+// Sans lui, l'interface ne saurait que signaler l'erreur en tête de formulaire.
 class ErreurValidation extends ErreurMetier {
-  constructor(message) {
+  constructor(message, champs = null) {
     super(message, 400);
+    this.champs = champs;
   }
 }
 

--- a/backend/src/middlewares/__tests__/gestionErreurs.test.js
+++ b/backend/src/middlewares/__tests__/gestionErreurs.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+
+// Le gestionnaire trie les erreurs avec instanceof, ce qui exige que les classes du
+// test soient exactement celles qu'il voit lui-même. Les sources étant en CommonJS, les
+// charger ici par import ES donnerait deux jeux de classes distincts et toute erreur
+// métier tomberait dans la branche des erreurs inattendues. Le require natif place les
+// deux modules dans le même cache, comme à l'exécution réelle du serveur.
+const require = createRequire(import.meta.url);
+const gestionErreurs = require('../gestionErreurs.js');
+const { ErreurValidation, ErreurIntrouvable, ErreurAuthentification } = require('../../erreurs.js');
+
+// Même doublure de réponse que les autres tests de middleware : le gestionnaire n'a
+// besoin que de status() et json() pour être exercé.
+function creerReponse() {
+  return {
+    statut: null,
+    corps: null,
+    status(code) {
+      this.statut = code;
+      return this;
+    },
+    json(donnees) {
+      this.corps = donnees;
+      return this;
+    },
+  };
+}
+
+const requete = { method: 'PATCH', originalUrl: '/api/compte/mot-de-passe' };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('traduction des erreurs métier', () => {
+  it('rend le statut et le message de l’erreur', () => {
+    const res = creerReponse();
+
+    gestionErreurs(new ErreurIntrouvable('Actif introuvable.'), requete, res, vi.fn());
+
+    expect(res.statut).toBe(404);
+    expect(res.corps).toEqual({ erreur: 'Actif introuvable.' });
+  });
+
+  // Non-régression : les erreurs qui ne portent pas de détail par champ doivent rendre
+  // exactement le même corps qu'avant l'ajout de ce détail.
+  it('n’ajoute aucune clé champs quand l’erreur n’en porte pas', () => {
+    const res = creerReponse();
+
+    gestionErreurs(new ErreurAuthentification('Email ou mot de passe incorrect.'), requete, res, vi.fn());
+
+    expect(res.statut).toBe(401);
+    expect(Object.keys(res.corps)).toEqual(['erreur']);
+  });
+
+  it('transmet le détail par champ quand l’erreur en porte un', () => {
+    const res = creerReponse();
+    const champs = [{ champ: 'ancienMotDePasse', message: 'Ancien mot de passe incorrect.' }];
+
+    gestionErreurs(new ErreurValidation('Ancien mot de passe incorrect.', champs), requete, res, vi.fn());
+
+    expect(res.statut).toBe(400);
+    expect(res.corps).toEqual({ erreur: 'Ancien mot de passe incorrect.', champs });
+  });
+
+  it('rend une erreur de validation sans détail quand aucun champ n’est précisé', () => {
+    const res = creerReponse();
+
+    gestionErreurs(new ErreurValidation('Données invalides.'), requete, res, vi.fn());
+
+    expect(res.corps).toEqual({ erreur: 'Données invalides.' });
+  });
+});
+
+describe('erreurs inattendues', () => {
+  // Le client ne doit jamais recevoir le détail technique : ni la pile, ni le message
+  // d'origine, qui renseigneraient sur la structure interne de l'application.
+  it('masque le détail d’une erreur non métier derrière un message générique', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = creerReponse();
+
+    gestionErreurs(new Error('relation "utilisateur" does not exist'), requete, res, vi.fn());
+
+    expect(res.statut).toBe(500);
+    expect(res.corps).toEqual({ erreur: 'Une erreur interne est survenue.' });
+  });
+});

--- a/backend/src/middlewares/gestionErreurs.js
+++ b/backend/src/middlewares/gestionErreurs.js
@@ -11,7 +11,13 @@ const { ErreurMetier } = require('../erreurs');
 // eslint-disable-next-line no-unused-vars
 function gestionErreurs(erreur, req, res, next) {
   if (erreur instanceof ErreurMetier) {
-    return res.status(erreur.statut).json({ erreur: erreur.message });
+    // Le détail par champ n'est ajouté que si l'erreur en porte un : les erreurs
+    // existantes n'en ont pas et leur réponse reste inchangée.
+    const corps = { erreur: erreur.message };
+    if (erreur.champs) {
+      corps.champs = erreur.champs;
+    }
+    return res.status(erreur.statut).json(corps);
   }
 
   console.error(`Erreur non gérée sur ${req.method} ${req.originalUrl}`, erreur);

--- a/backend/src/models/transaction.js
+++ b/backend/src/models/transaction.js
@@ -22,6 +22,25 @@ async function listerParActifEtUtilisateur(actifId, utilisateurId) {
   return rows;
 }
 
+// Tous les mouvements d'un compte, actifs confondus, pour l'export. Le symbole et la
+// classe de l'actif sont joints ici plutôt que rapportés ensuite : la jointure est déjà
+// nécessaire au cloisonnement, et les demander à part multiplierait les requêtes.
+//
+// Ordre chronologique ascendant, à la différence de la lecture par actif ci-dessus qui
+// sert une frise antéchronologique. C'est l'ordre du domaine, celui de la règle 6 de
+// D54 : les mouvements se lisent dans l'ordre où ils ont produit leurs effets.
+async function listerParUtilisateur(utilisateurId) {
+  const { rows } = await query(
+    `SELECT ${CHAMPS}, a.symbole, a.type AS classe
+     FROM transaction t
+     JOIN actif a ON a.id = t.actif_id
+     WHERE a.utilisateur_id = $1
+     ORDER BY t.date_transaction ASC, t.id ASC`,
+    [utilisateurId]
+  );
+  return rows;
+}
+
 // L'insertion est filtrée de la même façon : le SELECT qui alimente l'INSERT ne rend
 // une ligne que si l'actif appartient bien au demandeur. Si ce n'est pas le cas,
 // aucune ligne n'est insérée et la fonction rend null.
@@ -50,4 +69,4 @@ async function supprimer(id, actifId, utilisateurId) {
   return rowCount > 0;
 }
 
-module.exports = { listerParActifEtUtilisateur, creer, supprimer };
+module.exports = { listerParActifEtUtilisateur, listerParUtilisateur, creer, supprimer };

--- a/backend/src/models/utilisateur.js
+++ b/backend/src/models/utilisateur.js
@@ -2,7 +2,9 @@
 // query() du pool et sont paramétrées : aucune valeur n'est concaténée dans du SQL.
 //
 // Règle appliquée ici : mot_de_passe_hache ne remonte jamais vers les couches
-// supérieures, à la seule exception de trouverParEmail (voir son commentaire).
+// supérieures, à deux exceptions près, trouverParEmail et trouverAvecHachageParId
+// (voir leurs commentaires). Toutes deux servent une comparaison bcrypt, jamais un
+// affichage, et leur résultat ne quitte pas le service qui les appelle.
 
 const { query } = require('../db');
 
@@ -43,4 +45,43 @@ async function trouverParId(id) {
   return rows[0] || null;
 }
 
-module.exports = { creerUtilisateur, trouverParEmail, trouverParId };
+// Seconde et dernière fonction à renvoyer le hachage. Le changement de mot de passe
+// doit comparer l'ancien mot de passe alors qu'il ne connaît que le porteur du jeton :
+// il dispose de l'identifiant, pas de l'email, d'où cette variante de trouverParEmail.
+async function trouverAvecHachageParId(id) {
+  const { rows } = await query(
+    `SELECT ${CHAMPS_PUBLICS}, mot_de_passe_hache
+     FROM utilisateur
+     WHERE id = $1`,
+    [id]
+  );
+  return rows[0] || null;
+}
+
+async function mettreAJourMotDePasse(id, motDePasseHache) {
+  const { rowCount } = await query(
+    `UPDATE utilisateur
+     SET mot_de_passe_hache = $2
+     WHERE id = $1`,
+    [id, motDePasseHache]
+  );
+  return rowCount > 0;
+}
+
+// La suppression s'arrête à cette ligne : actif, alerte et snapshot_valorisation
+// référencent utilisateur en ON DELETE CASCADE, et transaction comme snapshot_cours
+// cascadent à leur tour depuis actif. Supprimer table par table dupliquerait une règle
+// que le schéma porte déjà, avec le risque d'en oublier une à la prochaine table ajoutée.
+async function supprimer(id) {
+  const { rowCount } = await query('DELETE FROM utilisateur WHERE id = $1', [id]);
+  return rowCount > 0;
+}
+
+module.exports = {
+  creerUtilisateur,
+  trouverParEmail,
+  trouverParId,
+  trouverAvecHachageParId,
+  mettreAJourMotDePasse,
+  supprimer,
+};

--- a/backend/src/routes/compte.js
+++ b/backend/src/routes/compte.js
@@ -2,7 +2,7 @@ const express = require('express');
 const controleur = require('../controllers/compte');
 const valider = require('../middlewares/valider');
 const authentifier = require('../middlewares/authentifier');
-const { schemaChangementMotDePasse } = require('../validation/compte');
+const { schemaChangementMotDePasse, schemaSuppressionCompte } = require('../validation/compte');
 
 const routeur = express.Router();
 
@@ -11,7 +11,7 @@ const routeur = express.Router();
 routeur.use(authentifier);
 
 routeur.patch('/mot-de-passe', valider(schemaChangementMotDePasse), controleur.changerMotDePasse);
-routeur.delete('/', controleur.supprimer);
+routeur.delete('/', valider(schemaSuppressionCompte), controleur.supprimer);
 routeur.get('/export-mouvements', controleur.exporterMouvements);
 
 module.exports = routeur;

--- a/backend/src/routes/compte.js
+++ b/backend/src/routes/compte.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const controleur = require('../controllers/compte');
+const valider = require('../middlewares/valider');
+const authentifier = require('../middlewares/authentifier');
+const { schemaChangementMotDePasse } = require('../validation/compte');
+
+const routeur = express.Router();
+
+// Aucune de ces routes n'est publique : l'authentification est posée pour le routeur
+// entier plutôt que répétée à chaque ligne.
+routeur.use(authentifier);
+
+routeur.patch('/mot-de-passe', valider(schemaChangementMotDePasse), controleur.changerMotDePasse);
+routeur.delete('/', controleur.supprimer);
+routeur.get('/export-mouvements', controleur.exporterMouvements);
+
+module.exports = routeur;

--- a/backend/src/services/__tests__/compte.test.js
+++ b/backend/src/services/__tests__/compte.test.js
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import bcrypt from 'bcrypt';
+
+// Comme pour l'authentification, les modèles sont des doublures : ces tests portent sur
+// les règles du service, pas sur l'accès aux données. bcrypt, lui, n'est pas simulé —
+// c'est le hachage réel qui doit être vérifié.
+const MOT_DE_PASSE = 'motdepasse-actuel';
+const NOUVEAU = 'motdepasse-nouveau';
+
+let creerServiceCompte;
+let hachage;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = 'postgresql://utilisateur:secret@localhost:5432/capitall';
+  process.env.JWT_SECRET = 'f'.repeat(32);
+  ({ creerServiceCompte } = await import('../compte.js'));
+  // Haché une seule fois : bcrypt au coût 10 est volontairement lent.
+  hachage = await bcrypt.hash(MOT_DE_PASSE, 10);
+});
+
+function compte() {
+  return {
+    id: 7,
+    email: 'camille@example.fr',
+    pseudo: 'Camille',
+    role: 'utilisateur',
+    actif: true,
+    mot_de_passe_hache: hachage,
+  };
+}
+
+function monter({ utilisateur = compte(), misAJour = true, supprime = true, mouvements = [] } = {}) {
+  const utilisateurs = {
+    trouverAvecHachageParId: vi.fn().mockResolvedValue(utilisateur),
+    mettreAJourMotDePasse: vi.fn().mockResolvedValue(misAJour),
+    supprimer: vi.fn().mockResolvedValue(supprime),
+  };
+  const transactions = {
+    listerParUtilisateur: vi.fn().mockResolvedValue(mouvements),
+  };
+  return { service: creerServiceCompte({ utilisateurs, transactions }), utilisateurs, transactions };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('changement de mot de passe (E7)', () => {
+  it('remplace le hachage quand l’ancien mot de passe est correct', async () => {
+    const { service, utilisateurs } = monter();
+
+    await service.changerMotDePasse({
+      utilisateurId: 7,
+      ancienMotDePasse: MOT_DE_PASSE,
+      nouveauMotDePasse: NOUVEAU,
+    });
+
+    expect(utilisateurs.mettreAJourMotDePasse).toHaveBeenCalledTimes(1);
+    const [identifiant, nouveauHachage] = utilisateurs.mettreAJourMotDePasse.mock.calls[0];
+    expect(identifiant).toBe(7);
+    // Le hachage écrit n'est ni l'ancien, ni le mot de passe en clair, et il valide
+    // bien le nouveau mot de passe.
+    expect(nouveauHachage).not.toBe(hachage);
+    expect(nouveauHachage).not.toContain(NOUVEAU);
+    await expect(bcrypt.compare(NOUVEAU, nouveauHachage)).resolves.toBe(true);
+    await expect(bcrypt.compare(MOT_DE_PASSE, nouveauHachage)).resolves.toBe(false);
+  });
+
+  it('lit le compte par son identifiant, jamais par une donnée du client', async () => {
+    const { service, utilisateurs } = monter();
+
+    await service.changerMotDePasse({
+      utilisateurId: 7,
+      ancienMotDePasse: MOT_DE_PASSE,
+      nouveauMotDePasse: NOUVEAU,
+    });
+
+    expect(utilisateurs.trouverAvecHachageParId).toHaveBeenCalledWith(7);
+  });
+
+  it('refuse un ancien mot de passe incorrect et rattache l’erreur à son champ', async () => {
+    const { service, utilisateurs } = monter();
+
+    const echec = await service
+      .changerMotDePasse({
+        utilisateurId: 7,
+        ancienMotDePasse: 'ce-n-est-pas-le-bon',
+        nouveauMotDePasse: NOUVEAU,
+      })
+      .catch((erreur) => erreur);
+
+    expect(echec.statut).toBe(400);
+    expect(echec.champs).toEqual([
+      { champ: 'ancienMotDePasse', message: 'Ancien mot de passe incorrect.' },
+    ]);
+    // Rien n'est écrit tant que l'ancien mot de passe n'est pas prouvé.
+    expect(utilisateurs.mettreAJourMotDePasse).not.toHaveBeenCalled();
+  });
+
+  it('ne divulgue jamais le hachage dans le message d’erreur', async () => {
+    const { service } = monter();
+
+    const echec = await service
+      .changerMotDePasse({ utilisateurId: 7, ancienMotDePasse: 'faux', nouveauMotDePasse: NOUVEAU })
+      .catch((erreur) => erreur);
+
+    expect(echec.message).not.toContain(hachage);
+    expect(echec.message).not.toContain('$2b$');
+  });
+
+  it('rend 404 quand le porteur du jeton n’a plus de compte', async () => {
+    const { service } = monter({ utilisateur: null });
+
+    await expect(
+      service.changerMotDePasse({
+        utilisateurId: 7,
+        ancienMotDePasse: MOT_DE_PASSE,
+        nouveauMotDePasse: NOUVEAU,
+      })
+    ).rejects.toMatchObject({ statut: 404 });
+  });
+});
+
+describe('suppression du compte (E7)', () => {
+  it('supprime le compte du porteur du jeton', async () => {
+    const { service, utilisateurs } = monter();
+
+    await service.supprimer({ utilisateurId: 7 });
+
+    expect(utilisateurs.supprimer).toHaveBeenCalledWith(7);
+    expect(utilisateurs.supprimer).toHaveBeenCalledTimes(1);
+  });
+
+  it('rend 404 quand aucune ligne n’a été supprimée', async () => {
+    const { service } = monter({ supprime: false });
+
+    await expect(service.supprimer({ utilisateurId: 7 })).rejects.toMatchObject({ statut: 404 });
+  });
+});
+
+// Deux actifs, mouvements volontairement entrelacés dans le temps : l'export doit les
+// rendre dans l'ordre chronologique global, et non actif par actif.
+const MOUVEMENTS = [
+  {
+    id: 1,
+    actif_id: 10,
+    sens: 'achat',
+    quantite: '0.50000000',
+    prix_unitaire: '54000.00',
+    frais: '12.50',
+    date_transaction: '2026-07-15T10:00:00.000Z',
+    note: null,
+    symbole: 'BTC',
+    classe: 'crypto',
+  },
+  {
+    id: 2,
+    actif_id: 20,
+    sens: 'achat',
+    quantite: '10.00000000',
+    prix_unitaire: '62.30',
+    frais: '0.00',
+    date_transaction: '2026-07-20T09:00:00.000Z',
+    note: null,
+    symbole: 'XAU',
+    classe: 'metal',
+  },
+  {
+    id: 3,
+    actif_id: 10,
+    sens: 'vente',
+    quantite: '0.20000000',
+    prix_unitaire: '61000.00',
+    frais: '8.00',
+    date_transaction: '2026-08-02T14:30:00.000Z',
+    note: null,
+    symbole: 'BTC',
+    classe: 'crypto',
+  },
+];
+
+async function exporter(mouvements) {
+  const { service } = monter({ mouvements });
+  const { contenu, nomFichier } = await service.exporterMouvements({ utilisateurId: 7 });
+  const lignes = contenu.trimEnd().split('\r\n');
+  return { contenu, nomFichier, entete: lignes[0], lignes: lignes.slice(1) };
+}
+
+describe('export des mouvements (E7, D84)', () => {
+  it('rend les huit colonnes attendues, dans l’ordre', async () => {
+    const { entete } = await exporter(MOUVEMENTS);
+
+    expect(entete).toBe('date;type;actif;classe;quantite;prix_unitaire;frais;montant');
+  });
+
+  it('classe les mouvements de tous les actifs dans l’ordre chronologique', async () => {
+    const { lignes } = await exporter(MOUVEMENTS);
+
+    expect(lignes).toHaveLength(3);
+    expect(lignes[0]).toContain('2026-07-15');
+    expect(lignes[1]).toContain('2026-07-20');
+    expect(lignes[2]).toContain('2026-08-02');
+    // L'entrelacement est bien respecté : l'or s'intercale entre les deux mouvements
+    // de bitcoin plutôt que d'être rendu après eux.
+    expect(lignes[1]).toContain('XAU');
+  });
+
+  it('écrit les dates en ISO 8601 et les nombres en décimal brut', async () => {
+    const { lignes } = await exporter(MOUVEMENTS);
+
+    expect(lignes[0]).toBe('2026-07-15T10:00:00.000Z;achat;BTC;crypto;0.50000000;54000.00;12.50;27000.00');
+  });
+
+  it('exporte le montant du moteur, frais exclus (D84)', async () => {
+    const { lignes } = await exporter(MOUVEMENTS);
+
+    // 0,5 x 54 000 = 27 000, et les 12,50 de frais restent dans leur propre colonne
+    // plutôt que d'être additionnés au montant.
+    const champs = lignes[0].split(';');
+    expect(champs[6]).toBe('12.50');
+    expect(champs[7]).toBe('27000.00');
+
+    // Même règle sur une vente : 0,2 x 61 000 = 12 200, les 8,00 de frais à part.
+    const vente = lignes[2].split(';');
+    expect(vente[6]).toBe('8.00');
+    expect(vente[7]).toBe('12200.00');
+  });
+
+  it('rend l’en-tête seul quand le compte n’a aucun mouvement', async () => {
+    const { contenu, entete, lignes } = await exporter([]);
+
+    expect(entete).toBe('date;type;actif;classe;quantite;prix_unitaire;frais;montant');
+    expect(lignes).toEqual([]);
+    expect(contenu).toBe('date;type;actif;classe;quantite;prix_unitaire;frais;montant\r\n');
+  });
+
+  it('nomme le fichier avec la date du jour', async () => {
+    const { nomFichier } = await exporter(MOUVEMENTS);
+    const jour = new Date().toISOString().slice(0, 10);
+
+    expect(nomFichier).toBe(`capitall-mouvements-${jour}.csv`);
+  });
+
+  it('ne demande que les mouvements du porteur du jeton', async () => {
+    const { service, transactions } = monter({ mouvements: MOUVEMENTS });
+
+    await service.exporterMouvements({ utilisateurId: 7 });
+
+    expect(transactions.listerParUtilisateur).toHaveBeenCalledWith(7);
+    expect(transactions.listerParUtilisateur).toHaveBeenCalledTimes(1);
+  });
+
+  it('neutralise un symbole qui commencerait comme une formule de tableur', async () => {
+    const { lignes } = await exporter([{ ...MOUVEMENTS[0], symbole: '=1+1' }]);
+
+    expect(lignes[0]).toContain(";'=1+1;");
+  });
+});

--- a/backend/src/services/__tests__/compte.test.js
+++ b/backend/src/services/__tests__/compte.test.js
@@ -122,19 +122,43 @@ describe('changement de mot de passe (E7)', () => {
 });
 
 describe('suppression du compte (E7)', () => {
-  it('supprime le compte du porteur du jeton', async () => {
+  it('supprime le compte du porteur du jeton quand le mot de passe est confirmé', async () => {
     const { service, utilisateurs } = monter();
 
-    await service.supprimer({ utilisateurId: 7 });
+    await service.supprimer({ utilisateurId: 7, motDePasse: MOT_DE_PASSE });
 
     expect(utilisateurs.supprimer).toHaveBeenCalledWith(7);
     expect(utilisateurs.supprimer).toHaveBeenCalledTimes(1);
   });
 
+  // La confirmation par mot de passe est une barrière, pas un ornement d'interface :
+  // vérifiée ici, elle résiste à un appel direct porteur d'un jeton dérobé.
+  it('refuse la suppression et n’efface rien quand le mot de passe est faux', async () => {
+    const { service, utilisateurs } = monter();
+
+    const echec = await service
+      .supprimer({ utilisateurId: 7, motDePasse: 'ce-n-est-pas-le-bon' })
+      .catch((erreur) => erreur);
+
+    expect(echec.statut).toBe(400);
+    expect(echec.champs).toEqual([{ champ: 'motDePasse', message: 'Mot de passe incorrect.' }]);
+    expect(utilisateurs.supprimer).not.toHaveBeenCalled();
+  });
+
   it('rend 404 quand aucune ligne n’a été supprimée', async () => {
     const { service } = monter({ supprime: false });
 
-    await expect(service.supprimer({ utilisateurId: 7 })).rejects.toMatchObject({ statut: 404 });
+    await expect(
+      service.supprimer({ utilisateurId: 7, motDePasse: MOT_DE_PASSE })
+    ).rejects.toMatchObject({ statut: 404 });
+  });
+
+  it('rend 404 quand le porteur du jeton n’a plus de compte', async () => {
+    const { service } = monter({ utilisateur: null });
+
+    await expect(
+      service.supprimer({ utilisateurId: 7, motDePasse: MOT_DE_PASSE })
+    ).rejects.toMatchObject({ statut: 404 });
   });
 });
 

--- a/backend/src/services/authentification.js
+++ b/backend/src/services/authentification.js
@@ -102,6 +102,10 @@ const service = creerServiceAuthentification();
 
 module.exports = {
   creerServiceAuthentification,
+  // Le coût de hachage est exporté pour que le changement de mot de passe applique
+  // exactement le même que l'inscription : deux valeurs distinctes produiraient des
+  // hachages de robustesse inégale selon la façon dont le compte a été créé.
+  COUT_HACHAGE,
   inscrire: service.inscrire,
   connecter: service.connecter,
 };

--- a/backend/src/services/compte.js
+++ b/backend/src/services/compte.js
@@ -89,7 +89,24 @@ function creerServiceCompte({
     // changement, comme la spécification l'exige, sans traitement particulier.
   }
 
-  async function supprimer({ utilisateurId }) {
+  async function supprimer({ utilisateurId, motDePasse }) {
+    const utilisateur = await utilisateurs.trouverAvecHachageParId(utilisateurId);
+
+    if (!utilisateur) {
+      throw new ErreurIntrouvable('Utilisateur introuvable.');
+    }
+
+    // La confirmation par mot de passe est vérifiée ici, et non par l'interface : elle
+    // est la dernière barrière avant une suppression irréversible, et un jeton dérobé
+    // ne doit pas suffire à la franchir.
+    const valide = await bcrypt.compare(motDePasse, utilisateur.mot_de_passe_hache);
+
+    if (!valide) {
+      throw new ErreurValidation('Mot de passe incorrect.', [
+        { champ: 'motDePasse', message: 'Mot de passe incorrect.' },
+      ]);
+    }
+
     const supprime = await utilisateurs.supprimer(utilisateurId);
 
     if (!supprime) {

--- a/backend/src/services/compte.js
+++ b/backend/src/services/compte.js
@@ -1,0 +1,141 @@
+// Logique métier de la gestion du compte : changement de mot de passe, suppression et
+// export des mouvements. Comme les autres services, il ne connaît ni Express ni les
+// codes HTTP, et reçoit ses dépendances en paramètre pour rester testable sans base.
+
+const bcrypt = require('bcrypt');
+const modeleUtilisateur = require('../models/utilisateur');
+const modeleTransaction = require('../models/transaction');
+const { COUT_HACHAGE } = require('./authentification');
+const { derouler, trierChronologiquement } = require('./calculPortefeuille');
+const { construire } = require('../utils/csv');
+const { ErreurValidation, ErreurIntrouvable } = require('../erreurs');
+
+// Colonnes de l'export, dans l'ordre du fichier (D84).
+const ENTETES = ['date', 'type', 'actif', 'classe', 'quantite', 'prix_unitaire', 'frais', 'montant'];
+
+const PREFIXE_FICHIER = 'capitall-mouvements';
+
+function jourCourant() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// pg rend un TIMESTAMPTZ sous forme d'objet Date ; les jeux d'essai le donnent parfois
+// déjà en chaîne. Les deux passent par Date pour ne produire qu'une seule forme.
+function enIso(valeur) {
+  return new Date(valeur).toISOString();
+}
+
+// Le montant de chaque ligne n'est pas recalculé ici : il est produit par derouler(),
+// le moteur qui le calcule déjà pour l'écran de détail d'une position. La formule, ses
+// échelles intermédiaires et son arrondi gardent ainsi un propriétaire unique (D69), et
+// le fichier exporté porte exactement le chiffre que l'application affiche.
+//
+// derouler() raisonne par position : les mouvements sont donc groupés par actif, puis
+// refondus en une seule liste que l'ordre chronologique du domaine remet en ordre.
+function calculerMontants(mouvements) {
+  const parActif = new Map();
+
+  for (const mouvement of mouvements) {
+    const groupe = parActif.get(mouvement.actif_id);
+    if (groupe) {
+      groupe.push(mouvement);
+    } else {
+      parActif.set(mouvement.actif_id, [mouvement]);
+    }
+  }
+
+  const calcules = [];
+  for (const groupe of parActif.values()) {
+    calcules.push(...derouler(groupe).mouvements);
+  }
+
+  return trierChronologiquement(calcules);
+}
+
+function creerServiceCompte({
+  utilisateurs = modeleUtilisateur,
+  transactions = modeleTransaction,
+} = {}) {
+  async function changerMotDePasse({ utilisateurId, ancienMotDePasse, nouveauMotDePasse }) {
+    const utilisateur = await utilisateurs.trouverAvecHachageParId(utilisateurId);
+
+    // Le porteur d'un jeton valide dont le compte a disparu entre-temps : le cas est
+    // improbable mais ne doit pas produire une comparaison bcrypt sur undefined.
+    if (!utilisateur) {
+      throw new ErreurIntrouvable('Utilisateur introuvable.');
+    }
+
+    const ancienValide = await bcrypt.compare(ancienMotDePasse, utilisateur.mot_de_passe_hache);
+
+    // L'erreur est rattachée au champ de l'ancien mot de passe : c'est lui que
+    // l'utilisateur doit corriger, et la spécification demande que le message s'y pose
+    // plutôt qu'en tête de formulaire. Aucun décompte de tentatives n'est tenu, aucune
+    // n'étant prévue par la spécification.
+    if (!ancienValide) {
+      throw new ErreurValidation('Ancien mot de passe incorrect.', [
+        { champ: 'ancienMotDePasse', message: 'Ancien mot de passe incorrect.' },
+      ]);
+    }
+
+    const hachage = await bcrypt.hash(nouveauMotDePasse, COUT_HACHAGE);
+    const misAJour = await utilisateurs.mettreAJourMotDePasse(utilisateurId, hachage);
+
+    if (!misAJour) {
+      throw new ErreurIntrouvable('Utilisateur introuvable.');
+    }
+
+    // Rien n'est renvoyé, et le jeton en cours reste valable : il est signé sur
+    // l'identifiant et le rôle, jamais sur le mot de passe. La session survit donc au
+    // changement, comme la spécification l'exige, sans traitement particulier.
+  }
+
+  async function supprimer({ utilisateurId }) {
+    const supprime = await utilisateurs.supprimer(utilisateurId);
+
+    if (!supprime) {
+      throw new ErreurIntrouvable('Utilisateur introuvable.');
+    }
+  }
+
+  async function exporterMouvements({ utilisateurId }) {
+    // Le cloisonnement est porté par la requête elle-même, qui joint actif sur son
+    // propriétaire : aucun filtre applicatif ne vient après, et aucun identifiant
+    // d'utilisateur ne transite par la requête HTTP.
+    const mouvements = await transactions.listerParUtilisateur(utilisateurId);
+
+    const lignes = calculerMontants(mouvements).map((mouvement) => [
+      enIso(mouvement.date_transaction),
+      mouvement.sens,
+      mouvement.symbole,
+      mouvement.classe,
+      // Les valeurs décimales sortent telles que la base les rend, point décimal
+      // compris : un fichier d'échange n'est pas un affichage, le formatage à la
+      // française y rendrait les colonnes inexploitables par un tableur.
+      mouvement.quantite,
+      mouvement.prix_unitaire,
+      mouvement.frais,
+      mouvement.montant,
+    ]);
+
+    // Un compte sans mouvement rend malgré tout un fichier : l'en-tête seul dit que
+    // l'export a fonctionné et qu'il n'y avait rien à exporter, là où un fichier vide
+    // laisserait croire à un échec.
+    return {
+      nomFichier: `${PREFIXE_FICHIER}-${jourCourant()}.csv`,
+      contenu: construire(ENTETES, lignes),
+    };
+  }
+
+  return { changerMotDePasse, supprimer, exporterMouvements };
+}
+
+// Instance par défaut, utilisée par les contrôleurs, comme pour l'authentification.
+const service = creerServiceCompte();
+
+module.exports = {
+  creerServiceCompte,
+  ENTETES,
+  changerMotDePasse: service.changerMotDePasse,
+  supprimer: service.supprimer,
+  exporterMouvements: service.exporterMouvements,
+};

--- a/backend/src/utils/__tests__/csv.test.js
+++ b/backend/src/utils/__tests__/csv.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { echapper, ligne, construire } from '../csv.js';
+
+describe('échappement CSV', () => {
+  it('laisse intact un champ ordinaire', () => {
+    expect(echapper('BTC')).toBe('BTC');
+    expect(echapper('27000.00')).toBe('27000.00');
+  });
+
+  it('encadre un champ contenant le séparateur', () => {
+    expect(echapper('Or ; lingot')).toBe('"Or ; lingot"');
+  });
+
+  it('double les guillemets et encadre le champ', () => {
+    expect(echapper('nom "court"')).toBe('"nom ""court"""');
+  });
+
+  it('encadre un champ contenant un saut de ligne', () => {
+    expect(echapper('deux\nlignes')).toBe('"deux\nlignes"');
+  });
+
+  it('rend une chaîne vide sur une valeur absente', () => {
+    expect(echapper(null)).toBe('');
+    expect(echapper(undefined)).toBe('');
+  });
+});
+
+describe('neutralisation des formules de tableur', () => {
+  // Le symbole d'un actif est saisi librement : exporté tel quel, un symbole commençant
+  // par un signe égal serait exécuté comme une formule à l'ouverture du fichier.
+  it("préfixe d'une apostrophe un champ commençant par une amorce de formule", () => {
+    expect(echapper('=1+1')).toBe("'=1+1");
+    expect(echapper('+BTC')).toBe("'+BTC");
+    expect(echapper('-BTC')).toBe("'-BTC");
+    expect(echapper('@somme')).toBe("'@somme");
+  });
+
+  it('ne préfixe pas un champ dont le signe est ailleurs', () => {
+    expect(echapper('BTC-EUR')).toBe('BTC-EUR');
+  });
+
+  it('encadre et neutralise à la fois quand les deux sont nécessaires', () => {
+    expect(echapper('=a;b')).toBe('"\'=a;b"');
+  });
+});
+
+describe('construction du fichier', () => {
+  it('joint les champs par un point-virgule', () => {
+    expect(ligne(['a', 'b', 'c'])).toBe('a;b;c');
+  });
+
+  it('sépare les lignes par un CRLF et termine le fichier par un saut de ligne', () => {
+    const contenu = construire(['date', 'actif'], [['2026-07-15', 'BTC']]);
+    expect(contenu).toBe('date;actif\r\n2026-07-15;BTC\r\n');
+  });
+
+  it("rend l'en-tête seul quand il n'y a aucune ligne", () => {
+    expect(construire(['date', 'actif'], [])).toBe('date;actif\r\n');
+  });
+});

--- a/backend/src/utils/csv.js
+++ b/backend/src/utils/csv.js
@@ -1,0 +1,55 @@
+// Sérialisation CSV. Module pur : il reçoit des valeurs, il rend une chaîne, sans
+// connaître ni les mouvements ni HTTP.
+//
+// Le séparateur est le point-virgule et non la virgule : les montants du domaine sont
+// écrits avec un point décimal, mais les tableurs francophones ouvrent un fichier
+// séparé par des virgules en une seule colonne. Le point-virgule est ce qu'ils
+// attendent, et il reste conforme au RFC 4180, qui n'impose pas la virgule.
+
+const SEPARATEUR = ';';
+
+// Caractères qui ouvrent une formule dans Excel, LibreOffice et Google Sheets. Un champ
+// qui commence par l'un d'eux est interprété comme du calcul et non comme du texte :
+// exporté tel quel, un symbole d'actif nommé « =1+1 » s'exécuterait à l'ouverture du
+// fichier. Le seul champ réellement saisi par l'utilisateur est le symbole, mais la
+// garde est posée pour tous, une colonne pouvant en devenir une demain.
+const AMORCES_DE_FORMULE = ['=', '+', '-', '@', '\t', '\r'];
+
+function neutraliserFormule(valeur) {
+  if (valeur.length > 0 && AMORCES_DE_FORMULE.includes(valeur[0])) {
+    return `'${valeur}`;
+  }
+  return valeur;
+}
+
+// Règle RFC 4180 : un champ n'est encadré que s'il en a besoin, et le guillemet se
+// protège en le doublant. Encadrer systématiquement serait valide mais rendrait le
+// fichier illisible à l'oeil, alors qu'il a vocation à être ouvert et relu.
+function echapper(valeur) {
+  const texte = valeur === null || valeur === undefined ? '' : String(valeur);
+  const neutralise = neutraliserFormule(texte);
+
+  if (
+    neutralise.includes(SEPARATEUR) ||
+    neutralise.includes('"') ||
+    neutralise.includes('\n') ||
+    neutralise.includes('\r')
+  ) {
+    return `"${neutralise.replace(/"/g, '""')}"`;
+  }
+
+  return neutralise;
+}
+
+function ligne(valeurs) {
+  return valeurs.map(echapper).join(SEPARATEUR);
+}
+
+// Fin de ligne CRLF, celle que le RFC 4180 prescrit et que les tableurs Windows
+// attendent. Le fichier se termine par un saut de ligne, y compris quand il ne porte
+// que son en-tête.
+function construire(entetes, lignes) {
+  return [ligne(entetes), ...lignes.map(ligne)].join('\r\n') + '\r\n';
+}
+
+module.exports = { SEPARATEUR, echapper, ligne, construire };

--- a/backend/src/validation/__tests__/compte.test.js
+++ b/backend/src/validation/__tests__/compte.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { schemaChangementMotDePasse } from '../compte.js';
+
+function valider(donnees) {
+  return schemaChangementMotDePasse.safeParse(donnees);
+}
+
+const VALIDE = { ancienMotDePasse: 'ancien-solide', nouveauMotDePasse: 'nouveau-solide' };
+
+describe('changement de mot de passe (E7)', () => {
+  it('accepte un couple valide', () => {
+    expect(valider(VALIDE).success).toBe(true);
+  });
+
+  it('refuse un nouveau mot de passe trop court', () => {
+    const resultat = valider({ ...VALIDE, nouveauMotDePasse: 'court' });
+
+    expect(resultat.success).toBe(false);
+    expect(resultat.error.issues[0].path).toEqual(['nouveauMotDePasse']);
+  });
+
+  it('refuse un ancien mot de passe vide', () => {
+    const resultat = valider({ ...VALIDE, ancienMotDePasse: '' });
+
+    expect(resultat.success).toBe(false);
+    expect(resultat.error.issues[0].path).toEqual(['ancienMotDePasse']);
+  });
+
+  // Un mot de passe court reste acceptable en ancien : la règle de longueur a pu être
+  // durcie depuis la création du compte, et l'utilisateur doit pouvoir le corriger.
+  it("n'impose pas la longueur minimale à l'ancien mot de passe", () => {
+    expect(valider({ ...VALIDE, ancienMotDePasse: 'court' }).success).toBe(true);
+  });
+
+  it('refuse un nouveau mot de passe identique à l’ancien', () => {
+    const resultat = valider({ ancienMotDePasse: 'meme-mot-de-passe', nouveauMotDePasse: 'meme-mot-de-passe' });
+
+    expect(resultat.success).toBe(false);
+    expect(resultat.error.issues[0].path).toEqual(['nouveauMotDePasse']);
+  });
+
+  // .strict() ferme la porte à toute clé inconnue, role compris (D23).
+  it('rejette une clé inconnue', () => {
+    expect(valider({ ...VALIDE, role: 'admin' }).success).toBe(false);
+  });
+});

--- a/backend/src/validation/__tests__/compte.test.js
+++ b/backend/src/validation/__tests__/compte.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { schemaChangementMotDePasse } from '../compte.js';
+import { schemaChangementMotDePasse, schemaSuppressionCompte } from '../compte.js';
 
 function valider(donnees) {
   return schemaChangementMotDePasse.safeParse(donnees);
@@ -42,5 +42,34 @@ describe('changement de mot de passe (E7)', () => {
   // .strict() ferme la porte à toute clé inconnue, role compris (D23).
   it('rejette une clé inconnue', () => {
     expect(valider({ ...VALIDE, role: 'admin' }).success).toBe(false);
+  });
+});
+
+describe('suppression du compte (E7)', () => {
+  it('accepte un mot de passe de confirmation', () => {
+    expect(schemaSuppressionCompte.safeParse({ motDePasse: 'peu-importe' }).success).toBe(true);
+  });
+
+  it('refuse une suppression sans mot de passe', () => {
+    expect(schemaSuppressionCompte.safeParse({}).success).toBe(false);
+    expect(schemaSuppressionCompte.safeParse({ motDePasse: '' }).success).toBe(false);
+  });
+
+  it('rejette une clé inconnue', () => {
+    expect(
+      schemaSuppressionCompte.safeParse({ motDePasse: 'x', utilisateur_id: 1 }).success
+    ).toBe(false);
+  });
+});
+
+describe('messages en français', () => {
+  // Sans message explicite sur z.string, une clé absente produirait le libellé anglais
+  // par défaut de la bibliothèque, qui remonterait tel quel jusqu'à l'écran.
+  it('nomme en français une clé absente', () => {
+    const suppression = schemaSuppressionCompte.safeParse({});
+    expect(suppression.error.issues[0].message).toBe('Le mot de passe est obligatoire.');
+
+    const changement = schemaChangementMotDePasse.safeParse({ nouveauMotDePasse: 'assez-long-ok' });
+    expect(changement.error.issues[0].message).toBe("L'ancien mot de passe est obligatoire.");
   });
 });

--- a/backend/src/validation/compte.js
+++ b/backend/src/validation/compte.js
@@ -1,0 +1,24 @@
+// Schémas de validation des entrées de gestion du compte (D41).
+//
+// La règle de longueur du nouveau mot de passe est celle de l'inscription, importée
+// plutôt que recopiée : durcir la règle un jour ne doit pas laisser une des deux
+// portes ouverte sur l'ancienne.
+
+const { z } = require('zod');
+const { motDePasse } = require('./utilisateur');
+
+// L'ancien mot de passe n'est contrôlé que sur sa présence. Lui appliquer la règle de
+// longueur courante empêcherait un compte créé sous une règle plus permissive de
+// changer précisément le mot de passe devenu trop court.
+const schemaChangementMotDePasse = z
+  .object({
+    ancienMotDePasse: z.string().min(1, "L'ancien mot de passe est obligatoire."),
+    nouveauMotDePasse: motDePasse,
+  })
+  .strict()
+  .refine((donnees) => donnees.ancienMotDePasse !== donnees.nouveauMotDePasse, {
+    message: 'Le nouveau mot de passe doit être différent de l\'ancien.',
+    path: ['nouveauMotDePasse'],
+  });
+
+module.exports = { schemaChangementMotDePasse };

--- a/backend/src/validation/compte.js
+++ b/backend/src/validation/compte.js
@@ -12,7 +12,11 @@ const { motDePasse } = require('./utilisateur');
 // changer précisément le mot de passe devenu trop court.
 const schemaChangementMotDePasse = z
   .object({
-    ancienMotDePasse: z.string().min(1, "L'ancien mot de passe est obligatoire."),
+    // Le message est donné à z.string autant qu'à min : sans lui, une clé absente
+    // produirait le message anglais par défaut de la bibliothèque.
+    ancienMotDePasse: z
+      .string("L'ancien mot de passe est obligatoire.")
+      .min(1, "L'ancien mot de passe est obligatoire."),
     nouveauMotDePasse: motDePasse,
   })
   .strict()
@@ -21,4 +25,15 @@ const schemaChangementMotDePasse = z
     path: ['nouveauMotDePasse'],
   });
 
-module.exports = { schemaChangementMotDePasse };
+// La suppression exige le mot de passe, et c'est le serveur qui le vérifie. Contrôlée
+// côté interface seulement, la confirmation ne protégerait de rien : un jeton dérobé
+// suffirait à supprimer le compte sans jamais connaître le mot de passe.
+const schemaSuppressionCompte = z
+  .object({
+    motDePasse: z
+      .string('Le mot de passe est obligatoire.')
+      .min(1, 'Le mot de passe est obligatoire.'),
+  })
+  .strict();
+
+module.exports = { schemaChangementMotDePasse, schemaSuppressionCompte };

--- a/backend/src/validation/utilisateur.js
+++ b/backend/src/validation/utilisateur.js
@@ -44,4 +44,6 @@ const schemaConnexion = z
   })
   .strict();
 
-module.exports = { schemaInscription, schemaConnexion };
+// motDePasse est exporté pour que le changement de mot de passe (validation/compte.js)
+// applique exactement la même règle de longueur qu'à l'inscription, sans la recopier.
+module.exports = { schemaInscription, schemaConnexion, motDePasse };

--- a/docs/cahier-des-charges.md
+++ b/docs/cahier-des-charges.md
@@ -96,7 +96,8 @@ Un périmètre se définit autant par ce qu'il exclut que par ce qu'il inclut.
 - En tant qu'utilisateur inscrit, je veux me connecter, afin de retrouver mon portefeuille. Contraintes : message d'échec strictement générique, ne révélant jamais si c'est l'adresse ou le mot de passe qui est en cause ; soumission verrouillée pendant l'appel réseau.
 - En tant qu'utilisateur connecté, je veux consulter les informations de mon compte, afin de vérifier mon identité applicative.
 - En tant qu'utilisateur connecté, je veux changer mon mot de passe, afin de préserver la sécurité de mon compte. Contraintes : l'ancien mot de passe est exigé, le nouveau respecte les mêmes règles qu'à l'inscription, la session en cours n'est pas invalidée.
-- En tant qu'utilisateur connecté, je veux supprimer mon compte, afin d'exercer mon droit à l'effacement. Contraintes : confirmation par le mot de passe, suppression en cascade des actifs, transactions, alertes et instantanés, opération irréversible et annoncée comme telle.
+- En tant qu'utilisateur connecté, je veux supprimer mon compte, afin d'exercer mon droit à l'effacement. Contraintes : confirmation par le mot de passe, vérifiée par le serveur et non par la seule interface, suppression en cascade des actifs, transactions, alertes et instantanés, opération irréversible et annoncée comme telle.
+- En tant qu'utilisateur connecté, je veux exporter mes mouvements dans un fichier, afin de les conserver ou de les exploiter hors de l'application. Contraintes : la totalité des mouvements du compte, format CSV lisible par un tableur, valeurs brutes sans mise en forme, aucun mouvement d'un autre compte accessible. Il ne s'agit pas d'un export fiscal, qui reste hors périmètre.
 - En tant qu'utilisateur connecté, je veux choisir la devise d'affichage et masquer les montants, afin d'adapter la consultation à mon contexte.
 
 ### 4.2 Gestion des actifs
@@ -272,7 +273,8 @@ Toutes les routes privées attendent le jeton dans l'en-tête d'autorisation. Un
 | POST | `/api/auth/inscription` | public | création de compte | 201, 400, 409 |
 | POST | `/api/auth/connexion` | public | authentification, émission du jeton | 200, 400, 401, 403 |
 | PATCH | `/api/compte/mot-de-passe` | authentifié | changement de mot de passe, ancien exigé | 204, 400, 401 |
-| DELETE | `/api/compte` | authentifié | suppression du compte et de ses données | 204, 401 |
+| DELETE | `/api/compte` | authentifié | suppression du compte et de ses données, mot de passe de confirmation exigé | 204, 400, 401 |
+| GET | `/api/compte/export-mouvements` | authentifié | export CSV de tous les mouvements du compte (D84) | 200, 401 |
 | GET | `/api/auth/moi` | authentifié | informations du compte courant | 200, 401 |
 | GET | `/api/actifs` | authentifié | liste des actifs suivis | 200, 401 |
 | POST | `/api/actifs` | authentifié | création d'un actif suivi | 201, 400, 401, 409 |
@@ -296,7 +298,7 @@ Toutes les routes privées attendent le jeton dans l'en-tête d'autorisation. Un
 
 Les routes d'administration renvoient 403 et non 404 : contrairement au cloisonnement entre utilisateurs, il n'y a ici aucun intérêt à masquer l'existence de la ressource, et un refus explicite est plus clair.
 
-**Statut à la date de cette version.** Les routes d'authentification, d'actifs, de transactions, de portefeuille et d'alertes sont développées et vérifiées. Les six routes d'annonces et d'administration constituent des engagements du présent cahier des charges, non encore développés à la date de la version 2.0. Ce tableau décrit la cible contractuelle du produit, l'état d'avancement relevant du suivi de projet.
+**Statut à la date de cette version.** Les routes d'authentification, de compte, d'actifs, de transactions, de portefeuille et d'alertes sont développées et vérifiées. Les six routes d'annonces et d'administration constituent des engagements du présent cahier des charges, non encore développés à la date de la version 2.0. Ce tableau décrit la cible contractuelle du produit, l'état d'avancement relevant du suivi de projet.
 
 Les structures de données échangées par chaque point d'entrée seront documentées dans une collection d'appels rejouable, constituée au fil du développement et versionnée avec le projet.
 

--- a/docs/conception/specification-fonctionnelle.md
+++ b/docs/conception/specification-fonctionnelle.md
@@ -295,7 +295,7 @@ En desktop, tableau à colonnes : Actif, Quantité, Cours, Prix de revient, Valo
 
 **Cas d'utilisation.** Changer son mot de passe ; se déconnecter ; supprimer son compte ; régler l'affichage ; savoir d'où viennent les cours.
 
-**Structure.** Un seul écran, quatre sections, sans sous-navigation.
+**Structure.** Un seul écran, cinq sections, sans sous-navigation.
 
 *Compte.* Adresse électronique, pseudonyme, date d'inscription, rôle. Lecture seule au MVP.
 
@@ -303,15 +303,17 @@ En desktop, tableau à colonnes : Actif, Quantité, Cours, Prix de revient, Valo
 
 *Affichage.* Devise d'affichage euro ou dollar. Masquage des montants par défaut.
 
+*Données.* Export de la totalité des mouvements du compte au format CSV (D84). Portée intégrale, tous actifs confondus, sans filtre de période ni d'actif. Huit colonnes, dans cet ordre : `date`, `type`, `actif`, `classe`, `quantite`, `prix_unitaire`, `frais`, `montant`. La colonne `actif` porte le symbole, unique par compte, et non le nom. La colonne `montant` est la quantité multipliée par le prix unitaire, **frais exclus**, ceux-ci occupant leur propre colonne ; elle reprend la valeur produite par le moteur de calcul et n'est pas recalculée pour l'export (D69). Fichier UTF-8 avec marque d'ordre des octets, séparateur point-virgule, fin de ligne CRLF, dates en ISO 8601, nombres décimaux bruts à point, sans mise en forme : un fichier d'échange n'est pas un affichage. Lignes en ordre chronologique ascendant, tous actifs confondus, celui de la règle 6 de D54. Nom du fichier `capitall-mouvements-AAAA-MM-JJ.csv`.
+
 *À propos.* Version de l'application, sources de cours utilisées et leur fréquence de rafraîchissement, mention explicite que l'application ne fournit aucun conseil en investissement.
 
-**Composants.** `Champ`, `Bouton`, `BasculeDevise`, `MasquageMontants`, `Confirmation`, `MessageErreur`.
+**Composants.** `Champ`, `Bouton`, `Carte`, `BasculeDevise`, `MasquageMontants`, `Confirmation`, `Message`, `MessageErreur`.
 
-**Interactions.** Le changement de mot de passe exige l'ancien et n'invalide pas la session en cours. La suppression du compte demande une confirmation par saisie du mot de passe et énonce sans ambiguïté ce qui sera supprimé, positions, mouvements et seuils compris, et que l'opération est irréversible.
+**Interactions.** Le changement de mot de passe exige l'ancien et n'invalide pas la session en cours, le jeton étant signé sur l'identifiant et le rôle et jamais sur le mot de passe. La suppression du compte demande une confirmation par saisie du mot de passe et énonce sans ambiguïté ce qui sera supprimé, positions, mouvements et seuils compris, et que l'opération est irréversible. **Ce mot de passe est vérifié par le serveur** : contrôlé par la seule interface, il ne protégerait pas d'un appel direct porteur d'un jeton dérobé. L'export est obtenu par un appel authentifié puis remis à l'utilisateur depuis la page ; il ne peut pas être un simple lien, le jeton ne vivant qu'en mémoire (D57) et n'accompagnant pas une navigation du navigateur.
 
-**Impacts API, à créer.** `PATCH /api/compte/mot-de-passe` et `DELETE /api/compte`. Les données du compte proviennent de `GET /api/auth/moi`, déjà disponible.
+**Impacts API, à créer.** `PATCH /api/compte/mot-de-passe`, `DELETE /api/compte` (le mot de passe de confirmation est transmis dans le corps) et `GET /api/compte/export-mouvements`, seule route du service à ne pas répondre en JSON. Les données du compte proviennent de `GET /api/auth/moi`, déjà disponible.
 
-**États particuliers.** *Ancien mot de passe incorrect* : erreur sur le champ concerné, sans indication de tentatives restantes. *Suppression en cours* : formulaire verrouillé, puis déconnexion et retour à la connexion avec message de confirmation.
+**États particuliers.** *Ancien mot de passe incorrect* : erreur sur le champ concerné, sans indication de tentatives restantes. *Suppression en cours* : formulaire verrouillé, puis déconnexion et retour à la connexion avec message de confirmation. *Mot de passe de suppression incorrect* : erreur sur le champ du dialogue, le compte restant intact. *Compte sans aucun mouvement* : l'export produit un fichier réduit à sa ligne d'en-tête, un fichier vide laissant croire à un échec. *Export en échec* : message dans la section Données, sans quitter l'écran.
 
 **Accessibilité.** Les sections sont des `section` avec titre. Le dialogue de suppression capture le focus et ne présélectionne jamais le bouton destructeur. Les réglages d'affichage sont des interrupteurs à `aria-checked`, avec un libellé qui décrit l'état et non l'action.
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import Patrimoine from './pages/Patrimoine';
 import Positions from './pages/Positions';
 import DetailPosition from './pages/DetailPosition';
 import Seuils from './pages/Seuils';
+import Compte from './pages/Compte';
 import Introuvable from './pages/Introuvable';
 
 export default function App() {
@@ -30,6 +31,7 @@ export default function App() {
             <Route path="/positions" element={<Positions />} />
             <Route path="/positions/:id" element={<DetailPosition />} />
             <Route path="/seuils" element={<Seuils />} />
+            <Route path="/compte" element={<Compte />} />
 
             {/* La saisie d'un mouvement est une feuille posée sur l'écran d'origine, et
                 non une page : elle n'a pas de route à elle. L'adresse reste toutefois

--- a/frontend/src/composants/Confirmation.jsx
+++ b/frontend/src/composants/Confirmation.jsx
@@ -22,9 +22,13 @@ import Bouton from './Bouton';
 //
 // Échap annule. C'est le geste attendu de tout dialogue, et il doit rester la sortie la
 // moins coûteuse.
+// Certaines suppressions demandent une saisie avant d'être confirmées, la suppression
+// du compte au premier chef. Ce contenu se place après la conséquence, hors du
+// paragraphe qui la porte : un champ de formulaire n'a rien à faire dans un <p>.
 export default function Confirmation({
   titre,
   consequence,
+  children,
   libelleConfirmation = 'Supprimer',
   enCours = false,
   surConfirmation,
@@ -37,9 +41,10 @@ export default function Confirmation({
     // L'élément actif au moment de l'ouverture est le bouton qui a demandé la
     // suppression : c'est là que le focus doit revenir.
     declencheur.current = document.activeElement;
-    // Le premier bouton du dialogue est celui d'annulation : le focus y entre, et
-    // jamais sur le bouton destructeur.
-    dialogue.current?.querySelector('button')?.focus();
+    // Quand le dialogue porte une saisie, c'est elle qui reçoit le focus, l'utilisateur
+    // ayant quelque chose à taper. Sinon, c'est le premier bouton, celui d'annulation.
+    // Dans les deux cas le bouton destructeur, placé en dernier, ne le reçoit jamais.
+    dialogue.current?.querySelector('input, button')?.focus();
 
     return () => {
       declencheur.current?.focus?.();
@@ -59,7 +64,9 @@ export default function Confirmation({
 
     // Piège à focus : la tabulation boucle entre le premier et le dernier élément
     // atteignable du dialogue.
-    const atteignables = dialogue.current?.querySelectorAll('button:not([disabled])');
+    const atteignables = dialogue.current?.querySelectorAll(
+      'input:not([disabled]), button:not([disabled])'
+    );
     if (!atteignables || atteignables.length === 0) {
       return;
     }
@@ -96,6 +103,7 @@ export default function Confirmation({
         <p id="consequence-confirmation" className="confirmation__consequence">
           {consequence}
         </p>
+        {children}
         <div className="confirmation__actions">
           <Bouton variante="secondaire" onClick={surAnnulation} desactive={enCours}>
             Annuler

--- a/frontend/src/mise-en-page/Coquille.jsx
+++ b/frontend/src/mise-en-page/Coquille.jsx
@@ -19,7 +19,7 @@ const ENTREES = [
   { chemin: '/patrimoine', libelle: 'Patrimoine', symbole: '◫', disponible: true },
   { chemin: '/positions', libelle: 'Positions', symbole: '◈', disponible: true },
   { chemin: '/seuils', libelle: 'Seuils', symbole: '△', disponible: true },
-  { chemin: '/compte', libelle: 'Compte', symbole: '◉', disponible: false },
+  { chemin: '/compte', libelle: 'Compte', symbole: '◉', disponible: true },
 ];
 
 export default function Coquille() {

--- a/frontend/src/pages/Compte.css
+++ b/frontend/src/pages/Compte.css
@@ -1,0 +1,97 @@
+/*
+  Écran Compte. Cinq cartes empilées, sans sous-navigation : la spécification veut un
+  seul écran, chaque section étant assez courte pour se lire d'un trait.
+*/
+
+.compte {
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-6);
+}
+
+.compte__entete {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--espace-4);
+}
+
+.compte__titre {
+  font-size: var(--taille-titre);
+  font-weight: var(--graisse-forte);
+  margin: 0;
+}
+
+.compte__carte {
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-4);
+}
+
+/* Liste de définitions plutôt qu'un tableau : ce sont des paires libellé/valeur, pas
+   des données à croiser en deux dimensions. */
+.compte__informations {
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-3);
+  margin: 0;
+}
+
+.compte__ligne {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--espace-4);
+}
+
+.compte__ligne dt {
+  color: var(--couleur-texte-attenue);
+}
+
+.compte__ligne dd {
+  margin: 0;
+  text-align: right;
+  font-weight: var(--graisse-forte);
+  /* L'adresse électronique peut être longue : elle se coupe plutôt que de pousser la
+     carte au-delà de la largeur de l'écran. */
+  overflow-wrap: anywhere;
+}
+
+.compte__note {
+  margin: 0;
+  color: var(--couleur-texte-attenue);
+  font-size: var(--taille-caption, 0.875rem);
+}
+
+.compte__formulaire {
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-3);
+}
+
+.compte__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--espace-3);
+}
+
+.compte__reglage {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--espace-4);
+}
+
+.compte__reglage-libelle {
+  margin: 0 0 var(--espace-1) 0;
+  font-weight: var(--graisse-forte);
+}
+
+/* En dessous de 480 px, le réglage et son contrôle ne tiennent plus côte à côte sans
+   réduire la zone tactile sous les 44 px exigés (D77) : ils passent l'un sous l'autre. */
+@media (max-width: 480px) {
+  .compte__reglage {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/frontend/src/pages/Compte.jsx
+++ b/frontend/src/pages/Compte.jsx
@@ -1,0 +1,385 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuthentification } from '../contexte/contexteAuthentification';
+import { api, ErreurApi } from '../services/api';
+import { CLE_DEVISE, CLE_MASQUAGE, lirePreference, ecrirePreference } from '../utils/preferences';
+import Bouton from '../composants/Bouton';
+import Champ from '../composants/Champ';
+import Carte from '../composants/Carte';
+import Message from '../composants/Message';
+import MessageErreur from '../composants/MessageErreur';
+import Confirmation from '../composants/Confirmation';
+import BasculeDevise from '../composants/BasculeDevise';
+import MasquageMontants from '../composants/MasquageMontants';
+import Squelette from '../composants/Squelette';
+import './Compte.css';
+
+function natureDeLErreur(erreur) {
+  if (!(erreur instanceof ErreurApi)) {
+    return 'api';
+  }
+  if (erreur.statut === 0) {
+    return 'reseau';
+  }
+  return erreur.statut === 401 ? 'session' : 'api';
+}
+
+// Le serveur renvoie les erreurs de formulaire champ par champ, au format
+// [{ champ, message }]. La conversion en objet évite de parcourir le tableau à chaque
+// champ affiché.
+function erreursParChamp(echec) {
+  if (!(echec instanceof ErreurApi) || !echec.champs) {
+    return {};
+  }
+  return Object.fromEntries(echec.champs.map(({ champ, message }) => [champ, message]));
+}
+
+function formaterDate(valeur) {
+  if (!valeur) {
+    return null;
+  }
+  return new Date(valeur).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+const LIBELLES_ROLE = { utilisateur: 'Utilisateur', admin: 'Administrateur' };
+
+export default function Compte() {
+  const { jeton, deconnecter } = useAuthentification();
+  const naviguer = useNavigate();
+
+  const [profil, setProfil] = useState(null);
+  const [chargement, setChargement] = useState(true);
+  const [erreur, setErreur] = useState(null);
+
+  // Préférences d'affichage : mêmes clés et mêmes accesseurs que les autres écrans, qui
+  // les lisent au montage. Cet écran est celui qui les règle, il n'en détient pas une
+  // seconde copie (D83).
+  const [devise, setDevise] = useState(() => lirePreference(CLE_DEVISE, 'EUR'));
+  const [masque, setMasque] = useState(() => lirePreference(CLE_MASQUAGE, 'non') === 'oui');
+
+  const [ancienMotDePasse, setAncienMotDePasse] = useState('');
+  const [nouveauMotDePasse, setNouveauMotDePasse] = useState('');
+  const [confirmationMotDePasse, setConfirmationMotDePasse] = useState('');
+  const [erreursMotDePasse, setErreursMotDePasse] = useState({});
+  const [motDePasseEnCours, setMotDePasseEnCours] = useState(false);
+  const [confirmationChangement, setConfirmationChangement] = useState(null);
+
+  const [exportEnCours, setExportEnCours] = useState(false);
+  const [erreurExport, setErreurExport] = useState(null);
+
+  const [aSupprimer, setASupprimer] = useState(false);
+  const [motDePasseSuppression, setMotDePasseSuppression] = useState('');
+  const [erreurSuppression, setErreurSuppression] = useState(null);
+  const [suppressionEnCours, setSuppressionEnCours] = useState(false);
+
+  const charger = useCallback(async () => {
+    setChargement(true);
+    setErreur(null);
+    try {
+      setProfil(await api.profil(jeton));
+    } catch (echec) {
+      setErreur(echec);
+    } finally {
+      setChargement(false);
+    }
+  }, [jeton]);
+
+  useEffect(() => {
+    charger();
+  }, [charger]);
+
+  async function soumettreMotDePasse(evenement) {
+    evenement.preventDefault();
+    setConfirmationChangement(null);
+
+    // La concordance des deux saisies est une vérification de formulaire, pas une règle
+    // métier : le serveur n'a pas à connaître le champ de confirmation.
+    if (nouveauMotDePasse !== confirmationMotDePasse) {
+      setErreursMotDePasse({
+        confirmationMotDePasse: 'La confirmation ne correspond pas au nouveau mot de passe.',
+      });
+      return;
+    }
+
+    setErreursMotDePasse({});
+    setMotDePasseEnCours(true);
+
+    try {
+      await api.changerMotDePasse(jeton, { ancienMotDePasse, nouveauMotDePasse });
+      setAncienMotDePasse('');
+      setNouveauMotDePasse('');
+      setConfirmationMotDePasse('');
+      // La session reste ouverte : le jeton ne dépend pas du mot de passe. Le dire
+      // évite que l'utilisateur s'attende à être déconnecté.
+      setConfirmationChangement(
+        'Mot de passe modifié. Votre session reste ouverte, le prochain accès demandera le nouveau mot de passe.'
+      );
+    } catch (echec) {
+      const parChamp = erreursParChamp(echec);
+      setErreursMotDePasse(
+        Object.keys(parChamp).length > 0 ? parChamp : { ancienMotDePasse: echec.message }
+      );
+    } finally {
+      setMotDePasseEnCours(false);
+    }
+  }
+
+  async function exporter() {
+    setErreurExport(null);
+    setExportEnCours(true);
+
+    try {
+      const { blob, nomFichier } = await api.exporterMouvements(jeton);
+
+      // Le fichier arrive par un appel authentifié : il n'existe que dans la page, et
+      // c'est un lien éphémère qui le remet à l'utilisateur. Un lien pointant sur
+      // l'adresse de l'API partirait sans jeton, le jeton ne vivant qu'en mémoire (D57).
+      const adresse = URL.createObjectURL(blob);
+      const lien = document.createElement('a');
+      lien.href = adresse;
+      lien.download = nomFichier;
+      document.body.appendChild(lien);
+      lien.click();
+      document.body.removeChild(lien);
+      URL.revokeObjectURL(adresse);
+    } catch (echec) {
+      setErreurExport(echec.message);
+    } finally {
+      setExportEnCours(false);
+    }
+  }
+
+  async function supprimerCompte() {
+    setErreurSuppression(null);
+    setSuppressionEnCours(true);
+
+    try {
+      // Le mot de passe part avec la demande : c'est le serveur qui le vérifie, et lui
+      // seul qui décide si la suppression a lieu.
+      await api.supprimerCompte(jeton, { motDePasse: motDePasseSuppression });
+      deconnecter();
+      naviguer('/connexion', {
+        replace: true,
+        state: { message: 'Votre compte et toutes vos données ont été supprimés.' },
+      });
+    } catch (echec) {
+      const parChamp = erreursParChamp(echec);
+      setErreurSuppression(parChamp.motDePasse ?? echec.message);
+      setSuppressionEnCours(false);
+    }
+  }
+
+  if (chargement && !profil) {
+    return (
+      <div className="compte" aria-busy="true">
+        <h1 className="compte__titre">Compte</h1>
+        <p className="lecteur-ecran-seulement" role="status">
+          Chargement des informations du compte
+        </p>
+        <Squelette forme="bloc" hauteur="8rem" />
+        <Squelette forme="bloc" hauteur="12rem" />
+      </div>
+    );
+  }
+
+  if (erreur && !profil) {
+    const nature = natureDeLErreur(erreur);
+    return (
+      <div className="compte">
+        <h1 className="compte__titre">Compte</h1>
+        <MessageErreur
+          nature={nature}
+          message={nature === 'api' ? erreur.message : undefined}
+          libelleAction={nature === 'session' ? 'Se reconnecter' : 'Réessayer'}
+          surAction={nature === 'session' ? () => naviguer('/connexion') : charger}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="compte">
+      <div className="compte__entete">
+        <h1 className="compte__titre">Compte</h1>
+      </div>
+
+      <Carte titre="Informations" className="compte__carte">
+        <dl className="compte__informations">
+          <div className="compte__ligne">
+            <dt>Adresse électronique</dt>
+            <dd>{profil.email}</dd>
+          </div>
+          <div className="compte__ligne">
+            <dt>Pseudonyme</dt>
+            <dd>{profil.pseudo}</dd>
+          </div>
+          <div className="compte__ligne">
+            <dt>Inscrit depuis le</dt>
+            <dd>{formaterDate(profil.date_inscription) ?? '—'}</dd>
+          </div>
+          <div className="compte__ligne">
+            <dt>Rôle</dt>
+            <dd>{LIBELLES_ROLE[profil.role] ?? profil.role}</dd>
+          </div>
+        </dl>
+        <p className="compte__note">Ces informations ne sont pas modifiables.</p>
+      </Carte>
+
+      <Carte titre="Sécurité" className="compte__carte">
+        {confirmationChangement && <Message variante="information">{confirmationChangement}</Message>}
+
+        <form onSubmit={soumettreMotDePasse} noValidate className="compte__formulaire">
+          <Champ
+            label="Mot de passe actuel"
+            type="password"
+            autoComplete="current-password"
+            valeur={ancienMotDePasse}
+            onChange={(e) => setAncienMotDePasse(e.target.value)}
+            erreur={erreursMotDePasse.ancienMotDePasse}
+            obligatoire
+          />
+          <Champ
+            label="Nouveau mot de passe"
+            type="password"
+            autoComplete="new-password"
+            valeur={nouveauMotDePasse}
+            onChange={(e) => setNouveauMotDePasse(e.target.value)}
+            erreur={erreursMotDePasse.nouveauMotDePasse}
+            aide="Dix caractères au minimum."
+            obligatoire
+          />
+          <Champ
+            label="Confirmer le nouveau mot de passe"
+            type="password"
+            autoComplete="new-password"
+            valeur={confirmationMotDePasse}
+            onChange={(e) => setConfirmationMotDePasse(e.target.value)}
+            erreur={erreursMotDePasse.confirmationMotDePasse}
+            obligatoire
+          />
+          <Bouton type="submit" enCours={motDePasseEnCours}>
+            Changer le mot de passe
+          </Bouton>
+        </form>
+
+        <div className="compte__actions">
+          <Bouton variante="secondaire" onClick={deconnecter}>
+            Se déconnecter
+          </Bouton>
+          <Bouton variante="danger" onClick={() => setASupprimer(true)}>
+            Supprimer mon compte
+          </Bouton>
+        </div>
+      </Carte>
+
+      <Carte titre="Affichage" className="compte__carte">
+        <div className="compte__reglage">
+          <div>
+            <p className="compte__reglage-libelle">Devise d&apos;affichage</p>
+            <p className="compte__note">
+              Les calculs restent en euros ; la bascule ne change que l&apos;affichage.
+            </p>
+          </div>
+          <BasculeDevise
+            devise={devise}
+            surChangement={(choix) => {
+              setDevise(choix);
+              ecrirePreference(CLE_DEVISE, choix);
+            }}
+          />
+        </div>
+
+        <div className="compte__reglage">
+          <div>
+            <p className="compte__reglage-libelle">Masquage des montants</p>
+            <p className="compte__note">
+              Remplace les montants par des points sur l&apos;ensemble des écrans.
+            </p>
+          </div>
+          <MasquageMontants
+            masque={masque}
+            surChangement={(valeur) => {
+              setMasque(valeur);
+              ecrirePreference(CLE_MASQUAGE, valeur ? 'oui' : 'non');
+            }}
+          />
+        </div>
+      </Carte>
+
+      <Carte titre="Données" className="compte__carte">
+        <p className="compte__note">
+          Exporte la totalité de vos mouvements, tous actifs confondus, au format CSV :
+          date, sens, actif, classe, quantité, prix unitaire, frais et montant. Les
+          montants y sont écrits en euros, sans mise en forme.
+        </p>
+        {erreurExport && <Message variante="erreur">{erreurExport}</Message>}
+        <Bouton variante="secondaire" onClick={exporter} enCours={exportEnCours}>
+          Exporter mes mouvements
+        </Bouton>
+      </Carte>
+
+      <Carte titre="À propos" className="compte__carte">
+        <dl className="compte__informations">
+          <div className="compte__ligne">
+            <dt>Version</dt>
+            <dd>0.1.0</dd>
+          </div>
+          {/* Sources et fréquences réelles : elles reprennent les adaptateurs branchés
+              et les durées de vie du cache définies côté serveur (D21). */}
+          <div className="compte__ligne">
+            <dt>Cryptomonnaies</dt>
+            <dd>Coinbase, rafraîchi toutes les 2 minutes</dd>
+          </div>
+          <div className="compte__ligne">
+            <dt>Devises</dt>
+            <dd>Frankfurter (BCE), rafraîchi une fois par heure</dd>
+          </div>
+          <div className="compte__ligne">
+            <dt>Métaux précieux</dt>
+            <dd>gold-api, rafraîchi toutes les 10 minutes</dd>
+          </div>
+          <div className="compte__ligne">
+            <dt>Actions</dt>
+            <dd>Fournisseur non branché : ces positions ne sont pas valorisées</dd>
+          </div>
+        </dl>
+        <p className="compte__note">
+          CapitAll est un outil de suivi. Il ne fournit aucun conseil en investissement et
+          ne constitue pas une recommandation d&apos;achat ou de vente.
+        </p>
+      </Carte>
+
+      {/* Le libellé du bouton de confirmation diffère de celui qui ouvre le dialogue :
+          deux commandes portant le même nom accessible seraient indistinguables à
+          l'oreille, et c'est la destructrice qui prêterait à confusion. */}
+      {aSupprimer && (
+        <Confirmation
+          titre="Supprimer définitivement votre compte ?"
+          consequence="Vos positions, vos mouvements, vos seuils et l'historique de votre patrimoine seront supprimés en même temps que votre compte. Cette opération est irréversible."
+          libelleConfirmation="Supprimer définitivement"
+          enCours={suppressionEnCours}
+          surAnnulation={() => {
+            setASupprimer(false);
+            setMotDePasseSuppression('');
+            setErreurSuppression(null);
+          }}
+          surConfirmation={supprimerCompte}
+        >
+          <Champ
+            label="Saisissez votre mot de passe pour confirmer"
+            type="password"
+            autoComplete="current-password"
+            valeur={motDePasseSuppression}
+            onChange={(e) => setMotDePasseSuppression(e.target.value)}
+            erreur={erreurSuppression}
+            obligatoire
+          />
+        </Confirmation>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Connexion.jsx
+++ b/frontend/src/pages/Connexion.jsx
@@ -19,6 +19,11 @@ export default function Connexion() {
   // Route demandée avant la redirection vers la connexion, le cas échéant.
   const destination = emplacement.state?.depuis ?? '/patrimoine';
 
+  // Message laissé par l'écran d'où l'on vient, aujourd'hui la suppression du compte :
+  // sans lui, la disparition du compte se solderait par un retour silencieux au
+  // formulaire, impossible à distinguer d'une déconnexion ordinaire.
+  const messageArrivee = emplacement.state?.message ?? null;
+
   if (estConnecte) {
     return <Navigate to={destination} replace />;
   }
@@ -49,7 +54,8 @@ export default function Connexion() {
 
         {/* Le jeton ne vit qu'en mémoire : une session expirée ramène ici. Le dire
             explicitement évite que la reconnexion passe pour une anomalie. */}
-        {sessionExpiree && !erreur && (
+        {messageArrivee && <Message variante="information">{messageArrivee}</Message>}
+        {sessionExpiree && !erreur && !messageArrivee && (
           <Message variante="information">
             Votre session a expiré. Reconnectez-vous pour retrouver vos données.
           </Message>

--- a/frontend/src/pages/__tests__/Compte.test.jsx
+++ b/frontend/src/pages/__tests__/Compte.test.jsx
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import Compte from '../Compte';
+import * as contexte from '../../contexte/contexteAuthentification';
+import { api, ErreurApi } from '../../services/api';
+import { CLE_DEVISE, CLE_MASQUAGE } from '../../utils/preferences';
+
+const PROFIL = {
+  id: 2,
+  email: 'camille@example.fr',
+  pseudo: 'Camille',
+  role: 'utilisateur',
+  actif: true,
+  date_inscription: '2026-05-12T09:30:00.000Z',
+};
+
+const deconnecter = vi.fn();
+
+let adresse;
+let etatDeNavigation;
+
+function Sonde() {
+  const emplacement = useLocation();
+  adresse = emplacement.pathname;
+  etatDeNavigation = emplacement.state;
+  return null;
+}
+
+function rendre() {
+  vi.spyOn(contexte, 'useAuthentification').mockReturnValue({
+    jeton: 'jeton-de-test',
+    utilisateur: { pseudo: 'Camille' },
+    estConnecte: true,
+    deconnecter,
+  });
+
+  return render(
+    <MemoryRouter initialEntries={['/compte']}>
+      <Compte />
+      <Sonde />
+    </MemoryRouter>
+  );
+}
+
+async function rendreCharge() {
+  rendre();
+  await screen.findByRole('heading', { name: 'Compte', level: 1 });
+}
+
+beforeEach(() => {
+  vi.spyOn(api, 'profil').mockResolvedValue(PROFIL);
+  vi.spyOn(api, 'changerMotDePasse').mockResolvedValue(null);
+  vi.spyOn(api, 'supprimerCompte').mockResolvedValue(null);
+  vi.spyOn(api, 'exporterMouvements').mockResolvedValue({
+    blob: new Blob(['date;type\r\n'], { type: 'text/csv' }),
+    nomFichier: 'capitall-mouvements-2026-08-27.csv',
+  });
+  // jsdom ne fournit pas ces deux fonctions : le téléchargement s'appuie dessus.
+  URL.createObjectURL = vi.fn(() => 'blob:faux');
+  URL.revokeObjectURL = vi.fn();
+  window.sessionStorage.clear();
+  deconnecter.mockClear();
+  adresse = undefined;
+  etatDeNavigation = undefined;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('composition', () => {
+  it('affiche les cinq sections de l’écran', async () => {
+    await rendreCharge();
+
+    for (const titre of ['Informations', 'Sécurité', 'Affichage', 'Données', 'À propos']) {
+      expect(screen.getByRole('heading', { name: titre })).toBeTruthy();
+    }
+  });
+
+  it('consomme le profil du serveur et l’affiche en lecture seule', async () => {
+    await rendreCharge();
+
+    expect(api.profil).toHaveBeenCalledWith('jeton-de-test');
+    expect(screen.getByText('camille@example.fr')).toBeTruthy();
+    expect(screen.getByText('Camille')).toBeTruthy();
+    expect(screen.getByText('Utilisateur')).toBeTruthy();
+    expect(screen.getByText(/12 mai 2026/)).toBeTruthy();
+  });
+
+  it('annonce la source des cours sans en inventer pour les actions', async () => {
+    await rendreCharge();
+
+    expect(screen.getByText(/Coinbase/)).toBeTruthy();
+    expect(screen.getByText(/Frankfurter/)).toBeTruthy();
+    expect(screen.getByText(/Fournisseur non branché/)).toBeTruthy();
+    expect(screen.getByText(/aucun conseil en investissement/)).toBeTruthy();
+  });
+});
+
+describe('changement de mot de passe', () => {
+  async function remplir(utilisateur, { ancien, nouveau, confirmation }) {
+    await utilisateur.type(screen.getByLabelText(/^Mot de passe actuel/), ancien);
+    await utilisateur.type(screen.getByLabelText(/^Nouveau mot de passe/), nouveau);
+    await utilisateur.type(screen.getByLabelText(/^Confirmer le nouveau/), confirmation);
+    await utilisateur.click(screen.getByRole('button', { name: 'Changer le mot de passe' }));
+  }
+
+  it('transmet les deux mots de passe et confirme que la session reste ouverte', async () => {
+    const utilisateur = userEvent.setup();
+    await rendreCharge();
+
+    await remplir(utilisateur, {
+      ancien: 'ancien-solide',
+      nouveau: 'nouveau-solide',
+      confirmation: 'nouveau-solide',
+    });
+
+    expect(api.changerMotDePasse).toHaveBeenCalledWith('jeton-de-test', {
+      ancienMotDePasse: 'ancien-solide',
+      nouveauMotDePasse: 'nouveau-solide',
+    });
+    expect(await screen.findByText(/votre session reste ouverte/i)).toBeTruthy();
+  });
+
+  // La spécification demande que le message se pose sur le champ concerné, et non en
+  // tête de formulaire : c'est ce champ que l'utilisateur doit corriger.
+  it('pose l’erreur du serveur sur le champ de l’ancien mot de passe', async () => {
+    const utilisateur = userEvent.setup();
+    api.changerMotDePasse.mockRejectedValue(
+      new ErreurApi('Ancien mot de passe incorrect.', 400, [
+        { champ: 'ancienMotDePasse', message: 'Ancien mot de passe incorrect.' },
+      ])
+    );
+    await rendreCharge();
+
+    await remplir(utilisateur, {
+      ancien: 'pas-le-bon',
+      nouveau: 'nouveau-solide',
+      confirmation: 'nouveau-solide',
+    });
+
+    const champ = screen.getByLabelText(/^Mot de passe actuel/);
+    await waitFor(() => expect(champ.getAttribute('aria-invalid')).toBe('true'));
+
+    const idErreur = champ.getAttribute('aria-describedby');
+    expect(document.getElementById(idErreur).textContent).toContain('Ancien mot de passe incorrect.');
+    // Le champ du nouveau mot de passe, lui, n'est pas mis en cause.
+    expect(screen.getByLabelText(/^Nouveau mot de passe/).getAttribute('aria-invalid')).toBeNull();
+  });
+
+  it('refuse une confirmation qui ne correspond pas, sans appeler le serveur', async () => {
+    const utilisateur = userEvent.setup();
+    await rendreCharge();
+
+    await remplir(utilisateur, {
+      ancien: 'ancien-solide',
+      nouveau: 'nouveau-solide',
+      confirmation: 'autre-chose-solide',
+    });
+
+    expect(api.changerMotDePasse).not.toHaveBeenCalled();
+    expect(screen.getByText(/La confirmation ne correspond pas/)).toBeTruthy();
+  });
+});
+
+describe('déconnexion', () => {
+  it('appelle la déconnexion du contexte', async () => {
+    const utilisateur = userEvent.setup();
+    await rendreCharge();
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Se déconnecter' }));
+
+    expect(deconnecter).toHaveBeenCalled();
+  });
+});
+
+describe('suppression du compte', () => {
+  async function ouvrir(utilisateur) {
+    await utilisateur.click(screen.getByRole('button', { name: 'Supprimer mon compte' }));
+    return screen.getByRole('dialog');
+  }
+
+  it('énonce ce qui sera supprimé et que l’opération est irréversible', async () => {
+    const utilisateur = userEvent.setup();
+    await rendreCharge();
+
+    const dialogue = await ouvrir(utilisateur);
+
+    expect(dialogue.textContent).toMatch(/mouvements/);
+    expect(dialogue.textContent).toMatch(/seuils/);
+    expect(dialogue.textContent).toMatch(/irréversible/);
+  });
+
+  // Le focus entre sur la saisie, jamais sur le bouton destructeur : une frappe
+  // d'Entrée réflexe ne doit rien confirmer.
+  it('donne le focus au champ de confirmation, pas au bouton destructeur', async () => {
+    const utilisateur = userEvent.setup();
+    await rendreCharge();
+    await ouvrir(utilisateur);
+
+    expect(document.activeElement).toBe(screen.getByLabelText(/Saisissez votre mot de passe/));
+    expect(document.activeElement).not.toBe(
+      screen.getByRole('button', { name: 'Supprimer définitivement' })
+    );
+  });
+
+  it('se ferme par Échap et rend le focus au bouton qui l’a ouvert', async () => {
+    const utilisateur = userEvent.setup();
+    await rendreCharge();
+    const declencheur = screen.getByRole('button', { name: 'Supprimer mon compte' });
+    await ouvrir(utilisateur);
+
+    await utilisateur.keyboard('{Escape}');
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    expect(document.activeElement).toBe(declencheur);
+  });
+
+  it('transmet le mot de passe, déconnecte et redirige avec un message', async () => {
+    const utilisateur = userEvent.setup();
+    await rendreCharge();
+    await ouvrir(utilisateur);
+
+    await utilisateur.type(screen.getByLabelText(/Saisissez votre mot de passe/), 'motdepasse-ok');
+    await utilisateur.click(screen.getByRole('button', { name: 'Supprimer définitivement' }));
+
+    await waitFor(() => expect(adresse).toBe('/connexion'));
+    expect(api.supprimerCompte).toHaveBeenCalledWith('jeton-de-test', {
+      motDePasse: 'motdepasse-ok',
+    });
+    expect(deconnecter).toHaveBeenCalled();
+    expect(etatDeNavigation.message).toMatch(/supprimés/);
+  });
+
+  it('affiche l’erreur du serveur sur le champ et ne redirige pas', async () => {
+    const utilisateur = userEvent.setup();
+    api.supprimerCompte.mockRejectedValue(
+      new ErreurApi('Mot de passe incorrect.', 400, [
+        { champ: 'motDePasse', message: 'Mot de passe incorrect.' },
+      ])
+    );
+    await rendreCharge();
+    await ouvrir(utilisateur);
+
+    await utilisateur.type(screen.getByLabelText(/Saisissez votre mot de passe/), 'faux');
+    await utilisateur.click(screen.getByRole('button', { name: 'Supprimer définitivement' }));
+
+    expect(await screen.findByText('Mot de passe incorrect.')).toBeTruthy();
+    expect(adresse).toBe('/compte');
+    expect(deconnecter).not.toHaveBeenCalled();
+  });
+});
+
+describe('préférences d’affichage', () => {
+  it('mémorise la devise choisie sur la clé partagée', async () => {
+    const utilisateur = userEvent.setup();
+    await rendreCharge();
+
+    await utilisateur.click(screen.getByLabelText('Afficher les montants en dollars'));
+
+    expect(window.sessionStorage.getItem(CLE_DEVISE)).toBe('USD');
+  });
+
+  it('mémorise le masquage sur la clé partagée', async () => {
+    const utilisateur = userEvent.setup();
+    await rendreCharge();
+
+    await utilisateur.click(screen.getByLabelText('Masquer les montants'));
+
+    expect(window.sessionStorage.getItem(CLE_MASQUAGE)).toBe('oui');
+  });
+
+  it('reprend la préférence déjà mémorisée par un autre écran', async () => {
+    window.sessionStorage.setItem(CLE_DEVISE, 'USD');
+    await rendreCharge();
+
+    expect(
+      screen.getByLabelText('Afficher les montants en dollars').getAttribute('aria-checked')
+    ).toBe('true');
+  });
+});
+
+describe('export des mouvements', () => {
+  it('télécharge le fichier par un appel authentifié', async () => {
+    const utilisateur = userEvent.setup();
+    await rendreCharge();
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Exporter mes mouvements' }));
+
+    await waitFor(() => expect(api.exporterMouvements).toHaveBeenCalledWith('jeton-de-test'));
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    // L'objet éphémère est libéré : sans cela le contenu resterait en mémoire jusqu'au
+    // rechargement de la page.
+    expect(URL.revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('affiche un message quand l’export échoue', async () => {
+    const utilisateur = userEvent.setup();
+    api.exporterMouvements.mockRejectedValue(new ErreurApi('Le serveur est injoignable.', 0));
+    await rendreCharge();
+
+    await utilisateur.click(screen.getByRole('button', { name: 'Exporter mes mouvements' }));
+
+    expect(await screen.findByText('Le serveur est injoignable.')).toBeTruthy();
+  });
+});
+
+describe('erreurs et chargement', () => {
+  it('annonce le chargement avant l’arrivée du profil', async () => {
+    let resoudre;
+    api.profil.mockReturnValue(new Promise((r) => { resoudre = r; }));
+    rendre();
+
+    expect(screen.getByRole('status').textContent).toMatch(/Chargement/);
+
+    resoudre(PROFIL);
+    await screen.findByRole('heading', { name: 'Compte', level: 1 });
+  });
+
+  it('propose de se reconnecter quand la session a expiré', async () => {
+    api.profil.mockRejectedValue(new ErreurApi('Jeton expiré.', 401));
+    rendre();
+
+    expect(await screen.findByRole('button', { name: 'Se reconnecter' })).toBeTruthy();
+  });
+
+  it('permet de réessayer après une erreur du serveur', async () => {
+    const utilisateur = userEvent.setup();
+    api.profil.mockRejectedValueOnce(new ErreurApi('Service indisponible.', 500));
+    rendre();
+
+    const reessayer = await screen.findByRole('button', { name: 'Réessayer' });
+    api.profil.mockResolvedValue(PROFIL);
+    await utilisateur.click(reessayer);
+
+    expect(await screen.findByText('camille@example.fr')).toBeTruthy();
+  });
+});

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -84,6 +84,49 @@ export async function requete(chemin, { methode = 'GET', corps, jeton } = {}) {
   );
 }
 
+// Le nom du fichier est porté par l'en-tête Content-Disposition. Il est produit par le
+// serveur à partir d'une date, jamais d'une saisie : il n'y a rien à assainir ici, mais
+// un repli reste prévu si l'en-tête venait à ne pas être lisible.
+function nomDeFichier(reponse, repli) {
+  const entete = reponse.headers.get('Content-Disposition') ?? '';
+  const trouve = entete.match(/filename="([^"]+)"/);
+  return trouve ? trouve[1] : repli;
+}
+
+// Récupération d'un fichier, là où requete() attend du JSON. Les deux partagent l'en-tête
+// d'autorisation, le traitement de la session perdue et la forme des erreurs ; seule la
+// lecture du corps diffère.
+//
+// Un simple lien vers l'adresse ne conviendrait pas : le jeton vit en mémoire (D57) et
+// n'accompagne pas une navigation du navigateur. Le fichier est donc demandé comme
+// n'importe quel appel authentifié, puis remis à l'utilisateur depuis la page.
+export async function requeteFichier(chemin, { jeton, nomParDefaut = 'export.csv' } = {}) {
+  let reponse;
+  try {
+    reponse = await fetch(`${BASE}${chemin}`, {
+      headers: jeton ? { Authorization: `Bearer ${jeton}` } : {},
+    });
+  } catch {
+    throw new ErreurApi('Le serveur est injoignable. Vérifiez votre connexion.', 0);
+  }
+
+  if (!reponse.ok) {
+    if (reponse.status === 401) {
+      surSessionPerdue?.();
+    }
+    // Un échec renvoie du JSON, même sur une route qui rend un fichier en cas de succès.
+    let donnees = null;
+    try {
+      donnees = await reponse.json();
+    } catch {
+      donnees = null;
+    }
+    throw new ErreurApi(donnees?.erreur ?? 'Une erreur est survenue.', reponse.status);
+  }
+
+  return { blob: await reponse.blob(), nomFichier: nomDeFichier(reponse, nomParDefaut) };
+}
+
 export const api = {
   inscription: (donnees) => requete('/auth/inscription', { methode: 'POST', corps: donnees }),
   connexion: (donnees) => requete('/auth/connexion', { methode: 'POST', corps: donnees }),
@@ -125,4 +168,13 @@ export const api = {
   // statut qu'accepte le schéma de validation du serveur.
   desactiverAlerte: (jeton, id) =>
     requete(`/alertes/${id}`, { methode: 'PATCH', corps: { statut: 'desactivee' }, jeton }),
+  // Le compte agit toujours sur le porteur du jeton : aucune de ces trois routes ne
+  // reçoit d'identifiant d'utilisateur, il n'y en a donc aucun à transmettre.
+  changerMotDePasse: (jeton, donnees) =>
+    requete('/compte/mot-de-passe', { methode: 'PATCH', corps: donnees, jeton }),
+  // Le mot de passe accompagne la suppression : c'est le serveur qui le vérifie, la
+  // confirmation devant résister à un appel direct et pas seulement au dialogue.
+  supprimerCompte: (jeton, donnees) => requete('/compte', { methode: 'DELETE', corps: donnees, jeton }),
+  exporterMouvements: (jeton) =>
+    requeteFichier('/compte/export-mouvements', { jeton, nomParDefaut: 'capitall-mouvements.csv' }),
 };


### PR DESCRIPTION
Closes #121
Closes #122

Dernier écran du MVP. Les sept écrans sont désormais livrés.

## Ce qui est livré

**Écran Compte**, cinq sections en une seule page, sans sous-navigation : informations du compte en lecture seule, sécurité (mot de passe, déconnexion, suppression), affichage (devise et masquage), données (export), à propos. L'entrée de navigation existait déjà en placeholder désactivé, elle est activée. `GET /api/auth/moi` était disponible depuis la chaîne d'authentification sans qu'aucun écran ne la consomme : c'est cet écran qui l'utilise enfin.

Les préférences de devise et de masquage passent par les clés et les accesseurs existants. Cet écran est celui qui les règle, il n'en détient pas une seconde copie, et elles ne touchent ni les valeurs enregistrées ni le contenu de l'export.

## Contrats créés

| Méthode | Route | Codes |
|---|---|---|
| `PATCH` | `/api/compte/mot-de-passe` | 204, 400, 401 |
| `DELETE` | `/api/compte` | 204, 400, 401 |
| `GET` | `/api/compte/export-mouvements` | 200 `text/csv`, 401 |

Toutes authentifiées, toutes rattachées au seul porteur du jeton : aucune n'accepte d'identifiant d'utilisateur en entrée. Le cloisonnement de l'export est porté par la jointure SQL sur le propriétaire, pas par un filtre applicatif.

La session survit au changement de mot de passe, comme la spécification l'exige : le jeton est signé sur l'identifiant et le rôle, jamais sur le mot de passe. La suppression s'arrête à la ligne `utilisateur`, les cascades du schéma faisant le reste.

## Décisions appliquées

**D84**, actée dans ce lot : contrat de l'export CSV. D64 puis D80 l'avaient inscrit au périmètre en une demi-phrase, sans emplacement, sans colonnes et sans format. La question a été portée au PO plutôt que tranchée en écrivant le code. Deux points que la commande ne fixait pas ont été tranchés sur les sources : la colonne s'appelle `montant` et non `montant_total`, le dépôt établissant `montant` comme la quantité multipliée par le prix unitaire **frais exclus** — nommer « total » une valeur qui les exclut, alors que les frais occupent la colonne voisine, aurait contredit le vocabulaire du domaine ; et la colonne `actif` porte le symbole, unique par compte, plutôt que le nom, saisi librement.

**D69** : l'export ne recalcule aucun montant. Les mouvements sont groupés par actif et confiés à `derouler()`, le moteur qui produit déjà ce chiffre pour l'écran de détail, puis refondus en une liste unique remise dans l'ordre chronologique du domaine (règle 6 de D54). Le fichier porte exactement le chiffre que l'application affiche.

**D57** : l'export ne peut pas être un lien. Le jeton vit en mémoire et n'accompagne pas une navigation du navigateur ; le fichier est demandé comme tout appel authentifié, puis remis depuis la page par un lien éphémère aussitôt libéré.

## Points de vigilance

**Un défaut de sécurité a été trouvé et corrigé en cours de lot.** La confirmation par mot de passe de la suppression, telle que le lot la construisait d'abord, n'existait que dans le dialogue : la route supprimait le compte sur la seule présentation d'un jeton valide. Un jeton dérobé aurait donc suffi à effacer un compte sans jamais connaître le mot de passe. Le mot de passe accompagne désormais la demande et le serveur le compare au hachage stocké. Le contrat gagne un 400, repris dans le cahier des charges.

**`ErreurValidation` peut désormais porter le détail par champ**, au format que le middleware de validation produit déjà. C'est ce qui permet de poser « ancien mot de passe incorrect » sur son champ, comme la spécification l'exige : la règle demande la base, un schéma ne peut pas la trancher seul. Additif — aucune erreur existante n'en porte, aucune réponse existante ne change.

**`Confirmation` a été étendu, pas contourné.** Le composant rendait sa conséquence dans un `<p>` et ne piégeait que les boutons : y glisser un champ aurait produit du HTML invalide et un champ inatteignable à la tabulation. Il accepte maintenant un contenu placé après le paragraphe, son piège prend les saisies en compte, et le focus entre sur la saisie quand il y en a une. Le bouton destructeur, toujours placé en dernier, ne le reçoit dans aucun des deux cas ; son libellé a été distingué de celui qui ouvre le dialogue, deux commandes au même nom accessible étant indistinguables à l'oreille.

**Première route du dépôt à ne pas répondre en JSON.** `Content-Disposition` est exposé par CORS, par précaution pour le jour où l'interface ne serait plus servie sous la même origine.

## Tests

**281 tests back (+43), 262 tests front (+20)**, lint muet, build sans avertissement. Aucune assertion existante retirée ni affaiblie.

Contrat contrôlé contre une réponse réelle, base et serveur lancés :

- changement de mot de passe : ancien faux (400 avec le champ), nouveau trop court, clé `role` rejetée par `.strict()`, sans jeton (401), valide (204) ; ancien mot de passe refusé et nouveau accepté à la reconnexion ; **session conservée**, le jeton d'avant le changement répond toujours 200
- export du compte de démonstration : six actifs, quatre classes, douze mouvements, ordre chronologique entrelacé vérifié à la lecture, marque d'ordre des octets contrôlée en hexadécimal, montants recoupés à la main
- en-tête seul sur un compte sans mouvement
- cloisonnement vérifié dans les deux sens, chaque compte ne voyant que ses propres mouvements
- suppression : sans mot de passe (400), mot de passe faux (400, **compte toujours présent**), mot de passe correct (204) ; cascade mesurée par comptage SQL avant et après sur `actif`, `transaction` et `alerte`, tous ramenés à zéro

La suppression a été éprouvée sur des comptes de test créés pour l'occasion, jamais sur le compte de démonstration, resté intact.