### PR TITLE
Finitions d'interface avant remise

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WalletWatch</title>
+    <!-- La marque en SVG : nette à toute taille, un seul fichier, aucune déclinaison en
+         plusieurs tailles à tenir à jour. Le PNG sert de repli aux navigateurs qui ne
+         gèrent pas encore l'icône vectorielle. -->
+    <link rel="icon" type="image/svg+xml" href="/marque.svg" />
+    <link rel="apple-touch-icon" href="/marque.svg" />
+    <meta name="theme-color" content="#101418" />
+    <meta
+      name="description"
+      content="WalletWatch réunit vos cryptomonnaies, devises, métaux précieux et actions sur un même tableau de bord, calcule votre prix de revient moyen pondéré et suit vos plus-values."
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/marque.svg
+++ b/frontend/public/marque.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="fond" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3987e5"/>
+      <stop offset="100%" stop-color="#ce6bb0"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="9" fill="url(#fond)"/>
+  <rect x="7" y="23" width="18" height="2.5" rx="1.25" fill="#0b1015" opacity=".55"/>
+  <path d="M7 18.5 L12.5 13 L17 16 L25 7" fill="none" stroke="#0b1015" stroke-width="2.6"
+        stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="25" cy="7" r="2.6" fill="#e8ecf1" stroke="#0b1015" stroke-width="2"/>
+</svg>

--- a/frontend/src/composants/BarreProgression.css
+++ b/frontend/src/composants/BarreProgression.css
@@ -4,24 +4,75 @@
   gap: var(--espace-2);
 }
 
+/*
+  22 px et non 6. La barre portait un filet de six pixels sur toute la largeur de la carte :
+  un trait long et fin se lit mal, et il ne laissait aucune place au chiffre qu'il
+  représente. À cette épaisseur, le pourcentage tient dedans.
+*/
 .barre-progression__piste {
-  height: 6px;
+  position: relative;
+  height: 22px;
   border-radius: var(--rayon-pilule);
   background: var(--couleur-carte-haute);
   overflow: hidden;
 }
 
 .barre-progression__remplissage {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
   height: 100%;
+  padding: 0 var(--espace-2);
   background: var(--couleur-accent);
   border-radius: var(--rayon-pilule);
+  box-sizing: border-box;
+}
+
+/* La couleur de la classe surveillée, celle de l'anneau de répartition (D98). Le seuil
+   dit ainsi ce qu'il surveille sans le répéter en toutes lettres. */
+.barre-progression__piste--crypto .barre-progression__remplissage {
+  background: var(--couleur-classe-crypto);
+}
+
+.barre-progression__piste--metal .barre-progression__remplissage {
+  background: var(--couleur-classe-metal);
+}
+
+.barre-progression__piste--devise .barre-progression__remplissage {
+  background: var(--couleur-classe-devise);
+}
+
+.barre-progression__piste--action .barre-progression__remplissage {
+  background: var(--couleur-classe-action);
 }
 
 /* Un seuil franchi n'est plus une progression mais un fait : la barre prend la couleur
-   d'avertissement, celle que D70 réserve aux états qui demandent un regard. */
+   d'avertissement, celle que D70 réserve aux états qui demandent un regard. Elle l'emporte
+   sur la couleur de classe, l'état primant l'appartenance. */
 .barre-progression__piste--atteint .barre-progression__remplissage {
   background: var(--couleur-avertissement);
+}
+
+/*
+  Le chiffre est posé sur le remplissage, à son extrémité. L'encre sombre s'y détache de
+  toutes les teintes de classe comme de l'ambre : ce sont les quatre couleurs mesurées en
+  D98, dont le contraste avec le fond de l'application dépasse 4,5:1, donc a fortiori avec
+  une encre presque noire. Hors du remplissage, sur la piste, il reprend l'encre atténuée.
+*/
+.barre-progression__pourcentage {
+  font-size: var(--taille-legende);
+  font-weight: var(--graisse-forte);
+  font-variant-numeric: tabular-nums;
+  color: var(--couleur-fond);
+  white-space: nowrap;
+}
+
+.barre-progression__pourcentage--dehors {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: var(--espace-2);
+  color: var(--couleur-texte-attenue);
 }
 
 .barre-progression__reperes {

--- a/frontend/src/composants/BarreProgression.jsx
+++ b/frontend/src/composants/BarreProgression.jsx
@@ -1,5 +1,6 @@
 import './BarreProgression.css';
 import Montant from './Montant';
+import { formaterPourcentage } from '../utils/formatage';
 
 // Avancement d'une valeur vers un seuil.
 //
@@ -17,6 +18,15 @@ import Montant from './Montant';
 // montant par un nombre pour une valeur restituée à la voix, ce que la politique de
 // formatage interdit. aria-valuetext porte les deux montants en toutes lettres, et
 // c'est lui que les lecteurs d'écran annoncent.
+//
+// L'écart restant avant franchissement est écrit dans la barre, à l'extrémité de son
+// remplissage. Il figurait auparavant dans le texte au-dessus, ce qui séparait le chiffre
+// de la forme qui le représente et obligeait à faire l'aller-retour. C'est bien l'écart
+// que la spécification demande, et non l'avancement : dire « il reste 6 % » répond à la
+// question posée devant un seuil, là où « vous en êtes à 94 % » la contourne. L'avancement
+// reste porté par la longueur de la barre et par aria-valuenow. La barre porte la couleur de la
+// classe d'actif surveillée, celle-là même que porte l'anneau de répartition (D98) : c'est
+// le seul repère qui relie un seuil à ce qu'il surveille sans le répéter en toutes lettres.
 //
 // Un cours indisponible ne donne pas une barre à zéro, qui se lirait comme « très
 // loin du seuil » : la barre disparaît au profit d'une mention explicite.
@@ -50,6 +60,8 @@ export default function BarreProgression({
   sens = 'au_dessus',
   atteint = false,
   masque = false,
+  classe = null,
+  ecart = null,
 }) {
   const avancement =
     valeur === null || valeur === undefined ? null : fraction(valeur, cible, sens);
@@ -65,10 +77,22 @@ export default function BarreProgression({
   const pourcentage = Math.round(avancement * 100);
   const description = sens === 'au_dessus' ? 'seuil haut' : 'seuil bas';
 
+  // Le pourcentage se lit dans la barre plutôt qu'au-dessus d'elle. Il y perd sa place
+  // quand la barre est trop courte pour l'accueillir : en deçà d'un cinquième, il se pose
+  // juste après le remplissage, sur la piste vide.
+  const dansLeRemplissage = pourcentage >= 22;
+  const etiquette = ecart === null || ecart === undefined ? null : `reste ${formaterPourcentage(ecart)}`;
+
   return (
     <div className="barre-progression">
       <div
-        className={`barre-progression__piste${atteint ? ' barre-progression__piste--atteint' : ''}`}
+        className={[
+          'barre-progression__piste',
+          atteint ? 'barre-progression__piste--atteint' : '',
+          classe ? `barre-progression__piste--${classe}` : '',
+        ]
+          .filter(Boolean)
+          .join(' ')}
         role="progressbar"
         aria-valuemin={0}
         aria-valuemax={100}
@@ -76,7 +100,19 @@ export default function BarreProgression({
         aria-valuetext={`${pourcentage} % du ${description}`}
         aria-label={libelle}
       >
-        <span className="barre-progression__remplissage" style={{ width: `${pourcentage}%` }} />
+        <span className="barre-progression__remplissage" style={{ width: `${pourcentage}%` }}>
+          {etiquette && dansLeRemplissage && (
+            <span className="barre-progression__pourcentage">{etiquette}</span>
+          )}
+        </span>
+        {etiquette && !dansLeRemplissage && (
+          <span
+            className="barre-progression__pourcentage barre-progression__pourcentage--dehors"
+            style={{ left: `${pourcentage}%` }}
+          >
+            {etiquette}
+          </span>
+        )}
       </div>
       <p className="barre-progression__reperes">
         {masque ? (

--- a/frontend/src/composants/Champ.css
+++ b/frontend/src/composants/Champ.css
@@ -48,3 +48,60 @@
 .champ__erreur {
   color: var(--couleur-negatif);
 }
+
+/*
+  Zone de saisie d'un mot de passe : le champ et sa commande de révélation partagent le
+  même cadre. Le bouton est posé par-dessus plutôt qu'à côté, pour que la bordure du champ
+  reste d'un seul tenant et que la largeur du champ ne dépende pas de la présence du
+  bouton.
+*/
+.champ__zone {
+  position: relative;
+  /* Conteneur souple, et non un simple bloc : dans un bloc, un input reprend sa largeur
+     intrinsèque d'une vingtaine de caractères au lieu de suivre celle du champ. Le
+     bouton, lui, reste positionné par-dessus. */
+  display: flex;
+}
+
+.champ__zone .champ__saisie {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.champ__zone--revelable .champ__saisie {
+  /* De la place pour le bouton, sans que le texte saisi passe dessous. */
+  padding-right: 44px;
+}
+
+.champ__revelation {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: grid;
+  place-items: center;
+  /* 44 px : la zone interactive minimale en mobile (D77). Le bouton occupe toute la
+     hauteur du champ, il n'y a donc rien à viser précisément. */
+  width: 44px;
+  height: 100%;
+  padding: 0;
+  background: none;
+  border: 0;
+  border-radius: 0 var(--rayon-carte) var(--rayon-carte) 0;
+  color: var(--couleur-texte-attenue);
+  cursor: pointer;
+}
+
+.champ__revelation:hover,
+.champ__revelation[aria-pressed='true'] {
+  color: var(--couleur-texte);
+}
+
+.champ__revelation svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}

--- a/frontend/src/composants/Champ.jsx
+++ b/frontend/src/composants/Champ.jsx
@@ -1,4 +1,4 @@
-import { useId } from 'react';
+import { useId, useState } from 'react';
 import './Champ.css';
 
 // Champ de formulaire accessible.
@@ -9,6 +9,13 @@ import './Champ.css';
 //   - le message d'erreur est rattaché au champ par aria-describedby ;
 //   - aria-invalid signale l'erreur, en plus de la bordure rouge, la couleur ne
 //     devant jamais porter seule une information.
+//
+// Un champ de mot de passe reçoit en plus une commande de révélation. Elle sert le cas le
+// plus banal de l'écran de connexion : une saisie refusée sans qu'on sache si le mot de
+// passe est faux ou mal tapé. Le champ bascule entre `password` et `text` ; rien n'est
+// transmis ni conservé différemment, seul l'affichage change. L'état est porté par
+// `aria-pressed` plutôt que par le seul dessin de l'icône, et le champ reste désigné par
+// le même label, donc annoncé de la même façon.
 export default function Champ({
   label,
   type = 'text',
@@ -22,6 +29,10 @@ export default function Champ({
   const identifiant = useId();
   const idErreur = `${identifiant}-erreur`;
   const idAide = `${identifiant}-aide`;
+
+  const [revele, setRevele] = useState(false);
+  const estMotDePasse = type === 'password';
+  const typeEffectif = estMotDePasse && revele ? 'text' : type;
 
   const decritPar = [erreur ? idErreur : null, aide ? idAide : null].filter(Boolean).join(' ');
 
@@ -38,17 +49,35 @@ export default function Champ({
         {obligatoire && <span className="lecteur-ecran-seulement"> (obligatoire)</span>}
       </label>
 
-      <input
-        id={identifiant}
-        type={type}
-        className={`champ__saisie${erreur ? ' champ__saisie--erreur' : ''}`}
-        value={valeur}
-        onChange={onChange}
-        required={obligatoire}
-        aria-invalid={erreur ? 'true' : undefined}
-        aria-describedby={decritPar || undefined}
-        {...proprietes}
-      />
+      <div className={`champ__zone${estMotDePasse ? ' champ__zone--revelable' : ''}`}>
+        <input
+          id={identifiant}
+          type={typeEffectif}
+          className={`champ__saisie${erreur ? ' champ__saisie--erreur' : ''}`}
+          value={valeur}
+          onChange={onChange}
+          required={obligatoire}
+          aria-invalid={erreur ? 'true' : undefined}
+          aria-describedby={decritPar || undefined}
+          {...proprietes}
+        />
+
+        {estMotDePasse && (
+          <button
+            type="button"
+            className="champ__revelation"
+            onClick={() => setRevele((etat) => !etat)}
+            aria-pressed={revele}
+            aria-label={revele ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M2 12s3.6-6 10-6 10 6 10 6-3.6 6-10 6-10-6-10-6z" />
+              <circle cx="12" cy="12" r="3" />
+              {revele && <path d="M4 4l16 16" />}
+            </svg>
+          </button>
+        )}
+      </div>
 
       {aide && (
         <p className="champ__aide" id={idAide}>

--- a/frontend/src/composants/CourbeMiniature.jsx
+++ b/frontend/src/composants/CourbeMiniature.jsx
@@ -22,7 +22,10 @@ import { sensVariation } from '../utils/formatage';
 // lisait sur une bande étroite alors que la colonne avait la place. Trente points sur
 // 80 px les espacent de moins de trois pixels, ce qui écrase toute inflexion.
 const LARGEUR = 120;
-const HAUTEUR = 24;
+// 32 px : à 24, trente points écrasaient les inflexions contre les bords du cadre. La
+// hauteur reste inférieure à celle d'une ligne de tableau, la colonne ne s'en trouve pas
+// élargie.
+const HAUTEUR = 32;
 const MARGE = 2;
 
 function trace(points) {

--- a/frontend/src/composants/CourbeMiniature.jsx
+++ b/frontend/src/composants/CourbeMiniature.jsx
@@ -18,7 +18,10 @@ import { sensVariation } from '../utils/formatage';
 // n'aboutit à une valeur affichée : la variation vient du serveur et passe par le
 // module de formatage comme partout ailleurs.
 
-const LARGEUR = 80;
+// 120 px et non 80 : sur la dernière colonne du tableau des positions, la courbe se
+// lisait sur une bande étroite alors que la colonne avait la place. Trente points sur
+// 80 px les espacent de moins de trois pixels, ce qui écrase toute inflexion.
+const LARGEUR = 120;
 const HAUTEUR = 24;
 const MARGE = 2;
 

--- a/frontend/src/composants/Feuille.css
+++ b/frontend/src/composants/Feuille.css
@@ -45,16 +45,34 @@
 
 .feuille__entete {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--espace-3);
   margin-bottom: var(--espace-3);
+  /* L'en-tête n'est pas du contenu à copier : sans cela, un clic à côté du titre y
+     laissait un curseur de texte, ce qui donnait à une zone inerte l'apparence d'un
+     champ de saisie. */
+  user-select: none;
+  cursor: default;
+}
+
+.feuille__intitule {
+  flex: 1;
+  min-width: 0;
 }
 
 .feuille__titre {
-  flex: 1;
   margin: 0;
   font-size: var(--taille-titre);
   font-weight: var(--graisse-forte);
+}
+
+/* Le nom de la cible, sous le titre : il peut être long, il se coupe plutôt que de
+   pousser le bouton de fermeture hors de l'écran. */
+.feuille__sous-titre {
+  margin: 2px 0 0;
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+  overflow-wrap: anywhere;
 }
 
 /* Zone tactile de 44 px en mobile (D77), le glyphe restant plus petit. */

--- a/frontend/src/composants/Feuille.jsx
+++ b/frontend/src/composants/Feuille.jsx
@@ -26,6 +26,11 @@ const ATTEIGNABLES =
 
 export default function Feuille({
   titre,
+  // Complément du titre, sur sa propre ligne. Concaténé au titre, un nom d'actif long
+  // — « Nouveau seuil — NVIDIA Corporation (NVDA) » — passait sur deux lignes en gras et
+  // en corps de titre, poussait le bouton de fermeture et déséquilibrait l'en-tête.
+  // Séparé, le titre reste court et stable, et le nom de l'actif se lit en dessous.
+  sousTitre,
   children,
   surFermeture,
   // Pendant un enregistrement, la feuille ne se referme plus : ni par le bouton, ni
@@ -37,6 +42,7 @@ export default function Feuille({
   const declencheur = useRef(null);
   const identifiant = useId();
   const idTitre = `${identifiant}-titre`;
+  const idSousTitre = `${identifiant}-sous-titre`;
 
   useEffect(() => {
     declencheur.current = document.activeElement;
@@ -92,7 +98,10 @@ export default function Feuille({
         className="feuille"
         role="dialog"
         aria-modal="true"
-        aria-labelledby={idTitre}
+        // Le nom du dialogue reprend les deux lignes de l'en-tête. Séparer le titre du
+        // nom de la cible règle un problème de mise en page ; il ne doit pas priver un
+        // lecteur d'écran de savoir sur quoi porte la feuille qui vient de s'ouvrir.
+        aria-labelledby={sousTitre ? `${idTitre} ${idSousTitre}` : idTitre}
         tabIndex={-1}
         ref={dialogue}
         onKeyDown={auClavier}
@@ -100,9 +109,16 @@ export default function Feuille({
         <span className="feuille__poignee" aria-hidden="true" />
 
         <header className="feuille__entete">
-          <h2 id={idTitre} className="feuille__titre">
-            {titre}
-          </h2>
+          <div className="feuille__intitule">
+            <h2 id={idTitre} className="feuille__titre">
+              {titre}
+            </h2>
+            {sousTitre && (
+              <p id={idSousTitre} className="feuille__sous-titre">
+                {sousTitre}
+              </p>
+            )}
+          </div>
           <button
             type="button"
             className="feuille__fermer"

--- a/frontend/src/composants/FeuilleSeuil.jsx
+++ b/frontend/src/composants/FeuilleSeuil.jsx
@@ -196,7 +196,8 @@ export default function FeuilleSeuil({
 
   return (
     <Feuille
-      titre={cibleActif && actifChoisi ? `Nouveau seuil — ${nomCible}` : 'Nouveau seuil'}
+      titre="Nouveau seuil"
+      sousTitre={cibleActif && actifChoisi ? nomCible : undefined}
       surFermeture={surFermeture}
       verrouillee={envoi}
     >

--- a/frontend/src/composants/Marque.css
+++ b/frontend/src/composants/Marque.css
@@ -1,0 +1,27 @@
+/*
+  Encre de la marque. Le tracé et la fente reprennent l'encre sombre du fond général, la
+  même que celle du bouton flottant sur son aplat d'accent : sur un dégradé bleu-rose,
+  c'est elle qui tient le contraste, là où l'encre de texte ordinaire s'y noierait.
+
+  Le point de relevé est en revanche clair : il doit se détacher du trait sombre qui le
+  porte, et non s'y fondre.
+*/
+.marque {
+  flex: none;
+  display: block;
+}
+
+.marque__trace {
+  stroke: #0b1015;
+}
+
+.marque__fente {
+  fill: #0b1015;
+  opacity: 0.55;
+}
+
+.marque__releve {
+  fill: var(--couleur-texte);
+  stroke: #0b1015;
+  stroke-width: 2;
+}

--- a/frontend/src/composants/Marque.jsx
+++ b/frontend/src/composants/Marque.jsx
@@ -1,0 +1,56 @@
+import './Marque.css';
+
+// Marque de l'application.
+//
+// Elle remplace la lettre W posée sur un carré d'accent, qui était un pis-aller : une
+// initiale dans une pastille ne dit rien du produit et se confond avec les dizaines
+// d'applications qui font la même chose.
+//
+// Le dessin réunit les deux moitiés du nom. Le corps arrondi et la fente horizontale
+// basse sont ceux d'un portefeuille ; la ligne qui le traverse en montant, avec son point
+// de relevé au sommet, est la courbe que l'application passe son temps à tracer. C'est
+// exactement ce que fait le produit : un portefeuille qu'on surveille.
+//
+// Le dégradé va du bleu des cryptomonnaies au rose des actions, deux des quatre couleurs
+// de classe arbitrées en D98. Aucune teinte nouvelle n'entre donc dans la palette, et la
+// marque emprunte au système au lieu de vivre à côté.
+//
+// Le tracé est décoratif : le nom du produit est écrit à côté, en toutes lettres. La
+// marque porte donc aria-hidden, et rien de ce qu'elle montre n'est perdu sans elle.
+export default function Marque({ taille = 32 }) {
+  return (
+    <svg
+      className="marque"
+      width={taille}
+      height={taille}
+      viewBox="0 0 32 32"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <defs>
+        <linearGradient id="marque-fond" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="var(--couleur-classe-crypto)" />
+          <stop offset="100%" stopColor="var(--couleur-classe-action)" />
+        </linearGradient>
+      </defs>
+
+      {/* Le corps du portefeuille. */}
+      <rect x="0" y="0" width="32" height="32" rx="9" fill="url(#marque-fond)" />
+
+      {/* La fente, en bas : ce qui fait lire un portefeuille plutôt qu'une pastille. */}
+      <rect x="7" y="23" width="18" height="2.5" rx="1.25" className="marque__fente" />
+
+      {/* La courbe suivie, et son dernier relevé. Elle monte vers la droite et sort du
+          cadre optique du corps, ce qui donne au signe son mouvement. */}
+      <path
+        className="marque__trace"
+        d="M7 18.5 L12.5 13 L17 16 L25 7"
+        fill="none"
+        strokeWidth="2.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle className="marque__releve" cx="25" cy="7" r="2.6" />
+    </svg>
+  );
+}

--- a/frontend/src/composants/__tests__/affichage.test.jsx
+++ b/frontend/src/composants/__tests__/affichage.test.jsx
@@ -145,7 +145,7 @@ describe('JetonClasse', () => {
   // La forme ne se prononce pas : le nom de la classe est toujours restitué.
   it('nomme la classe même lorsque le libellé n\'est pas visible', () => {
     render(<JetonClasse classe="metal" />);
-    expect(screen.getByText('Métal précieux')).toBeTruthy();
+    expect(screen.getByText('Métaux')).toBeTruthy();
   });
 
   it('ignore une classe inconnue plutôt que d\'afficher une forme muette', () => {

--- a/frontend/src/mise-en-page/Coquille.css
+++ b/frontend/src/mise-en-page/Coquille.css
@@ -43,7 +43,11 @@
   align-items: center;
   gap: var(--espace-1);
   padding: var(--espace-2) var(--espace-1);
-  font-size: var(--taille-legende);
+  /* Corps de texte plutôt que légende : ces cinq libellés sont la structure de
+     l'application, pas une annotation. Ils étaient plus petits que la moindre valeur
+     affichée à côté d'eux. */
+  font-size: var(--taille-corps);
+  font-weight: var(--graisse-forte);
   color: var(--couleur-texte-attenue);
   text-decoration: none;
 }
@@ -201,7 +205,11 @@
   }
 
   .coquille__pseudo {
-    font-size: var(--taille-legende);
+    /* Corps de texte plutôt que légende : ces cinq libellés sont la structure de
+     l'application, pas une annotation. Ils étaient plus petits que la moindre valeur
+     affichée à côté d'eux. */
+  font-size: var(--taille-corps);
+  font-weight: var(--graisse-forte);
     color: var(--couleur-texte-attenue);
   }
 

--- a/frontend/src/mise-en-page/Coquille.css
+++ b/frontend/src/mise-en-page/Coquille.css
@@ -43,11 +43,13 @@
   align-items: center;
   gap: var(--espace-1);
   padding: var(--espace-2) var(--espace-1);
-  /* Corps de texte plutôt que légende : ces cinq libellés sont la structure de
-     l'application, pas une annotation. Ils étaient plus petits que la moindre valeur
-     affichée à côté d'eux. */
-  font-size: var(--taille-corps);
+  /* Ces cinq libellés sont la structure de l'application, pas une annotation : ils
+     doivent dominer le contenu qu'ils encadrent, et non lui céder le pas. 16 px les
+     place entre le corps de texte et le titre d'écran, et l'espacement vertical suit —
+     une liste plus haute se balaie mieux qu'une liste plus dense. */
+  font-size: 16px;
   font-weight: var(--graisse-forte);
+  letter-spacing: 0.01em;
   color: var(--couleur-texte-attenue);
   text-decoration: none;
 }
@@ -168,7 +170,7 @@
   .coquille__liste {
     flex: none;
     flex-direction: column;
-    gap: var(--espace-1);
+    gap: var(--espace-2);
   }
 
   .coquille__liste > li {
@@ -179,12 +181,15 @@
     display: none;
   }
 
+  /* Le rail latéral reprend la taille posée plus haut : 14 px y ramenaient les libellés
+     sous le poids des chiffres qu'ils encadrent. La marge intérieure verticale suit, pour
+     que quatre entrées plus grosses restent une liste aérée et non un bloc compact. */
   .coquille__lien {
     flex-direction: row;
     justify-content: flex-start;
     gap: var(--espace-3);
-    padding: var(--espace-3);
-    font-size: var(--taille-corps);
+    padding: var(--espace-3) var(--espace-4);
+    font-size: 16px;
     border-radius: var(--rayon-carte);
   }
 
@@ -205,11 +210,13 @@
   }
 
   .coquille__pseudo {
-    /* Corps de texte plutôt que légende : ces cinq libellés sont la structure de
-     l'application, pas une annotation. Ils étaient plus petits que la moindre valeur
-     affichée à côté d'eux. */
-  font-size: var(--taille-corps);
+    /* Ces cinq libellés sont la structure de l'application, pas une annotation : ils
+     doivent dominer le contenu qu'ils encadrent, et non lui céder le pas. 16 px les
+     place entre le corps de texte et le titre d'écran, et l'espacement vertical suit —
+     une liste plus haute se balaie mieux qu'une liste plus dense. */
+  font-size: 16px;
   font-weight: var(--graisse-forte);
+  letter-spacing: 0.01em;
     color: var(--couleur-texte-attenue);
   }
 

--- a/frontend/src/mise-en-page/Coquille.css
+++ b/frontend/src/mise-en-page/Coquille.css
@@ -152,20 +152,8 @@
     font-weight: var(--graisse-forte);
   }
 
-  .coquille__marque > span {
-    display: grid;
-    place-items: center;
-    width: 32px;
-    height: 32px;
-    border-radius: var(--rayon-carte);
-    background: var(--couleur-accent);
-    /* La même encre sombre que le bouton flottant, sur le même fond accentué. La
-       couleur de texte ordinaire n'y atteignait que 2,40:1, mesuré au navigateur : la
-       lettre était illisible, même si son aria-hidden la met hors du champ formel de
-       la règle. */
-    color: #0b1015;
-    font-size: var(--taille-corps);
-  }
+  /* La marque porte son propre dessin et ses propres couleurs : voir Marque.jsx. Il n'y
+     a plus de pastille à styler ici. */
 
   .coquille__liste {
     flex: none;

--- a/frontend/src/mise-en-page/Coquille.jsx
+++ b/frontend/src/mise-en-page/Coquille.jsx
@@ -2,6 +2,7 @@ import { NavLink, Outlet, useLocation } from 'react-router-dom';
 import { useAuthentification } from '../contexte/contexteAuthentification';
 import { useMouvement } from '../hooks/useMouvement';
 import Bouton from '../composants/Bouton';
+import Marque from '../composants/Marque';
 import './Coquille.css';
 
 // Navigation principale. Les écrans non encore développés figurent déjà dans la
@@ -62,7 +63,7 @@ export default function Coquille() {
   return (
     <div className="coquille">
       <nav className="coquille__navigation" aria-label="Navigation principale">
-        <p className="coquille__marque"><span aria-hidden="true">W</span>WalletWatch</p>
+        <p className="coquille__marque"><Marque />WalletWatch</p>
 
         <ul className="coquille__liste">
           {ENTREES.map((entree) =>

--- a/frontend/src/pages/Authentification.css
+++ b/frontend/src/pages/Authentification.css
@@ -93,3 +93,40 @@
   font-size: var(--taille-legende);
   color: var(--couleur-texte-attenue);
 }
+
+/*
+  La marque en tête de carte. Les écrans d'authentification sont les seuls où le rail de
+  navigation n'existe pas encore : sans elle, rien n'y nomme l'application, et l'écran de
+  connexion d'un outil patrimonial gagne à dire tout de suite chez qui l'on est.
+*/
+.authentification__marque {
+  display: flex;
+  align-items: center;
+  gap: var(--espace-3);
+  margin: 0 0 var(--espace-6);
+  font-size: var(--taille-titre);
+  font-weight: var(--graisse-forte);
+  letter-spacing: 0.01em;
+}
+
+/*
+  Une lueur très basse derrière la carte, dans les deux teintes de la marque. Elle donne
+  un fond à un écran qui n'était qu'un aplat, sans rien ajouter à charger : c'est un
+  dégradé calculé par le navigateur, pas une image. Les valeurs sont volontairement
+  faibles — au-delà, le contraste du texte de la carte s'en trouverait affecté.
+*/
+.authentification {
+  position: relative;
+  isolation: isolate;
+}
+
+.authentification::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background:
+    radial-gradient(60% 45% at 50% 0%, color-mix(in srgb, var(--couleur-classe-crypto) 12%, transparent), transparent 70%),
+    radial-gradient(45% 40% at 85% 100%, color-mix(in srgb, var(--couleur-classe-action) 9%, transparent), transparent 70%);
+  pointer-events: none;
+}

--- a/frontend/src/pages/Compte.css
+++ b/frontend/src/pages/Compte.css
@@ -63,10 +63,57 @@
   font-size: var(--taille-caption, 0.875rem);
 }
 
+/* Même raison que pour le formulaire : l'action d'export garde sa largeur propre. */
+.compte__carte > .bouton {
+  align-self: flex-start;
+}
+
+/*
+  Fiche « À propos ». Les lignes y étaient réparties comme celles du bloc d'informations,
+  libellé à gauche et valeur poussée à droite. Cela tient tant que la valeur est courte ;
+  la ligne des actions, qui court sur trois lignes, se retrouvait ferrée à droite en
+  drapeau, décalée de tout le reste. Deux colonnes fixes et un texte aligné à gauche
+  règlent le cas sans traiter cette ligne à part.
+*/
+.compte__informations--propos {
+  display: grid;
+  grid-template-columns: minmax(8rem, max-content) 1fr;
+  column-gap: var(--espace-6);
+  row-gap: var(--espace-3);
+  align-items: baseline;
+}
+
+.compte__informations--propos .compte__ligne {
+  display: contents;
+}
+
+.compte__informations--propos dd {
+  text-align: left;
+  font-weight: var(--graisse-normale);
+}
+
+@media (max-width: 479px) {
+  .compte__informations--propos {
+    grid-template-columns: 1fr;
+    row-gap: var(--espace-1);
+  }
+
+  .compte__informations--propos dd {
+    margin-bottom: var(--espace-2);
+  }
+}
+
 .compte__formulaire {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: var(--espace-3);
+}
+
+/* Les champs occupent la largeur de la carte, le bouton la sienne : un bouton étiré sur
+   toute la carte se lit comme une action principale de page, ce qu'il n'est pas. */
+.compte__formulaire .champ {
+  align-self: stretch;
 }
 
 .compte__actions {

--- a/frontend/src/pages/Compte.jsx
+++ b/frontend/src/pages/Compte.jsx
@@ -328,7 +328,7 @@ export default function Compte() {
       </Carte>
 
       <Carte titre="À propos" className="compte__carte">
-        <dl className="compte__informations">
+        <dl className="compte__informations compte__informations--propos">
           <div className="compte__ligne">
             <dt>Version</dt>
             <dd>0.1.0</dd>
@@ -336,23 +336,37 @@ export default function Compte() {
           {/* Sources et fréquences réelles : elles reprennent les adaptateurs branchés
               et les durées de vie du cache définies côté serveur (D21). */}
           <div className="compte__ligne">
-            <dt>Cryptomonnaies</dt>
-            <dd>Coinbase, rafraîchi toutes les 2 minutes</dd>
+            <dt>Cryptos</dt>
+            <dd>Coinbase, toutes les 2 minutes</dd>
           </div>
           <div className="compte__ligne">
             <dt>Devises</dt>
-            <dd>Frankfurter (BCE), rafraîchi une fois par heure</dd>
+            <dd>Frankfurter (taux de référence BCE), une fois par heure</dd>
           </div>
           <div className="compte__ligne">
-            <dt>Métaux précieux</dt>
-            <dd>gold-api, rafraîchi toutes les 10 minutes</dd>
+            <dt>Métaux</dt>
+            <dd>gold-api, toutes les 10 minutes. Cotation à l&apos;once troy</dd>
           </div>
           <div className="compte__ligne">
             <dt>Actions</dt>
             <dd>
-              Financial Modeling Prep, puis Finnhub et Alpha Vantage en secours, rafraîchi
-              toutes les 5 minutes. Ces positions ne sont valorisées que si une clé de
-              fournisseur est configurée sur le serveur.
+              Financial Modeling Prep, puis Finnhub et Alpha Vantage en secours, toutes les
+              5 minutes
+            </dd>
+          </div>
+          <div className="compte__ligne">
+            <dt>Devise de référence</dt>
+            <dd>
+              Euro. L&apos;affichage en dollar convertit au taux du jour, sans modifier
+              les montants enregistrés
+            </dd>
+          </div>
+          <div className="compte__ligne">
+            <dt>Cours indisponible</dt>
+            <dd>
+              Le dernier cours connu prend le relais, avec sa date. À défaut, la position
+              n&apos;est pas valorisée et sort du total, plutôt que d&apos;être comptée
+              pour zéro
             </dd>
           </div>
         </dl>

--- a/frontend/src/pages/Connexion.jsx
+++ b/frontend/src/pages/Connexion.jsx
@@ -5,6 +5,7 @@ import Bouton from '../composants/Bouton';
 import Champ from '../composants/Champ';
 import Message from '../composants/Message';
 import './Authentification.css';
+import Marque from '../composants/Marque';
 
 export default function Connexion() {
   const { connecter, estConnecte, sessionExpiree } = useAuthentification();
@@ -49,6 +50,10 @@ export default function Connexion() {
   return (
     <main className="authentification">
       <div className="authentification__carte">
+        <p className="authentification__marque">
+          <Marque taille={28} />
+          WalletWatch
+        </p>
         <h1 className="authentification__titre">Connexion</h1>
         <p className="authentification__intro">Accédez au suivi de votre patrimoine.</p>
 

--- a/frontend/src/pages/DetailPosition.css
+++ b/frontend/src/pages/DetailPosition.css
@@ -241,3 +241,76 @@
   text-align: center;
   color: var(--couleur-texte-attenue);
 }
+
+/*
+  Bande principale de la fiche : la valorisation et les trois repères de la position.
+  Empilées en mobile, côte à côte au-dessus du point de rupture, dans la même proportion
+  que le patrimoine et sa répartition sur l'écran d'accueil.
+*/
+.detail__principal {
+  display: flex;
+  flex-direction: column;
+  gap: var(--espace-6);
+}
+
+/* Deux repères nommés sous le grand chiffre, plutôt qu'une file de variations dont on
+   devait deviner à quelle question chacune répondait. Même traitement que l'écran
+   Patrimoine, filet vertical compris. */
+.detail__reperes {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--espace-4);
+  margin: var(--espace-6) 0 0;
+}
+
+.detail__marqueur + .detail__marqueur {
+  padding-left: var(--espace-4);
+  border-left: 1px solid var(--couleur-bordure);
+}
+
+.detail__marqueur dt {
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.detail__marqueur dd {
+  margin: var(--espace-1) 0 0;
+  font-size: var(--taille-titre);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (min-width: 768px) {
+  .detail__principal {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+    align-items: stretch;
+  }
+
+  /* Dans la bande, le trio reprend la colonne : trois lignes empilées y tiennent mieux
+     qu'une rangée, la largeur disponible étant celle d'une colonne et non d'un écran. */
+  .detail__principal .detail__trio {
+    flex-direction: column;
+    justify-content: center;
+    gap: 0;
+    padding: 0 var(--espace-4);
+    border: 1px solid var(--couleur-bordure);
+    border-radius: var(--rayon-carte);
+  }
+
+  .detail__principal .detail__repere {
+    flex: none;
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--espace-4);
+    padding: var(--espace-4) 0;
+    border-bottom: 1px solid var(--couleur-bordure);
+    border-left: 0;
+  }
+
+  .detail__principal .detail__repere:last-child {
+    border-bottom: 0;
+  }
+}

--- a/frontend/src/pages/DetailPosition.css
+++ b/frontend/src/pages/DetailPosition.css
@@ -289,12 +289,17 @@
   }
 
   /* Dans la bande, le trio reprend la colonne : trois lignes empilées y tiennent mieux
-     qu'une rangée, la largeur disponible étant celle d'une colonne et non d'un écran. */
+     qu'une rangée, la largeur disponible étant celle d'une colonne et non d'un écran.
+
+     La marge intérieure est portée par les lignes et non par le cadre : posée sur le
+     cadre, elle arrêtait les filets de séparation à seize pixels du bord, et le cadre
+     paraissait plus large que son contenu. Les filets vont maintenant d'un bord à
+     l'autre, et le texte respire à l'intérieur. */
   .detail__principal .detail__trio {
     flex-direction: column;
     justify-content: center;
     gap: 0;
-    padding: 0 var(--espace-4);
+    padding: 0;
     border: 1px solid var(--couleur-bordure);
     border-radius: var(--rayon-carte);
   }
@@ -304,8 +309,8 @@
     flex-direction: row;
     align-items: baseline;
     justify-content: space-between;
-    gap: var(--espace-4);
-    padding: var(--espace-4) 0;
+    gap: var(--espace-6);
+    padding: var(--espace-4) var(--espace-6);
     border-bottom: 1px solid var(--couleur-bordure);
     border-left: 0;
   }

--- a/frontend/src/pages/DetailPosition.jsx
+++ b/frontend/src/pages/DetailPosition.jsx
@@ -424,6 +424,13 @@ export default function DetailPosition() {
         </Message>
       )}
 
+      {/*
+        Valorisation et repères de la position se partagent une bande, comme le patrimoine
+        et sa répartition sur l'écran d'accueil. La valorisation occupait auparavant toute
+        la largeur pour trois chiffres, laissant ses deux tiers droits vides, et les repères
+        s'alignaient en dessous sur une rangée qui n'avait plus rien à quoi se comparer.
+      */}
+      <div className="detail__principal">
       <section className="detail__valorisation" aria-labelledby="titre-valorisation">
         <h2 id="titre-valorisation" className="detail__intitule">
           Valorisation de la position
@@ -440,20 +447,33 @@ export default function DetailPosition() {
             className="detail__valeur"
           />
         )}
-        <p className="detail__variations">
-          {!masque && (
-            <Variation
-              valeur={afficher(position.plus_value_latente)}
-              mode="absolue"
-              devise={devise}
-              amplitude={position.pourcentage_variation}
-            />
-          )}
-          {position.pourcentage_variation !== null && (
-            <Variation valeur={position.pourcentage_variation} />
-          )}
-          <span className="detail__depuis">de plus-value latente</span>
-        </p>
+        <dl className="detail__reperes">
+          <div className="detail__marqueur">
+            <dt>Gains latents</dt>
+            <dd>
+              {masque ? (
+                <span aria-label="Montant masqué">••••</span>
+              ) : (
+                <Variation
+                  valeur={afficher(position.plus_value_latente)}
+                  mode="absolue"
+                  devise={devise}
+                  amplitude={position.pourcentage_variation}
+                />
+              )}
+            </dd>
+          </div>
+          <div className="detail__marqueur">
+            <dt>Progression</dt>
+            <dd>
+              {position.pourcentage_variation === null ? (
+                <span className="detail__depuis">—</span>
+              ) : (
+                <Variation valeur={position.pourcentage_variation} />
+              )}
+            </dd>
+          </div>
+        </dl>
       </section>
 
       <dl className="detail__trio">
@@ -493,6 +513,7 @@ export default function DetailPosition() {
           </dd>
         </div>
       </dl>
+      </div>
 
       {/*
         Le graphe de cours et sa ligne de prix de revient (D79). L'aire se teinte de part

--- a/frontend/src/pages/Inscription.jsx
+++ b/frontend/src/pages/Inscription.jsx
@@ -5,6 +5,7 @@ import Bouton from '../composants/Bouton';
 import Champ from '../composants/Champ';
 import Message from '../composants/Message';
 import './Authentification.css';
+import Marque from '../composants/Marque';
 
 // Contrôles repris de ceux du serveur, qui reste l'autorité : cette validation n'est
 // qu'un confort, elle évite un aller-retour réseau pour une erreur évidente.
@@ -113,6 +114,10 @@ export default function Inscription() {
   return (
     <main className="authentification">
       <div className="authentification__carte">
+        <p className="authentification__marque">
+          <Marque taille={28} />
+          WalletWatch
+        </p>
         <h1 className="authentification__titre">Créer un compte</h1>
         <p className="authentification__intro">
           Réunissez vos cryptomonnaies, devises, métaux et actions sur un seul tableau de bord.

--- a/frontend/src/pages/MotDePasseOublie.jsx
+++ b/frontend/src/pages/MotDePasseOublie.jsx
@@ -5,6 +5,7 @@ import Bouton from '../composants/Bouton';
 import Champ from '../composants/Champ';
 import Message from '../composants/Message';
 import './Authentification.css';
+import Marque from '../composants/Marque';
 
 // Demande de réinitialisation d'un mot de passe oublié (D23).
 //
@@ -40,6 +41,10 @@ export default function MotDePasseOublie() {
   return (
     <main className="authentification">
       <div className="authentification__carte">
+        <p className="authentification__marque">
+          <Marque taille={28} />
+          WalletWatch
+        </p>
         <h1 className="authentification__titre">Mot de passe oublié</h1>
         <p className="authentification__intro">
           Indiquez l’adresse de votre compte. Vous recevrez une clé permettant d’en choisir un

--- a/frontend/src/pages/Patrimoine.css
+++ b/frontend/src/pages/Patrimoine.css
@@ -93,13 +93,35 @@
   font-variant-numeric: tabular-nums;
 }
 
-.patrimoine__variations {
-  display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  /* 12 px entre éléments liés. */
-  gap: var(--espace-3);
-  margin: var(--espace-3) 0 0;
+/*
+  Les deux repères qui suivent le patrimoine. Chacun porte son intitulé : deux valeurs
+  posées à la suite du grand chiffre laissaient deviner laquelle répondait à quelle
+  question. Ils sont séparés par un filet vertical, comme les chiffres de contexte du bas
+  d'écran, plutôt que par des cartes qui leur donneraient le poids d'indicateurs de tête.
+*/
+.patrimoine__reperes {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--espace-4);
+  margin: var(--espace-6) 0 var(--espace-3);
+}
+
+.patrimoine__repere + .patrimoine__repere {
+  padding-left: var(--espace-4);
+  border-left: 1px solid var(--couleur-bordure);
+}
+
+.patrimoine__repere dt {
+  font-size: var(--taille-legende);
+  color: var(--couleur-texte-attenue);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.patrimoine__repere dd {
+  margin: var(--espace-1) 0 0;
+  font-size: var(--taille-titre);
+  font-variant-numeric: tabular-nums;
 }
 
 .patrimoine__depuis {
@@ -174,10 +196,10 @@
 @media (min-width: 768px) {
   .patrimoine__principal {
     display: grid;
-    /* Les deux blocs sont de même rang : ni l'un ni l'autre n'est un aparté. La
-       répartition demande un peu moins de place que le patrimoine, qui porte le plus
-       gros chiffre de l'application. */
-    grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    /* La répartition prend la plus grande part. Le bloc de patrimoine porte trois
+       chiffres et n'a pas besoin de plus, tandis que la répartition doit loger un anneau
+       et quatre lignes chiffrées : c'est elle que l'espace supplémentaire sert. */
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
     align-items: stretch;
   }
 
@@ -191,7 +213,7 @@
 
   .patrimoine__contexte {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
     gap: var(--espace-6);
   }
 

--- a/frontend/src/pages/Patrimoine.jsx
+++ b/frontend/src/pages/Patrimoine.jsx
@@ -341,23 +341,41 @@ export default function Patrimoine() {
               className="patrimoine__valeur"
             />
           )}
-          <p className="patrimoine__variations">
-            {!masque && (
-              <Variation
-                valeur={afficher(portefeuille.plus_value_latente)}
-                mode="absolue"
-                devise={devise}
-                amplitude={portefeuille.pourcentage_variation}
-              />
-            )}
-            {portefeuille.pourcentage_variation !== null && (
-              <Variation valeur={portefeuille.pourcentage_variation} />
-            )}
-            {/* Ce chiffre est la plus-value latente rapportée au coût des positions
-                encore détenues. Il portait la mention « depuis l'origine », que le
-                sélecteur de période emploie aussi pour l'évolution de la valeur suivie :
-                deux calculs différents sous un même mot, sur le même écran. */}
-            <span className="patrimoine__depuis">sur le coût des positions détenues</span>
+          {/* Trois repères et non un seul chiffre suivi d'une file de variations. La
+              carte portait le patrimoine puis deux valeurs collées à sa suite, sans dire
+              laquelle répondait à quelle question ; elle en pose maintenant trois, chacune
+              nommée. Le pourcentage est rapporté au coût des positions encore détenues, et
+              non « depuis l'origine » : le sélecteur de période emploie déjà ce mot pour
+              l'évolution de la valeur suivie, qui est un autre calcul. */}
+          <dl className="patrimoine__reperes">
+            <div className="patrimoine__repere">
+              <dt>Gains latents</dt>
+              <dd>
+                {masque ? (
+                  <span aria-label="Montant masqué">••••</span>
+                ) : (
+                  <Variation
+                    valeur={afficher(portefeuille.plus_value_latente)}
+                    mode="absolue"
+                    devise={devise}
+                    amplitude={portefeuille.pourcentage_variation}
+                  />
+                )}
+              </dd>
+            </div>
+            <div className="patrimoine__repere">
+              <dt>Progression</dt>
+              <dd>
+                {portefeuille.pourcentage_variation === null ? (
+                  <span className="patrimoine__depuis">—</span>
+                ) : (
+                  <Variation valeur={portefeuille.pourcentage_variation} />
+                )}
+              </dd>
+            </div>
+          </dl>
+          <p className="patrimoine__depuis">
+            Gains et progression rapportés au coût des positions détenues.
           </p>
         </section>
 
@@ -416,19 +434,8 @@ export default function Patrimoine() {
           </dd>
         </div>
         <div className="patrimoine__ligne">
-          <dt>Plus-value latente</dt>
-          <dd>
-            {masque ? (
-              <span aria-label="Montant masqué">••••</span>
-            ) : (
-              <Variation
-                valeur={afficher(portefeuille.plus_value_latente)}
-                mode="absolue"
-                devise={devise}
-                amplitude={portefeuille.pourcentage_variation}
-              />
-            )}
-          </dd>
+          <dt>Positions suivies</dt>
+          <dd>{actifs.length}</dd>
         </div>
         <div className="patrimoine__ligne">
           <dt>Plus-value réalisée</dt>

--- a/frontend/src/pages/Reinitialisation.jsx
+++ b/frontend/src/pages/Reinitialisation.jsx
@@ -5,6 +5,7 @@ import Bouton from '../composants/Bouton';
 import Champ from '../composants/Champ';
 import Message from '../composants/Message';
 import './Authentification.css';
+import Marque from '../composants/Marque';
 
 // Choix d'un nouveau mot de passe à partir d'une clé de réinitialisation.
 //
@@ -74,6 +75,10 @@ export default function Reinitialisation() {
   return (
     <main className="authentification">
       <div className="authentification__carte">
+        <p className="authentification__marque">
+          <Marque taille={28} />
+          WalletWatch
+        </p>
         <h1 className="authentification__titre">Nouveau mot de passe</h1>
         <p className="authentification__intro">
           Saisissez la clé reçue, puis le mot de passe que vous souhaitez utiliser.

--- a/frontend/src/pages/Seuils.css
+++ b/frontend/src/pages/Seuils.css
@@ -99,18 +99,51 @@
   border-radius: var(--rayon-pilule);
 }
 
+/* Croix de retrait, au coin supérieur droit de la carte. Elle remplace une commande
+   pleine largeur qui pesait autant que le seuil qu'elle supprime. La zone reste à 44 px,
+   même si le dessin n'en occupe que la moitié. */
 .seuils__retrait {
-  align-self: flex-start;
-  min-height: 44px;
-  padding: 0 var(--espace-2);
-  font-family: var(--police);
-  font-size: var(--taille-legende);
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  margin: calc(-1 * var(--espace-2)) calc(-1 * var(--espace-2)) 0 0;
+  padding: 0;
   color: var(--couleur-texte-attenue);
   background: none;
   border: none;
+  border-radius: var(--rayon-carte);
   cursor: pointer;
+}
+
+.seuils__retrait svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
 }
 
 .seuils__retrait:hover {
   color: var(--couleur-negatif);
+  background: var(--couleur-carte-haute);
+}
+
+/*
+  Un seuil franchi n'appelle plus de décision : il rend compte. Sa carte se resserre donc
+  à un peu plus de la moitié de la hauteur d'une carte en cours — une ligne au lieu de
+  trois — et le groupe passe en tête d'écran, ce que fait déjà l'ordre du document.
+*/
+.seuils__carte--franchi {
+  padding: var(--espace-3) var(--espace-4);
+}
+
+.seuils__carte--franchi .seuils__ligne {
+  align-items: center;
+}
+
+.seuils__carte--franchi .seuils__sous-texte {
+  margin: 0;
 }

--- a/frontend/src/pages/Seuils.css
+++ b/frontend/src/pages/Seuils.css
@@ -147,3 +147,27 @@
 .seuils__carte--franchi .seuils__sous-texte {
   margin: 0;
 }
+
+/*
+  Deux seuils par ligne au-dessus du point de rupture. Une carte de seuil tient sur trois
+  lignes de texte au plus : empilées sur toute la largeur d'un écran de bureau, six d'entre
+  elles remplissaient deux hauteurs d'écran pour un contenu qui n'occupait qu'un tiers de
+  la largeur. Les cartes gardent la même hauteur sur une ligne, ce que « stretch » assure
+  sans avoir à figer une valeur.
+*/
+@media (min-width: 900px) {
+  .seuils__liste {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--espace-3);
+    align-items: stretch;
+  }
+
+  .seuils__liste > li {
+    display: flex;
+  }
+
+  .seuils__liste > li > .carte {
+    flex: 1;
+  }
+}

--- a/frontend/src/pages/Seuils.jsx
+++ b/frontend/src/pages/Seuils.jsx
@@ -73,6 +73,30 @@ function nomCible(seuil) {
   return seuil.type_cible === 'capital_total' ? 'Patrimoine total' : (seuil.nom_actif ?? seuil.symbole);
 }
 
+// Retrait d'un seuil.
+//
+// Le bouton était une commande pleine largeur au bas de chaque carte : il pesait autant
+// que le seuil qu'il supprime, et sur une liste de six seuils, six commandes de
+// suppression occupaient plus de place que l'information. Il devient une croix au coin
+// supérieur droit, à l'emplacement où l'on ferme une chose depuis toujours.
+//
+// La croix seule ne se prononce pas : le nom accessible dit ce qu'elle retire, et la
+// confirmation qui suit rappelle le seuil concerné. Sa zone reste à 44 px.
+function BoutonRetrait({ seuil, surRetrait }) {
+  return (
+    <button
+      type="button"
+      className="seuils__retrait"
+      onClick={() => surRetrait(seuil)}
+      aria-label={`Retirer ce seuil, ${nomCible(seuil)}`}
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M6 6l12 12M18 6L6 18" />
+      </svg>
+    </button>
+  );
+}
+
 export default function Seuils() {
   const { jeton } = useAuthentification();
   const naviguer = useNavigate();
@@ -311,15 +335,8 @@ export default function Seuils() {
                         </p>
                       </div>
                       <span className="seuils__puce-franchi">Franchi</span>
+                      <BoutonRetrait seuil={seuil} surRetrait={setARetirer} />
                     </div>
-                    <button
-                      type="button"
-                      className="seuils__retrait"
-                      onClick={() => setARetirer(seuil)}
-                    >
-                      Retirer
-                      <span className="lecteur-ecran-seulement"> ce seuil, {nomCible(seuil)}</span>
-                    </button>
                   </Carte>
                 </li>
               );
@@ -352,15 +369,8 @@ export default function Seuils() {
                             <Montant valeur={afficher(seuil.valeur_seuil)} devise={deviseAffichee} />
                           )}
                         </p>
-                        {/* Un pourcentage, jamais converti ni masqué, au même titre que
-                            la performance ou la répartition ailleurs dans l'application :
-                            il ne représente pas un montant, seule une devise en porte. */}
-                        {seuil.ecart_pourcentage !== null && (
-                          <p className="seuils__sous-texte">
-                            reste <Montant valeur={seuil.ecart_pourcentage} type="pourcentage" />
-                          </p>
-                        )}
                       </div>
+                      <BoutonRetrait seuil={seuil} surRetrait={setARetirer} />
                     </div>
 
                     <BarreProgression
@@ -369,17 +379,10 @@ export default function Seuils() {
                       devise={deviseAffichee}
                       masque={masque}
                       sens={seuil.sens_seuil}
+                      classe={type}
+                      ecart={seuil.ecart_pourcentage}
                       libelle={`Progression vers le seuil, ${nomCible(seuil)}`}
                     />
-
-                    <button
-                      type="button"
-                      className="seuils__retrait"
-                      onClick={() => setARetirer(seuil)}
-                    >
-                      Retirer
-                      <span className="lecteur-ecran-seulement"> ce seuil, {nomCible(seuil)}</span>
-                    </button>
                   </Carte>
                 </li>
               );

--- a/frontend/src/pages/__tests__/Compte.test.jsx
+++ b/frontend/src/pages/__tests__/Compte.test.jsx
@@ -98,10 +98,12 @@ describe('composition', () => {
     expect(screen.getByText(/Coinbase/)).toBeTruthy();
     expect(screen.getByText(/Frankfurter/)).toBeTruthy();
     // Le texte affirmait que le fournisseur d'actions n'était pas branché. Il l'est
-    // depuis D85, et l'écran décrit maintenant la chaîne réelle ainsi que sa condition :
-    // la valorisation dépend d'une clé configurée côté serveur.
+    // depuis D85, et l'écran décrit la chaîne réelle, repli compris.
     expect(screen.getByText(/Financial Modeling Prep/)).toBeTruthy();
-    expect(screen.getByText(/clé de fournisseur est configurée/)).toBeTruthy();
+    expect(screen.getByText(/gold-api/)).toBeTruthy();
+    // La fiche dit aussi ce qui arrive quand un cours manque : c'est la question que
+    // l'utilisateur se pose devant une ligne sans valorisation.
+    expect(screen.getByText(/dernier cours connu/)).toBeTruthy();
     expect(screen.getByText(/aucun conseil en investissement/)).toBeTruthy();
   });
 });

--- a/frontend/src/pages/__tests__/Connexion.test.jsx
+++ b/frontend/src/pages/__tests__/Connexion.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import Connexion from '../Connexion';
 import * as contexte from '../../contexte/contexteAuthentification';
@@ -50,6 +51,33 @@ describe('écran de connexion', () => {
     // getByLabelText échoue si le label n'est pas relié au champ : le test vaut
     // vérification d'accessibilité.
     expect(screen.getByLabelText(/adresse électronique/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/mot de passe/i)).toBeInTheDocument();
+    // Le sélecteur restreint la recherche au champ : la commande de révélation porte
+    // elle aussi « mot de passe » dans son nom accessible, et c'est voulu.
+    expect(screen.getByLabelText(/mot de passe/i, { selector: 'input' })).toBeInTheDocument();
+  });
+
+  // La saisie masquée est le premier suspect d'un refus de connexion. La commande dit son
+  // état plutôt que de le laisser deviner au dessin de l'icône.
+  it('permet de révéler puis de masquer le mot de passe saisi', async () => {
+    const utilisateur = userEvent.setup();
+    vi.spyOn(contexte, 'useAuthentification').mockReturnValue({
+      estConnecte: false,
+      connecter: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <Connexion />
+      </MemoryRouter>
+    );
+
+    const champ = screen.getByLabelText(/mot de passe/i, { selector: 'input' });
+    expect(champ.getAttribute('type')).toBe('password');
+
+    await utilisateur.click(screen.getByLabelText('Afficher le mot de passe'));
+    expect(champ.getAttribute('type')).toBe('text');
+
+    await utilisateur.click(screen.getByLabelText('Masquer le mot de passe'));
+    expect(champ.getAttribute('type')).toBe('password');
   });
 });

--- a/frontend/src/pages/__tests__/DetailPosition.test.jsx
+++ b/frontend/src/pages/__tests__/DetailPosition.test.jsx
@@ -562,7 +562,10 @@ describe('saisie d’un seuil depuis l’onglet Seuils', () => {
 
     await utilisateur.click(screen.getByRole('button', { name: '+ Seuil' }));
 
-    expect(screen.getByRole('dialog', { name: 'Nouveau seuil — Bitcoin (BTC)' })).toBeTruthy();
+    // Le nom du dialogue reprend les deux lignes de son en-tête : le titre, court et
+    // stable, puis la cible. Un nom d'actif long tenait auparavant sur la même ligne que
+    // le titre, en gras et en corps de titre, et poussait le bouton de fermeture.
+    expect(screen.getByRole('dialog', { name: 'Nouveau seuil Bitcoin (BTC)' })).toBeTruthy();
     expect(screen.getByLabelText('Cible').value).toBe('actif:1');
     const options = within(screen.getByLabelText('Cible')).getAllByRole('option');
     expect(options.map((option) => option.value)).not.toContain('capital_total');

--- a/frontend/src/pages/__tests__/DetailPosition.test.jsx
+++ b/frontend/src/pages/__tests__/DetailPosition.test.jsx
@@ -168,7 +168,7 @@ describe('composition de la fiche', () => {
     rendre();
 
     expect(await screen.findByRole('heading', { name: 'Bitcoin', level: 1 })).toBeTruthy();
-    expect(screen.getByText(/BTC · Cryptomonnaie/)).toBeTruthy();
+    expect(screen.getByText(/BTC · Cryptos/)).toBeTruthy();
     expect(screen.getByLabelText(/Cours à jour, source coinbase/)).toBeTruthy();
   });
 

--- a/frontend/src/pages/__tests__/Patrimoine.test.jsx
+++ b/frontend/src/pages/__tests__/Patrimoine.test.jsx
@@ -76,10 +76,9 @@ describe('règles de comportement', () => {
     rendre();
 
     expect(await screen.findByText(/12.480,65/)).toBeTruthy();
-    // La variation absolue paraît deux fois, et c'est voulu : en tête, comme variation
-    // du patrimoine depuis l'origine, et plus bas, nommée « plus-value latente » parmi
-    // les chiffres de contexte. Ce sont deux lectures du même montant.
-    expect(screen.getAllByLabelText(/en hausse de 2.480,65/)).toHaveLength(2);
+    // Le montant des gains latents ne paraît plus qu'une fois : il est nommé en tête de
+    // carte, et les chiffres de contexte du bas ne le répètent plus.
+    expect(screen.getAllByLabelText(/en hausse de 2.480,65/)).toHaveLength(1);
     // Une variation relative s'écrit à une décimale : 24,81 s'affiche « +24,8 % ».
     expect(screen.getByLabelText(/en hausse de 24,8 /)).toBeTruthy();
   });
@@ -150,7 +149,7 @@ describe('règles de comportement', () => {
         .getAttribute('href')
     ).toBe('/positions?classes=crypto');
     expect(
-      screen.getByRole('link', { name: 'Voir les positions de la classe Action' })
+      screen.getByRole('link', { name: 'Voir les positions de la classe Actions' })
         .getAttribute('href')
     ).toBe('/positions?classes=action');
   });

--- a/frontend/src/pages/__tests__/Patrimoine.test.jsx
+++ b/frontend/src/pages/__tests__/Patrimoine.test.jsx
@@ -146,7 +146,7 @@ describe('règles de comportement', () => {
     await screen.findByText('Répartition');
 
     expect(
-      screen.getByRole('link', { name: 'Voir les positions de la classe Cryptomonnaie' })
+      screen.getByRole('link', { name: 'Voir les positions de la classe Cryptos' })
         .getAttribute('href')
     ).toBe('/positions?classes=crypto');
     expect(
@@ -472,7 +472,7 @@ describe('accessibilité', () => {
     // de description à fournir, elle se lit directement, entrée par entrée.
     await screen.findByText(/12.480,65/);
     const entrees = screen.getAllByRole('listitem');
-    const crypto = entrees.find((entree) => entree.textContent.includes('Cryptomonnaie'));
+    const crypto = entrees.find((entree) => entree.textContent.includes('Cryptos'));
 
     expect(crypto).toBeTruthy();
     expect(crypto.textContent).toMatch(/59,9/);

--- a/frontend/src/pages/__tests__/Positions.test.jsx
+++ b/frontend/src/pages/__tests__/Positions.test.jsx
@@ -196,11 +196,11 @@ describe('filtres par classe', () => {
     rendre();
     await screen.findByRole('table');
 
-    const filtreCrypto = screen.getByRole('button', { name: /Cryptomonnaie, 1 position/ });
+    const filtreCrypto = screen.getByRole('button', { name: /Cryptos, 1 position/ });
     await utilisateur.click(filtreCrypto);
 
     // Le compteur des autres classes ne bouge pas : ce sont des repères, pas un reste.
-    expect(screen.getByRole('button', { name: /Métal précieux, 1 position/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Métaux, 1 position/ })).toBeTruthy();
     expect(lignesDuTableau()).toHaveLength(1);
   });
 
@@ -209,8 +209,8 @@ describe('filtres par classe', () => {
     rendre();
     await screen.findByRole('table');
 
-    await utilisateur.click(screen.getByRole('button', { name: /Cryptomonnaie/ }));
-    await utilisateur.click(screen.getByRole('button', { name: /Métal précieux/ }));
+    await utilisateur.click(screen.getByRole('button', { name: /Cryptos/ }));
+    await utilisateur.click(screen.getByRole('button', { name: /Métaux/ }));
 
     expect(lignesDuTableau()).toHaveLength(2);
     expect(adresse.search).toContain('classes=crypto%2Cmetal');
@@ -249,9 +249,9 @@ describe('états', () => {
     rendre('/positions?classes=crypto');
     await screen.findByRole('table');
 
-    await utilisateur.click(screen.getByRole('button', { name: /Cryptomonnaie/ }));
+    await utilisateur.click(screen.getByRole('button', { name: /Cryptos/ }));
     await utilisateur.click(screen.getByRole('button', { name: /Devise/ }));
-    await utilisateur.click(screen.getByRole('button', { name: /Métal précieux/ }));
+    await utilisateur.click(screen.getByRole('button', { name: /Métaux/ }));
 
     // Rien ne correspond : l'en-tête et les filtres restent affichés.
     api.portefeuille.mockResolvedValue({ ...PORTEFEUILLE, actifs: [POSITIONS[0]] });
@@ -315,7 +315,7 @@ describe('accessibilité et affichage', () => {
     await screen.findByRole('table');
 
     // Le lien de la liste mobile, celui qui est parcouru à la voix.
-    const lien = screen.getByRole('link', { name: /Bitcoin, Cryptomonnaie, valorisée/ });
+    const lien = screen.getByRole('link', { name: /Bitcoin, Cryptos, valorisée/ });
     expect(lien.getAttribute('href')).toBe('/positions/1');
   });
 

--- a/frontend/src/pages/__tests__/Seuils.test.jsx
+++ b/frontend/src/pages/__tests__/Seuils.test.jsx
@@ -145,9 +145,9 @@ describe('composition', () => {
     expect(screen.queryByText(/Or/)).toBeNull();
   });
 
-  // Le pourcentage restant est toujours écrit en toutes lettres à côté de la barre :
-  // ce n'est pas elle qui porte seule l'information.
-  it("écrit l'écart restant en toutes lettres à côté de la barre", async () => {
+  // L'écart restant est écrit en toutes lettres dans la barre, à l'extrémité de son
+  // remplissage : ce n'est pas la longueur seule qui porte l'information.
+  it("écrit l'écart restant en toutes lettres dans la barre", async () => {
     rendre();
     await screen.findByRole('heading', { name: 'Seuils', level: 1 });
 

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -38,8 +38,24 @@ h2 {
   font-weight: var(--graisse-forte);
 }
 
+/*
+  Les liens ne sont pas soulignés au repos. Sur des écrans qui alignent des chiffres, un
+  soulignement par ligne fabrique une trame parasite : la répartition, les positions et la
+  navigation sont des blocs à activer, pas des renvois dans un texte suivi.
+
+  Le soulignement n'est pas supprimé pour autant, il est déplacé au survol et à la prise
+  de focus. La couleur ne porte donc jamais seule l'information « ceci est un lien » : le
+  pointeur et le clavier la doublent tous deux, et l'indicateur de focus défini ci-dessous
+  reste visible dans tous les cas.
+*/
 a {
   color: var(--couleur-accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
 }
 
 /*

--- a/frontend/src/utils/classesActifs.js
+++ b/frontend/src/utils/classesActifs.js
@@ -8,8 +8,8 @@
 //
 // Le vocabulaire est celui du lexique du projet, il ne s'invente pas ici.
 export const LIBELLES_CLASSE = {
-  crypto: 'Cryptomonnaie',
-  metal: 'Métal précieux',
+  crypto: 'Cryptos',
+  metal: 'Métaux',
   devise: 'Devise',
   action: 'Action',
 };

--- a/frontend/src/utils/classesActifs.js
+++ b/frontend/src/utils/classesActifs.js
@@ -10,6 +10,6 @@
 export const LIBELLES_CLASSE = {
   crypto: 'Cryptos',
   metal: 'Métaux',
-  devise: 'Devise',
-  action: 'Action',
+  devise: 'Devises',
+  action: 'Actions',
 };


### PR DESCRIPTION
Report sur `main` des cinq commits de finition d'interface fusionnés dans `dev` par la PR #129 : marque et icône d'onglet, blocs de synthèse à trois repères, seuils sur deux colonnes avec barre repensée, pastilles de variation allégées, révélation du mot de passe, classes d'actifs au pluriel et correction de l'en-tête des feuilles de saisie.

359 tests d'interface et 410 tests serveur au vert, lint muet, audit des dépendances sans vulnérabilité.